### PR TITLE
PHOENIX-1344 fix duplicit values in NTH_VALUE function

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/NthValueFunctionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/NthValueFunctionIT.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
+import java.util.ArrayList;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -150,6 +151,155 @@ public class NthValueFunctionIT extends BaseHBaseManagedTimeIT {
         assertTrue(rs.next());
         assertEquals(rs.getLong(1), 7);
         assertFalse(rs.next());
+    }
+
+    @Test
+    public void nonUniqueValuesInOrderByAsc() throws Exception {
+        Connection conn = DriverManager.getConnection(getUrl());
+
+        String ddl = "CREATE TABLE IF NOT EXISTS nthValue "
+                + "(id INTEGER NOT NULL PRIMARY KEY, page_id UNSIGNED_LONG,"
+                + " dates INTEGER, val INTEGER)";
+        conn.createStatement().execute(ddl);
+
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (2, 8, 1, 7)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (3, 8, 2, 9)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (4, 8, 2, 4)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (5, 8, 2, 2)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (6, 8, 3, 3)");
+        conn.commit();
+
+        ResultSet rs = conn.createStatement().executeQuery("SELECT NTH_VALUE(val, 3) WITHIN GROUP (ORDER BY dates ASC) FROM nthValue GROUP BY page_id");
+
+        assertTrue(rs.next());
+        assertInIntArray(new int[]{2, 4, 9}, rs.getInt(1));
+        assertFalse(rs.next());
+    }
+
+    @Test
+    public void nonUniqueValuesInOrderByAscSkipDuplicit() throws Exception {
+        Connection conn = DriverManager.getConnection(getUrl());
+
+        String ddl = "CREATE TABLE IF NOT EXISTS nthValue "
+                + "(id INTEGER NOT NULL PRIMARY KEY, page_id UNSIGNED_LONG,"
+                + " dates INTEGER, val INTEGER)";
+        conn.createStatement().execute(ddl);
+
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (2, 8, 1, 7)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (3, 8, 2, 9)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (4, 8, 2, 4)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (5, 8, 2, 2)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (6, 8, 3, 3)");
+        conn.commit();
+
+        ResultSet rs = conn.createStatement().executeQuery("SELECT NTH_VALUE(val, 5) WITHIN GROUP (ORDER BY dates ASC) FROM nthValue GROUP BY page_id");
+
+        assertTrue(rs.next());
+        assertEquals(3, rs.getInt(1));
+        assertFalse(rs.next());
+    }
+
+    @Test
+    public void nonUniqueValuesInOrderByDesc() throws Exception {
+        Connection conn = DriverManager.getConnection(getUrl());
+
+        String ddl = "CREATE TABLE IF NOT EXISTS nthValue "
+                + "(id INTEGER NOT NULL PRIMARY KEY, page_id UNSIGNED_LONG,"
+                + " dates INTEGER, val INTEGER)";
+        conn.createStatement().execute(ddl);
+
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (2, 8, 1, 7)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (3, 8, 2, 9)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (4, 8, 2, 4)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (5, 8, 2, 2)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (6, 8, 3, 3)");
+        conn.commit();
+
+        ResultSet rs = conn.createStatement().executeQuery("SELECT NTH_VALUE(val, 3) WITHIN GROUP (ORDER BY dates DESC) FROM nthValue GROUP BY page_id");
+
+        assertTrue(rs.next());
+        assertInIntArray(new int[]{2, 4, 9}, rs.getInt(1));
+        assertFalse(rs.next());
+    }
+
+    @Test
+    public void nonUniqueValuesInOrderNextValueDesc() throws Exception {
+        Connection conn = DriverManager.getConnection(getUrl());
+
+        String ddl = "CREATE TABLE IF NOT EXISTS nthValue "
+                + "(id INTEGER NOT NULL PRIMARY KEY, page_id UNSIGNED_LONG,"
+                + " dates INTEGER, val INTEGER)";
+        conn.createStatement().execute(ddl);
+
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (2, 8, 0, 7)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (3, 8, 1, 9)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (4, 8, 2, 4)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (5, 8, 2, 2)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (6, 8, 3, 3)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (7, 8, 3, 5)");
+        conn.commit();
+
+        ResultSet rs = conn.createStatement().executeQuery("SELECT NTH_VALUE(val, 2) WITHIN GROUP (ORDER BY dates DESC) FROM nthValue GROUP BY page_id");
+
+        assertTrue(rs.next());
+        assertInIntArray(new int[]{3, 5}, rs.getInt(1));
+        assertFalse(rs.next());
+    }
+
+    @Test
+    public void nonUniqueValuesInOrderNextValueAsc() throws Exception {
+        Connection conn = DriverManager.getConnection(getUrl());
+
+        String ddl = "CREATE TABLE IF NOT EXISTS nthValue "
+                + "(id INTEGER NOT NULL PRIMARY KEY, page_id UNSIGNED_LONG,"
+                + " dates INTEGER, val INTEGER)";
+        conn.createStatement().execute(ddl);
+
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (2, 8, 0, 7)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (3, 8, 1, 9)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (4, 8, 2, 4)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (5, 8, 2, 2)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (6, 8, 3, 3)");
+        conn.createStatement().execute("UPSERT INTO nthValue (id, page_id, dates, val) VALUES (7, 8, 3, 5)");
+        conn.commit();
+
+        ResultSet rs = conn.createStatement().executeQuery("SELECT NTH_VALUE(val, 5) WITHIN GROUP (ORDER BY dates ASC) FROM nthValue GROUP BY page_id");
+
+        assertTrue(rs.next());
+        assertInIntArray(new int[]{3, 5}, rs.getInt(1));
+        assertFalse(rs.next());
+    }
+
+    @Test
+    public void ignoreNullValues() throws Exception {
+        Connection conn = DriverManager.getConnection(getUrl());
+
+        String ddl = "CREATE TABLE IF NOT EXISTS nth_test_table "
+                + "(id INTEGER NOT NULL, page_id UNSIGNED_LONG,"
+                + " dates BIGINT NOT NULL, \"value\" BIGINT NULL CONSTRAINT pk PRIMARY KEY (id, dates))";
+        conn.createStatement().execute(ddl);
+
+        conn.createStatement().execute("UPSERT INTO nth_test_table (id, page_id, dates, \"value\") VALUES (1, 8, 1, 1)");
+        conn.createStatement().execute("UPSERT INTO nth_test_table (id, page_id, dates, \"value\") VALUES (2, 8, 2, NULL)");
+        conn.createStatement().execute("UPSERT INTO nth_test_table (id, page_id, dates, \"value\") VALUES (3, 8, 3, NULL)");
+        conn.createStatement().execute("UPSERT INTO nth_test_table (id, page_id, dates, \"value\") VALUES (5, 8, 4, 4)");
+        conn.createStatement().execute("UPSERT INTO nth_test_table (id, page_id, dates, \"value\") VALUES (4, 8, 5, 5)");
+        conn.commit();
+
+        ResultSet rs = conn.createStatement().executeQuery(
+                "SELECT NTH_VALUE(\"value\", 2)  WITHIN GROUP (ORDER BY dates DESC) FROM nth_test_table GROUP BY page_id");
+
+        assertTrue(rs.next());
+        assertEquals(rs.getLong(1), 4);
+        assertFalse(rs.next());
+    }
+
+    private void assertInIntArray(int[] should, int actualValue) {
+        ArrayList<Integer> shouldList = new ArrayList<Integer>();
+        for (int i: should) {
+            shouldList.add(i);
+        }
+        assertTrue(shouldList.contains(actualValue));
     }
 
 }


### PR DESCRIPTION
I've fixed issue PHOENIX-1344, but there is one thing: the NTH_VALUE function is not deterministic now.  Nondeterministic come to light when nth value could be any of values as long as "ordered by" values are duplicit. Methond getDeterminism is implemented in parent: AggregateFunction and returns Determinism.PER_ROW. Is that ok?
I've used LinkedList (over ArrayDeque) for storing multiple values to one "ordered by" key cos LinkedList can hold null values and there can be in future switch for respect null values.
