### PR TITLE
PHOENIX-1722 Speedup CONVERT_TZ function

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ConvertTimezoneFunctionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ConvertTimezoneFunctionIT.java
@@ -23,8 +23,10 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import org.apache.phoenix.exception.SQLExceptionCode;
+import static org.junit.Assert.assertFalse;
 import org.junit.Test;
 
 /**
@@ -129,7 +131,7 @@ public class ConvertTimezoneFunctionIT extends BaseHBaseManagedTimeIT {
         try {
             ResultSet rs = conn.createStatement().executeQuery(
                     "SELECT k1, dates, CONVERT_TZ(dates, 'UNKNOWN_TIMEZONE', 'America/Adak') FROM TIMEZONE_OFFSET_TEST");
-    
+
             rs.next();
             rs.getDate(3).getTime();
             fail();
@@ -137,4 +139,24 @@ public class ConvertTimezoneFunctionIT extends BaseHBaseManagedTimeIT {
             assertEquals(SQLExceptionCode.ILLEGAL_DATA.getErrorCode(), e.getErrorCode());
         }
     }
+
+	@Test
+	public void testConvertMultipleRecords() throws Exception {
+		Connection conn = DriverManager.getConnection(getUrl());
+		String ddl = "CREATE TABLE IF NOT EXISTS TIMEZONE_OFFSET_TEST (k1 INTEGER NOT NULL, dates DATE CONSTRAINT pk PRIMARY KEY (k1))";
+		Statement stmt = conn.createStatement();
+		stmt.execute(ddl);
+		stmt.execute("UPSERT INTO TIMEZONE_OFFSET_TEST (k1, dates) VALUES (1, TO_DATE('2014-03-01 00:00:00'))");
+		stmt.execute("UPSERT INTO TIMEZONE_OFFSET_TEST (k1, dates) VALUES (2, TO_DATE('2014-03-01 00:00:00'))");
+		conn.commit();
+
+		ResultSet rs = stmt.executeQuery(
+				"SELECT k1, dates, CONVERT_TZ(dates, 'UTC', 'America/Adak') FROM TIMEZONE_OFFSET_TEST");
+
+		assertTrue(rs.next());
+		assertEquals(1393596000000L, rs.getDate(3).getTime()); //Fri, 28 Feb 2014 14:00:00
+		assertTrue(rs.next());
+		assertEquals(1393596000000L, rs.getDate(3).getTime()); //Fri, 28 Feb 2014 14:00:00
+		assertFalse(rs.next());
+	}
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/cache/JodaTimezoneCache.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/cache/JodaTimezoneCache.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.cache;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.schema.IllegalDataException;
+import org.joda.time.DateTimeZone;
+
+public class JodaTimezoneCache {
+
+    public static final int CACHE_EXPRIRE_TIME_MINUTES = 10;
+    private static final LoadingCache<ByteBuffer, DateTimeZone> cachedJodaTimeZones = createTimezoneCache();
+
+    /**
+     * Returns joda's DateTimeZone instance from cache or create new instance and cache it.
+     *
+     * @param timezoneId Timezone Id as accepted by {@code DateTimeZone.forID()}. E.g. Europe/Isle_of_Man
+     * @return joda's DateTimeZone instance
+     * @throws IllegalDataException if unknown timezone id is passed
+     */
+    public static DateTimeZone getInstance(ByteBuffer timezoneId) {
+        try {
+            return cachedJodaTimeZones.get(timezoneId);
+        } catch (ExecutionException ex) {
+            throw new IllegalDataException(ex);
+        } catch (UncheckedExecutionException e) {
+            throw new IllegalDataException("Unknown timezone " + Bytes.toString(timezoneId.array()));
+        }
+    }
+
+    /**
+     * Returns joda's DateTimeZone instance from cache or create new instance and cache it.
+     *
+     * @param timezoneId Timezone Id as accepted by {@code DateTimeZone.forID()}. E.g. Europe/Isle_of_Man
+     * @return joda's DateTimeZone instance
+     * @throws IllegalDataException if unknown timezone id is passed
+     */
+    public static DateTimeZone getInstance(ImmutableBytesWritable timezoneId) {
+        return getInstance(ByteBuffer.wrap(timezoneId.copyBytes()));
+    }
+
+    /**
+     * Returns joda's DateTimeZone instance from cache or create new instance and cache it.
+     *
+     * @param timezoneId Timezone Id as accepted by {@code DateTimeZone.forID()}. E.g. Europe/Isle_of_Man
+     * @return joda's DateTimeZone instance
+     * @throws IllegalDataException if unknown timezone id is passed
+     */
+    public static DateTimeZone getInstance(String timezoneId) {
+        return getInstance(ByteBuffer.wrap(Bytes.toBytes(timezoneId)));
+    }
+
+    private static LoadingCache<ByteBuffer, DateTimeZone> createTimezoneCache() {
+        return CacheBuilder.newBuilder().expireAfterAccess(CACHE_EXPRIRE_TIME_MINUTES, TimeUnit.MINUTES).build(new CacheLoader<ByteBuffer, DateTimeZone>() {
+
+            @Override
+            public DateTimeZone load(ByteBuffer timezone) throws Exception {
+                return DateTimeZone.forID(Bytes.toString(timezone.array()));
+            }
+        });
+    }
+
+}

--- a/phoenix-core/src/test/java/org/apache/phoenix/cache/JodaTimezoneCacheTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/cache/JodaTimezoneCacheTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.cache;
+
+import java.nio.ByteBuffer;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.schema.IllegalDataException;
+import org.joda.time.DateTimeZone;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class JodaTimezoneCacheTest {
+
+    @Test
+    public void testGetInstanceByteBufferUTC() {
+        DateTimeZone instance = JodaTimezoneCache.getInstance(ByteBuffer.wrap(Bytes.toBytes("UTC")));
+        assertTrue(instance instanceof DateTimeZone);
+    }
+
+    @Test
+    public void testGetInstanceString() {
+        DateTimeZone instance = JodaTimezoneCache.getInstance("America/St_Vincent");
+        assertTrue(instance instanceof DateTimeZone);
+    }
+
+    @Test(expected = IllegalDataException.class)
+    public void testGetInstanceStringUnknown() {
+        JodaTimezoneCache.getInstance("SOME_UNKNOWN_TIMEZONE");
+    }
+
+    @Test
+    public void testGetInstanceImmutableBytesWritable() {
+        ImmutableBytesWritable ptr = new ImmutableBytesWritable(Bytes.toBytes("Europe/Isle_of_Man"));
+        DateTimeZone instance = JodaTimezoneCache.getInstance(ptr);
+        assertTrue(instance instanceof DateTimeZone);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <commons-codec.version>1.7</commons-codec.version>
     <htrace.version>3.1.0-incubating</htrace.version>
     <collections.version>3.2.1</collections.version>
-    <jodatime.version>2.3</jodatime.version>
+    <jodatime.version>2.7</jodatime.version>
 
     <!-- Test Dependencies -->
     <mockito-all.version>1.8.5</mockito-all.version>


### PR DESCRIPTION
Using Joda Time lib instead of java.util.TimeZone. This would speedup this function more than 3 times. I've also updated version of Joda Time to 2.7 cause of some timezone bugfixes and speedups.
