### PR TITLE
PHOENIX-2364 Fix Reverse timestamp row key

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/types/PUnsignedInt.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/types/PUnsignedInt.java
@@ -158,6 +158,7 @@ public class PUnsignedInt extends PWholeNumber<Integer> {
       checkForSufficientLength(b, o, Bytes.SIZEOF_INT);
       if (sortOrder == SortOrder.DESC) {
         b = SortOrder.invert(b, o, new byte[Bytes.SIZEOF_INT], 0, Bytes.SIZEOF_INT);
+        o = 0;
       }
       int v = Bytes.toInt(b, o);
       if (v < 0) {


### PR DESCRIPTION
When inverting the nanosecond part of a Timestamp key the offset should be reset.
