### PR TITLE
PHOENIX-2256: Correct two bugs in PMetaDataImpl

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/PMetaDataImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/PMetaDataImpl.java
@@ -160,7 +160,7 @@ public class PMetaDataImpl implements PMetaData {
                     newCache.put(tableRef.table.getKey(), new PTableRef(tableRef));
                     toRemove.add(tableRef);
                     toRemoveBytes += tableRef.estSize;
-                    if (toRemoveBytes - toRemove.peekLast().estSize > overage) {
+                    while (toRemoveBytes - toRemove.peekLast().estSize >= overage) {
                         PTableRef removedRef = toRemove.removeLast();
                         toRemoveBytes -= removedRef.estSize;
                     }

--- a/phoenix-core/src/test/java/org/apache/phoenix/schema/PMetaDataImplTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/schema/PMetaDataImplTest.java
@@ -104,6 +104,25 @@ public class PMetaDataImplTest {
         assertEquals(2, metaData.size());
         assertNames(metaData, "d","e");
     }
+
+    @Test
+    public void shouldNotEvictMoreEntriesThanNecessary() throws Exception {
+        long maxSize = 5;
+        PMetaData metaData = new PMetaDataImpl(5, maxSize, new TestTimeKeeper());
+        metaData = addToTable(metaData, "a", 1);
+        assertEquals(1, metaData.size());
+        metaData = addToTable(metaData, "b", 1);
+        assertEquals(2, metaData.size());
+        assertNames(metaData, "a", "b");
+        metaData = addToTable(metaData, "c", 3);
+        assertEquals(3, metaData.size());
+        assertNames(metaData, "a", "b", "c");
+        getFromTable(metaData, "a");
+        getFromTable(metaData, "b");
+        metaData = addToTable(metaData, "d", 3);
+        assertEquals(3, metaData.size());
+        assertNames(metaData, "a", "b", "d");
+    }
     
     private static class PSizedTable extends PTableImpl {
         private final int size;

--- a/phoenix-core/src/test/java/org/apache/phoenix/schema/PMetaDataImplTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/schema/PMetaDataImplTest.java
@@ -17,16 +17,15 @@
  */
 package org.apache.phoenix.schema;
 
-import static org.junit.Assert.assertEquals;
-
-import java.sql.SQLException;
-import java.util.Set;
-
+import com.google.common.collect.Sets;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.phoenix.util.TimeKeeper;
 import org.junit.Test;
 
-import com.google.common.collect.Sets;
+import java.sql.SQLException;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
 
 public class PMetaDataImplTest {
     
@@ -123,7 +122,47 @@ public class PMetaDataImplTest {
         assertEquals(3, metaData.size());
         assertNames(metaData, "a", "b", "d");
     }
-    
+
+    @Test
+    public void shouldAlwaysKeepAtLeastOneEntryEvenIfTooLarge() throws Exception {
+        long maxSize = 5;
+        PMetaData metaData = new PMetaDataImpl(5, maxSize, new TestTimeKeeper());
+        metaData = addToTable(metaData, "a", 1);
+        assertEquals(1, metaData.size());
+        metaData = addToTable(metaData, "b", 1);
+        assertEquals(2, metaData.size());
+        metaData = addToTable(metaData, "c", 5);
+        assertEquals(1, metaData.size());
+        metaData = addToTable(metaData, "d", 20);
+        assertEquals(1, metaData.size());
+        assertNames(metaData, "d");
+        metaData = addToTable(metaData, "e", 1);
+        assertEquals(1, metaData.size());
+        metaData = addToTable(metaData, "f", 2);
+        assertEquals(2, metaData.size());
+        assertNames(metaData, "e", "f");
+    }
+
+    @Test
+    public void shouldAlwaysKeepOneEntryIfMaxSizeIsZero() throws Exception {
+        long maxSize = 0;
+        PMetaData metaData = new PMetaDataImpl(0, maxSize, new TestTimeKeeper());
+        metaData = addToTable(metaData, "a", 1);
+        assertEquals(1, metaData.size());
+        metaData = addToTable(metaData, "b", 1);
+        assertEquals(1, metaData.size());
+        metaData = addToTable(metaData, "c", 5);
+        assertEquals(1, metaData.size());
+        metaData = addToTable(metaData, "d", 20);
+        assertEquals(1, metaData.size());
+        assertNames(metaData, "d");
+        metaData = addToTable(metaData, "e", 1);
+        assertEquals(1, metaData.size());
+        metaData = addToTable(metaData, "f", 2);
+        assertEquals(1, metaData.size());
+        assertNames(metaData, "f");
+    }
+
     private static class PSizedTable extends PTableImpl {
         private final int size;
         private final PTableKey key;


### PR DESCRIPTION
PHOENIX-2256: More entries than necessary could end up being evicted.

This PR also adds a new test to catch one of the bugs.

Previously, one of the bugs (`>` should have been `>=`) was being picked up on Java 8, but not Java 7, because the traversal ordering of one of the JDK collections happened to have changed. The bug was still present in Java 7, but the collection ordering meant that the test didn't pick it up.

The second bug (`if` should have been `while`) is picked up by the new test on both Java 7 and Java 8. The essence of the bug is that if several things are queued for eviction, and something large and old gets added to the eviction queue, the implementation was only considering removing one element from the eviction queue, whereas it should have removed as many as possible from the eviction queue while still leaving enough to clear space for the new element being added to the table.