### PR TITLE
IndexFailed when data table name contains  ":"

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/util/SchemaUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/SchemaUtil.java
@@ -262,7 +262,7 @@ public class SchemaUtil {
     }
 
     private static String getName(String optionalQualifier, String name, boolean caseSensitive) {
-        String cq = caseSensitive ? "\"" + name + "\"" : name;
+        String cq = caseSensitive || (name!=null && name.contains(":")) ? "\"" + name + "\"" : name;
         if (optionalQualifier == null || optionalQualifier.isEmpty()) {
             return cq;
         }


### PR DESCRIPTION
bin/hbase org.apache.phoenix.mapreduce.index.IndexTool  --data-table raw:table --index-table INDEX --output-path hdfs://ip:port/folder

failed when active index table


2016-04-23 00:13:06,262 ERROR [main] index.IndexTool:  An exception occured while performing the indexing job : org.apache.phoenix.exception.PhoenixParserException: ERROR 601 (42P00): Syntax error. Encountered ":" at line 1, column 44.
        at org.apache.phoenix.exception.PhoenixParserException.newException(PhoenixParserException.java:33)
        at org.apache.phoenix.parse.SQLParser.parseStatement(SQLParser.java:111)
        at org.apache.phoenix.jdbc.PhoenixStatement$PhoenixStatementParser.parseStatement(PhoenixStatement.java:1185)
        at org.apache.phoenix.jdbc.PhoenixStatement.parseStatement(PhoenixStatement.java:1268)
        at org.apache.phoenix.jdbc.PhoenixStatement.execute(PhoenixStatement.java:1339)
        at org.apache.phoenix.mapreduce.index.IndexToolUtil.updateIndexState(IndexToolUtil.java:72)
        at org.apache.phoenix.mapreduce.index.IndexTool.run(IndexTool.java:252)
        at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
        at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:84)
        at org.apache.phoenix.mapreduce.index.IndexTool.main(IndexTool.java:378)
Caused by: NoViableAltException(25@[])
        at org.apache.phoenix.parse.PhoenixSQLParser.from_table_name(PhoenixSQLParser.java:9170)
        at org.apache.phoenix.parse.PhoenixSQLParser.alter_index_node(PhoenixSQLParser.java:2762)
        at org.apache.phoenix.parse.PhoenixSQLParser.oneStatement(PhoenixSQLParser.java:838)
        at org.apache.phoenix.parse.PhoenixSQLParser.statement(PhoenixSQLParser.java:500)
        at org.apache.phoenix.parse.SQLParser.parseStatement(SQLParser.java:108)
        ... 8 more