### PR TITLE
PHOENIX-3298 Single column primary key may not be null

### DIFF
--- a/phoenix-core/src/main/codegen/includes/parserImpls.ftl
+++ b/phoenix-core/src/main/codegen/includes/parserImpls.ftl
@@ -543,7 +543,7 @@ SqlColumnDefNode ColumnDef() :
 {
     SqlIdentifier columnName;
     SqlDataTypeNode dataType;
-    boolean isNull = true;
+    Boolean isNull = null;
     boolean isPk = false;
     SortOrder sortOrder = SortOrder.getDefault();
     boolean isRowTimestamp = false;

--- a/phoenix-core/src/main/java/org/apache/calcite/sql/SqlColumnDefNode.java
+++ b/phoenix-core/src/main/java/org/apache/calcite/sql/SqlColumnDefNode.java
@@ -35,7 +35,7 @@ public class SqlColumnDefNode extends SqlNode{
             SqlParserPos pos,
             SqlIdentifier columnName,
             SqlDataTypeNode dataType,
-            boolean isNullable,
+            Boolean isNullable,
             boolean isPk,
             SortOrder sortOrder,
             String expressionStr,

--- a/phoenix-core/src/test/java/org/apache/phoenix/compile/QueryCompilerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/compile/QueryCompilerTest.java
@@ -1453,7 +1453,7 @@ public class QueryCompilerTest extends BaseConnectionlessQueryTest {
             }
         }
     }
-    
+
     @Test
     public void testInvalidNullCompositePrimaryKey() throws Exception {
         Connection conn = DriverManager.getConnection(getUrl());


### PR DESCRIPTION
Note: This patch will not immediately resolve the testInvalidPrimaryKeyDecl() test case due to another issue, PHOENIX-3345. However, they are independent issues so there's no reason to wait on this.