### PR TITLE
[PHOENIX-2956] apache-rat plugin error: Too many unapproved licenses

### DIFF
--- a/dev/make_rc.sh
+++ b/dev/make_rc.sh
@@ -69,7 +69,7 @@ mkdir $DIR_BIN;
 mv $REL_SRC.tar.gz $DIR_REL_SRC_TAR_PATH;
 
 # Copy common jars
-mvn clean apache-rat:check package -DskipTests -Dcheckstyle.skip=true -q;
+mvn clean apache-rat:check -Drat.numUnapprovedLicenses=100 package -DskipTests -Dcheckstyle.skip=true -q;
 rm -rf $(find . -type d -name archive-tmp);
 
 # Copy all phoenix-*.jars to release dir


### PR DESCRIPTION
[ERROR] Failed to execute goal org.apache.rat:apache-rat-plugin:0.8:check (default-cli) on project phoenix-core: Too many unapproved licenses: 4 -> [Help 1]

In the build shell script of `make_rc.sh`, fix by `-Drat.numUnapprovedLicenses=100` 
