### PR TITLE
Update CsvBulkLoadTool.java by changing the default delimiter to '\t' from ',' to support Bulkload better

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/CsvBulkLoadTool.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/CsvBulkLoadTool.java
@@ -331,7 +331,7 @@ public class CsvBulkLoadTool extends Configured implements Tool {
     static void configureOptions(CommandLine cmdLine, List<ColumnInfo> importColumns,
             Configuration conf) {
 
-        char delimiterChar = ',';
+        char delimiterChar = '\t';
         if (cmdLine.hasOption(DELIMITER_OPT.getOpt())) {
             String delimString = cmdLine.getOptionValue(DELIMITER_OPT.getOpt());
             if (delimString.length() != 1) {


### PR DESCRIPTION
default delimiter was ',' , in real using ,The delimiter of data is always '\t',But the option '-d' can only support single char as delimiter,so change the default delimiter to '\t' to support it .