### PR TITLE
PBoolean.toBytes(object, sortOrder) negates the value

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/types/PBoolean.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/types/PBoolean.java
@@ -57,7 +57,7 @@ public class PBoolean extends PDataType<Boolean> {
       // TODO: review - return null?
       throw newIllegalDataException(this + " may not be null");
     }
-    return ((Boolean) object).booleanValue() ^ sortOrder == SortOrder.ASC ?
+    return ((Boolean) object).booleanValue() & sortOrder == SortOrder.ASC ?
         TRUE_BYTES :
         FALSE_BYTES;
   }
@@ -138,7 +138,7 @@ public class PBoolean extends PDataType<Boolean> {
   public Object getSampleValue(Integer maxLength, Integer arrayLength) {
     return RANDOM.get().nextBoolean();
   }
-  
+
     @Override
     public PhoenixArrayFactory getArrayFactory() {
         return new PhoenixArrayFactory() {


### PR DESCRIPTION
Same issue in older releases.
Try:
System.out.println(PDataType.BOOLEAN.toObject(PDataType.BOOLEAN.toBytes(true, SortOrder.ASC), SortOrder.ASC));