### PR TITLE
PHOENIX-1938 Like operator should throw proper exception when it is used with data type other then Varcahr and Char

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ExpressionCompilerIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ExpressionCompilerIT.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.end2end;
+
+import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.apache.phoenix.exception.SQLExceptionCode;
+import org.apache.phoenix.schema.types.PBinary;
+import org.apache.phoenix.schema.types.PChar;
+import org.apache.phoenix.schema.types.PDataType;
+import org.apache.phoenix.schema.types.PVarbinary;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.util.PropertiesUtil;
+import org.junit.Test;
+
+public class ExpressionCompilerIT extends BaseHBaseManagedTimeIT {
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testLikeOperator() throws SQLException {
+		Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+		Connection conn = DriverManager.getConnection(getUrl(), props);
+		conn.setAutoCommit(false);
+
+		try {
+			String ddl = "CREATE TABLE test_table "
+					+ "  (a_string varchar not null primary key)";
+			createTestTable(getUrl(), ddl);
+
+			String upsertQuery = "UPSERT INTO test_table VALUES('Example')";
+			PreparedStatement stmt = conn.prepareStatement(upsertQuery);
+			stmt.execute();
+
+			for (PDataType<?> dataType : PDataType.values()) {
+				if (dataType.isArrayType() || PVarbinary.INSTANCE == dataType
+						|| PBinary.INSTANCE == dataType) {
+					continue;
+				}
+				Object value1 = dataType.getSampleValue();
+				String selectQuery = "select * from test_table where ?"
+						+ " LIKE " + "?";
+				stmt = conn.prepareStatement(selectQuery);
+				stmt.setObject(1, value1, dataType.getSqlType());
+				stmt.setObject(2, value1, dataType.getSqlType());
+				try {
+					stmt.execute();
+					if (PVarchar.INSTANCE != dataType
+							&& PChar.INSTANCE != dataType) {
+						fail("LIKE with type " + dataType
+								+ " should throw exception.");
+					}
+				} catch (SQLException sqe) {
+					assertEquals(
+							SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR
+									.getErrorCode(),
+							sqe.getErrorCode());
+				}
+			}
+
+		} finally {
+			conn.close();
+		}
+	}
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ExpressionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ExpressionCompiler.java
@@ -125,7 +125,6 @@ import org.apache.phoenix.schema.types.PLong;
 import org.apache.phoenix.schema.types.PTimestamp;
 import org.apache.phoenix.schema.types.PUnsignedTimestamp;
 import org.apache.phoenix.schema.types.PVarbinary;
-import org.apache.phoenix.schema.types.PVarbinaryArray;
 import org.apache.phoenix.schema.types.PVarchar;
 import org.apache.phoenix.schema.types.PhoenixArray;
 import org.apache.phoenix.util.ExpressionUtil;
@@ -458,25 +457,25 @@ public class ExpressionCompiler extends UnsupportedAllParseNodeVisitor<Expressio
         ParseNode rhsNode = node.getChildren().get(1);
         Expression lhs = children.get(0);
         Expression rhs = children.get(1);
-        
-		if (PVarchar.INSTANCE != lhs.getDataType()
-				&& PChar.INSTANCE != lhs.getDataType()) {
-			throw new SQLExceptionInfo.Builder(
-					SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR)
-					.setMessage(
-							"LIKE does not support " + lhs.getDataType()
-									+ " in expression" + lhsNode).build()
-					.buildException();
-		}
-		if (PVarchar.INSTANCE != rhs.getDataType()
-				&& PChar.INSTANCE != rhs.getDataType()) {
-			throw new SQLExceptionInfo.Builder(
-					SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR)
-					.setMessage(
-							"LIKE does not support " + rhs.getDataType()
-									+ " in expression" + rhsNode).build()
-					.buildException();
-		}
+
+	if (PVarchar.INSTANCE != lhs.getDataType()
+			&& PChar.INSTANCE != lhs.getDataType()) {
+		throw new SQLExceptionInfo.Builder(
+				SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR)
+				.setMessage(
+						"LIKE does not support " + lhs.getDataType()
+								+ " in expression" + lhsNode).build()
+				.buildException();
+	}
+	if (PVarchar.INSTANCE != rhs.getDataType()
+			&& PChar.INSTANCE != rhs.getDataType()) {
+		throw new SQLExceptionInfo.Builder(
+				SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR)
+				.setMessage(
+						"LIKE does not support " + rhs.getDataType()
+								+ " in expression" + rhsNode).build()
+				.buildException();
+	}
 		
         if (lhsNode instanceof BindParseNode) {
             context.getBindManager().addParamMetaData((BindParseNode)lhsNode, rhs);

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ExpressionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ExpressionCompiler.java
@@ -125,6 +125,8 @@ import org.apache.phoenix.schema.types.PLong;
 import org.apache.phoenix.schema.types.PTimestamp;
 import org.apache.phoenix.schema.types.PUnsignedTimestamp;
 import org.apache.phoenix.schema.types.PVarbinary;
+import org.apache.phoenix.schema.types.PVarbinaryArray;
+import org.apache.phoenix.schema.types.PVarchar;
 import org.apache.phoenix.schema.types.PhoenixArray;
 import org.apache.phoenix.util.ExpressionUtil;
 import org.apache.phoenix.util.IndexUtil;
@@ -456,11 +458,26 @@ public class ExpressionCompiler extends UnsupportedAllParseNodeVisitor<Expressio
         ParseNode rhsNode = node.getChildren().get(1);
         Expression lhs = children.get(0);
         Expression rhs = children.get(1);
-        if ( rhs.getDataType() != null && lhs.getDataType() != null && 
-                !lhs.getDataType().isCoercibleTo(rhs.getDataType())  && 
-                !rhs.getDataType().isCoercibleTo(lhs.getDataType())) {
-            throw TypeMismatchException.newException(lhs.getDataType(), rhs.getDataType(), node.toString());
-        }
+        
+		if (PVarchar.INSTANCE != lhs.getDataType()
+				&& PChar.INSTANCE != lhs.getDataType()) {
+			throw new SQLExceptionInfo.Builder(
+					SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR)
+					.setMessage(
+							"LIKE does not support " + lhs.getDataType()
+									+ " in expression" + lhsNode).build()
+					.buildException();
+		}
+		if (PVarchar.INSTANCE != rhs.getDataType()
+				&& PChar.INSTANCE != rhs.getDataType()) {
+			throw new SQLExceptionInfo.Builder(
+					SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR)
+					.setMessage(
+							"LIKE does not support " + rhs.getDataType()
+									+ " in expression" + rhsNode).build()
+					.buildException();
+		}
+		
         if (lhsNode instanceof BindParseNode) {
             context.getBindManager().addParamMetaData((BindParseNode)lhsNode, rhs);
         }

--- a/phoenix-core/src/test/java/org/apache/phoenix/compile/ExpressionCompilerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/compile/ExpressionCompilerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.phoenix.compile;
 
 import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;

--- a/phoenix-core/src/test/java/org/apache/phoenix/compile/ExpressionCompilerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/compile/ExpressionCompilerTest.java
@@ -1,0 +1,82 @@
+package org.apache.phoenix.compile;
+
+import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.apache.phoenix.exception.SQLExceptionCode;
+import org.apache.phoenix.expression.Expression;
+import org.apache.phoenix.expression.LiteralExpression;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.jdbc.PhoenixStatement;
+import org.apache.phoenix.parse.LikeParseNode;
+import org.apache.phoenix.parse.LikeParseNode.LikeType;
+import org.apache.phoenix.parse.LiteralParseNode;
+import org.apache.phoenix.parse.ParseNodeFactory;
+import org.apache.phoenix.query.BaseConnectionlessQueryTest;
+import org.apache.phoenix.schema.types.PBinary;
+import org.apache.phoenix.schema.types.PChar;
+import org.apache.phoenix.schema.types.PDataType;
+import org.apache.phoenix.schema.types.PVarbinary;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.util.PropertiesUtil;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class ExpressionCompilerTest extends BaseConnectionlessQueryTest {
+	private ExpressionCompiler getExpressionCompiler() throws SQLException {
+		PhoenixConnection pconn = DriverManager.getConnection(getUrl(),
+				PropertiesUtil.deepCopy(TEST_PROPERTIES)).unwrap(
+				PhoenixConnection.class);
+		PhoenixStatement phoenixStatement = new PhoenixStatement(pconn);
+		StatementContext statementContext = new StatementContext(
+				phoenixStatement);
+		return new ExpressionCompiler(statementContext);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testVisitLeaveForLikeParseNode() throws SQLException {
+		ExpressionCompiler expressionCompiler = getExpressionCompiler();
+		for (PDataType<?> dataType : PDataType.values()) {
+			if (dataType.isArrayType() || PVarbinary.INSTANCE == dataType
+					|| PBinary.INSTANCE == dataType) {
+				continue;
+			}
+			Object value1 = dataType.getSampleValue();
+			LiteralParseNode parseNode1 = new LiteralParseNode(value1);
+			Object value2 = dataType.getSampleValue();
+			LiteralParseNode parseNode2 = new LiteralParseNode(value2);
+
+			ParseNodeFactory factory = new ParseNodeFactory();
+			LikeParseNode likeParseNode = factory.like(parseNode1, parseNode2,
+					false, LikeType.CASE_INSENSITIVE);
+			Expression expression1 = LiteralExpression.newConstant(value1,
+					dataType);
+			Expression expression2 = LiteralExpression.newConstant(value2,
+					dataType);
+
+			if (PVarchar.INSTANCE != dataType && PChar.INSTANCE != dataType) {
+				try {
+					expressionCompiler.visitLeave(likeParseNode,
+							Lists.newArrayList(expression1, expression2));
+					fail("LikeParseNode should throw exception for data type which is not coercible to VARCHAR");
+				} catch (SQLException sqe) {
+					assertEquals(
+							SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR
+									.getErrorCode(),
+							sqe.getErrorCode());
+				}
+			} else {
+				expressionCompiler.visitLeave(likeParseNode,
+						Lists.newArrayList(expression1, expression2));
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
LIKE operator should be supported only for Varchar and Char and it should throw SQLException with SQLExceptionCode.TYPE_NOT_SUPPORTED_FOR_OPERATOR for any other data type. 


Postgres specification : http://www.postgresql.org/docs/8.3/static/functions-matching.html
Oracle specification: http://docs.oracle.com/cd/B12037_01/server.101/b10759/conditions016.htm

@JamesRTaylor  @twdsilva  Can you please review this.
