### PR TITLE
PHOENIX-2112 support UTF8String for spark 1.4.0

### DIFF
--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -20,6 +20,7 @@ package org.apache.phoenix.spark
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.UTF8String
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.sources._
 import org.apache.commons.lang.StringEscapeUtils.escapeSql

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -92,6 +92,7 @@ case class PhoenixRelation(tableName: String, zkUrl: String)(@transient val sqlC
   // Helper function to escape string values in SQL queries
   private def compileValue(value: Any): Any = value match {
     case stringValue: String => s"'${escapeSql(stringValue)}'"
+    case stringValue: UTF8String => s"'${escapeSql(stringValue.toString)}'"
     case _ => value
   }
 }


### PR DESCRIPTION
In Spark 1.4.0, Phoenix-Spark will throw an exception when we put a filter like `a='a'` , because phoenix did not recognize `UTF8String` as a String Type, and then transform this expression to `a=a`