### PR TITLE
PHOENIX-2288 Phoenix-Spark: PDecimal precision and scale aren't carried through to Spark DataFrame

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/util/PhoenixRuntime.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/PhoenixRuntime.java
@@ -30,7 +30,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -469,20 +468,8 @@ public class PhoenixRuntime {
         if (pColumn == null) {
             throw new SQLException("pColumn must not be null.");
         }
-        int sqlType = pColumn.getDataType().getSqlType();
-        if (pColumn.getMaxLength() == null) {
-            return new ColumnInfo(pColumn.toString(), sqlType);
-        }
-        if (sqlType == Types.CHAR || sqlType == Types.VARCHAR) {
-            int maxLength = pColumn.getMaxLength();
-            return new ColumnInfo(pColumn.toString(), sqlType, maxLength);
-        }
-        if (sqlType == Types.DECIMAL) {
-            int precision = pColumn.getMaxLength();
-            int scale = pColumn.getScale() == null ? 0 : Math.min(precision, pColumn.getScale());
-            return new ColumnInfo(pColumn.toString(), sqlType, precision, scale);
-        }
-        return new ColumnInfo(pColumn.toString(), sqlType);
+        return ColumnInfo.create(pColumn.toString(), pColumn.getDataType().getSqlType(),
+                pColumn.getMaxLength(), pColumn.getScale());
     }
 
    /**

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/PhoenixRuntime.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/PhoenixRuntime.java
@@ -470,7 +470,7 @@ public class PhoenixRuntime {
             throw new SQLException("pColumn must not be null.");
         }
         int sqlType = pColumn.getDataType().getSqlType();
-        if (pColumn.getMaxLength() != null) {
+        if (pColumn.getMaxLength() == null) {
             return new ColumnInfo(pColumn.toString(), sqlType);
         }
         if (sqlType == Types.CHAR || sqlType == Types.VARCHAR) {

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/ColumnInfoTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/ColumnInfoTest.java
@@ -55,4 +55,24 @@ public class ColumnInfoTest {
         ColumnInfo columnInfo = new ColumnInfo(":myColumn", Types.INTEGER);
         assertEquals(columnInfo, ColumnInfo.fromString(columnInfo.toString()));
     }
+    
+    @Test
+    public void testOptionalDescriptionType() {
+        testType(new ColumnInfo("a.myColumn", Types.CHAR), "CHAR:\"a\".\"myColumn\"");
+        testType(new ColumnInfo("a.myColumn", Types.CHAR, 100), "CHAR(100):\"a\".\"myColumn\"");
+        testType(new ColumnInfo("a.myColumn", Types.VARCHAR), "VARCHAR:\"a\".\"myColumn\"");
+        testType(new ColumnInfo("a.myColumn", Types.VARCHAR, 100), "VARCHAR(100):\"a\".\"myColumn\"");
+        testType(new ColumnInfo("a.myColumn", Types.DECIMAL), "DECIMAL:\"a\".\"myColumn\"");
+        testType(new ColumnInfo("a.myColumn", Types.DECIMAL, 100, 10), "DECIMAL(100,10):\"a\".\"myColumn\"");
+    }
+
+    private void testType(ColumnInfo columnInfo, String expected) {
+        assertEquals(expected, columnInfo.toString());
+        ColumnInfo reverted = ColumnInfo.fromString(columnInfo.toString());
+        assertEquals(reverted.getColumnName(), columnInfo.getColumnName());
+        assertEquals(reverted.getDisplayName(), columnInfo.getDisplayName());
+        assertEquals(reverted.getSqlType(), columnInfo.getSqlType());
+        assertEquals(reverted.getMaxLength(), columnInfo.getMaxLength());
+        assertEquals(reverted.getScale(), columnInfo.getScale());
+    }
 }


### PR DESCRIPTION
from jira description

> When loading a Spark dataframe from a Phoenix table with a 'DECIMAL' type, the underlying precision and scale aren't carried forward to Spark.
> 
> The Spark catalyst schema converter should load these from the underlying column. These appear to be exposed in the ResultSetMetaData, but if there was a way to expose these somehow through ColumnInfo, it would be cleaner.
> 
> I'm not sure if Pig has the same issues or not, but I suspect it may.

It seemed enough just for current usage in spark-interagation. But in long term, PDataType should contain meta information like maxLength or precision, etc.
