### PR TITLE
PHOENIX-1601 Fix performance script for binary distribution of phoenix

### DIFF
--- a/bin/phoenix_utils.py
+++ b/bin/phoenix_utils.py
@@ -50,7 +50,7 @@ def findFileInPathWithoutRecursion(pattern, path):
 
 def setPath():
  PHOENIX_CLIENT_JAR_PATTERN = "phoenix-*-client*.jar"
- PHOENIX_TESTS_JAR_PATTERN = "phoenix-*-tests*.jar"
+ PHOENIX_TESTS_JAR_PATTERN = "phoenix-core-*-tests*.jar"
  global current_dir
  current_dir = os.path.dirname(os.path.abspath(__file__))
  global phoenix_jar_path


### PR DESCRIPTION
Change the PHOENIX_TEST_JAR_PATTERN since it was also matching flume tests jars.

The performance.py script wasn't working anymore in the bin distribution of phoenix
because the flume test jar was matching the test jar pattern for phoenix core test jar.
This new pattern fixes this issue.
