### PR TITLE
PHOENIX-1722 Speedup CONVERT_TZ function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <commons-codec.version>1.7</commons-codec.version>
     <htrace.version>2.04</htrace.version>
     <collections.version>3.2.1</collections.version>
-    <jodatime.version>2.3</jodatime.version>
+    <jodatime.version>2.7</jodatime.version>
 
     <!-- Test Dependencies -->
     <mockito-all.version>1.8.5</mockito-all.version>


### PR DESCRIPTION
Using Joda Time lib instead of java.util.TimeZone. This would speedup this function more than 3 times. I've also updated version of Joda Time to 2.7 cause of some timezone bugfixes and speedups.
