### PR TITLE
PHOENIX-2349 SortOrderExpressionTest.toChar() is failing in different locale

### DIFF
--- a/phoenix-core/src/test/java/org/apache/phoenix/expression/SortOrderExpressionTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/expression/SortOrderExpressionTest.java
@@ -26,6 +26,7 @@ import java.sql.Date;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
@@ -145,8 +146,14 @@ public class SortOrderExpressionTest {
     
     @Test
     public void toChar() throws Exception {
-        List<Expression> args = Lists.newArrayList(getInvertedLiteral(date(12, 11, 2001), PDate.INSTANCE));
-        evaluateAndAssertResult(new ToCharFunction(args, FunctionArgumentType.TEMPORAL, "", DateUtil.getDateFormatter("MM/dd/yy hh:mm a")), "12/11/01 12:00 AM");
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.US);
+            List<Expression> args = Lists.newArrayList(getInvertedLiteral(date(12, 11, 2001), PDate.INSTANCE));
+            evaluateAndAssertResult(new ToCharFunction(args, FunctionArgumentType.TEMPORAL, "", DateUtil.getDateFormatter("MM/dd/yy hh:mm a")), "12/11/01 12:00 AM");
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
     
     @Test


### PR DESCRIPTION
For example in ko.kr,
```
Tests run: 24, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.025 sec <<< FAILURE! - in org.apache.phoenix.expression.SortOrderExpressionTest
toChar(org.apache.phoenix.expression.SortOrderExpressionTest)  Time elapsed: 0.007 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<12/11/01 12:00 [AM]> but was:<12/11/01 12:00 [오전]>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.apache.phoenix.expression.SortOrderExpressionTest.evaluateAndAssertResult(SortOrderExpressionTest.java:322)
	at org.apache.phoenix.expression.SortOrderExpressionTest.evaluateAndAssertResult(SortOrderExpressionTest.java:312)
	at org.apache.phoenix.expression.SortOrderExpressionTest.toChar(SortOrderExpressionTest.java:149)
```