### PR TITLE
PHOENIX-3355 Register Phoenix built-in functions as Calcite functions

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DateTimeIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DateTimeIT.java
@@ -411,45 +411,45 @@ public class DateTimeIT extends ParallelStatsDisabledIT {
     @Test
     public void testYearFunctionDate() throws SQLException {
 
-        assertEquals(2008, callYearFunction("YEAR(TO_DATE('2008-01-01', 'yyyy-MM-dd', 'local'))"));
+        assertEquals(2008, callYearFunction("\"YEAR\"(TO_DATE('2008-01-01', 'yyyy-MM-dd', 'local'))"));
 
         assertEquals(2004,
-            callYearFunction("YEAR(TO_DATE('2004-12-13 10:13:18', 'yyyy-MM-dd hh:mm:ss'))"));
+            callYearFunction("\"YEAR\"(TO_DATE('2004-12-13 10:13:18', 'yyyy-MM-dd hh:mm:ss'))"));
 
-        assertEquals(2015, callYearFunction("YEAR(TO_DATE('2015-01-27T16:17:57+00:00'))"));
+        assertEquals(2015, callYearFunction("\"YEAR\"(TO_DATE('2015-01-27T16:17:57+00:00'))"));
 
-        assertEquals(2005, callYearFunction("YEAR(TO_DATE('2005-12-13 10:13:18'))"));
+        assertEquals(2005, callYearFunction("\"YEAR\"(TO_DATE('2005-12-13 10:13:18'))"));
 
-        assertEquals(2006, callYearFunction("YEAR(TO_DATE('2006-12-13'))"));
+        assertEquals(2006, callYearFunction("\"YEAR\"(TO_DATE('2006-12-13'))"));
 
-        assertEquals(2015, callYearFunction("YEAR(TO_DATE('2015-W05'))"));
+        assertEquals(2015, callYearFunction("\"YEAR\"(TO_DATE('2015-W05'))"));
 
         assertEquals(
             2008,
-            callYearFunction("YEAR(TO_DATE('Sat, 3 Feb 2008 03:05:06 GMT', 'EEE, d MMM yyyy HH:mm:ss z', 'UTC'))"));
+            callYearFunction("\"YEAR\"(TO_DATE('Sat, 3 Feb 2008 03:05:06 GMT', 'EEE, d MMM yyyy HH:mm:ss z', 'UTC'))"));
     }
 
     @Test
     public void testYearFunctionTimestamp() throws SQLException {
 
-        assertEquals(2015, callYearFunction("YEAR(TO_TIMESTAMP('2015-01-27T16:17:57+00:00'))"));
+        assertEquals(2015, callYearFunction("\"YEAR\"(TO_TIMESTAMP('2015-01-27T16:17:57+00:00'))"));
 
-        assertEquals(2015, callYearFunction("YEAR(TO_TIMESTAMP('2015-01-27T16:17:57Z'))"));
+        assertEquals(2015, callYearFunction("\"YEAR\"(TO_TIMESTAMP('2015-01-27T16:17:57Z'))"));
 
-        assertEquals(2015, callYearFunction("YEAR(TO_TIMESTAMP('2015-W10-3'))"));
+        assertEquals(2015, callYearFunction("\"YEAR\"(TO_TIMESTAMP('2015-W10-3'))"));
 
-        assertEquals(2015, callYearFunction("YEAR(TO_TIMESTAMP('2015-W05'))"));
+        assertEquals(2015, callYearFunction("\"YEAR\"(TO_TIMESTAMP('2015-W05'))"));
 
-        assertEquals(2015, callYearFunction("YEAR(TO_TIMESTAMP('2015-063'))"));
+        assertEquals(2015, callYearFunction("\"YEAR\"(TO_TIMESTAMP('2015-063'))"));
 
-        assertEquals(2006, callYearFunction("YEAR(TO_TIMESTAMP('2006-12-13'))"));
+        assertEquals(2006, callYearFunction("\"YEAR\"(TO_TIMESTAMP('2006-12-13'))"));
 
         assertEquals(2004,
-            callYearFunction("YEAR(TO_TIMESTAMP('2004-12-13 10:13:18', 'yyyy-MM-dd hh:mm:ss'))"));
+            callYearFunction("\"YEAR\"(TO_TIMESTAMP('2004-12-13 10:13:18', 'yyyy-MM-dd hh:mm:ss'))"));
 
         assertEquals(
             2008,
-            callYearFunction("YEAR(TO_TIMESTAMP('Sat, 3 Feb 2008 03:05:06 GMT', 'EEE, d MMM yyyy HH:mm:ss z', 'UTC'))"));
+            callYearFunction("\"YEAR\"(TO_TIMESTAMP('Sat, 3 Feb 2008 03:05:06 GMT', 'EEE, d MMM yyyy HH:mm:ss z', 'UTC'))"));
     }
 
     @Test
@@ -470,8 +470,8 @@ public class DateTimeIT extends ParallelStatsDisabledIT {
         conn.createStatement().execute(dml);
         conn.commit();
 
-        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, YEAR(timestamps), YEAR(times), Year(unsignedDates), YEAR(unsignedTimestamps), " +
-                "YEAR(unsignedTimes) FROM " + tableName + " where YEAR(dates) = 2004");
+        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, \"YEAR\"(timestamps), \"YEAR\"(times), \"YEAR\"(unsignedDates), \"YEAR\"(unsignedTimestamps), " +
+                "\"YEAR\"(unsignedTimes) FROM " + tableName + " where \"YEAR\"(dates) = 2004");
         assertTrue(rs.next());
         assertEquals(1, rs.getInt(1));
         assertEquals(2006, rs.getInt(2));
@@ -500,8 +500,8 @@ public class DateTimeIT extends ParallelStatsDisabledIT {
         conn.createStatement().execute(dml);
         conn.commit();
 
-        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, MONTH(timestamps), MONTH(times), MONTH(unsignedDates), MONTH(unsignedTimestamps), " +
-                "MONTH(unsignedTimes) FROM " + tableName + " where MONTH(dates) = 3");
+        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, \"MONTH\"(timestamps), \"MONTH\"(times), \"MONTH\"(unsignedDates), \"MONTH\"(unsignedTimestamps), " +
+                "\"MONTH\"(unsignedTimes) FROM " + tableName + " where \"MONTH\"(dates) = 3");
         assertTrue(rs.next());
         assertEquals(1, rs.getInt(1));
         assertEquals(4, rs.getInt(2));
@@ -577,7 +577,7 @@ public class DateTimeIT extends ParallelStatsDisabledIT {
         conn.createStatement().execute(dml);
         conn.commit();
 
-        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, WEEK(dates), WEEK(times) FROM " + tableName + " where WEEK(timestamps)=15");
+        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, \"WEEK\"(dates), \"WEEK\"(times) FROM " + tableName + " where \"WEEK\"(timestamps)=15");
         assertTrue(rs.next());
         assertEquals(1, rs.getInt(1));
         assertEquals(2, rs.getInt(2));
@@ -602,7 +602,7 @@ public class DateTimeIT extends ParallelStatsDisabledIT {
         conn.createStatement().execute(dml);
         conn.commit();
 
-        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, HOUR(dates), HOUR(times) FROM " + tableName + " where HOUR(timestamps)=15");
+        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, \"HOUR\"(dates), \"HOUR\"(times) FROM " + tableName + " where \"HOUR\"(timestamps)=15");
         assertTrue(rs.next());
         assertEquals(1, rs.getInt(1));
         assertEquals(3, rs.getInt(2));
@@ -649,8 +649,8 @@ public class DateTimeIT extends ParallelStatsDisabledIT {
         conn.createStatement().execute(dml);
         conn.commit();
 
-        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, MINUTE(dates), MINUTE(times), MINUTE(unsignedDates), MINUTE(unsignedTimestamps), " +
-                "MINUTE(unsignedTimes) FROM " + tableName + " where MINUTE(timestamps)=20");
+        ResultSet rs = conn.createStatement().executeQuery("SELECT k1, \"MINUTE\"(dates), \"MINUTE\"(times), \"MINUTE\"(unsignedDates), \"MINUTE\"(unsignedTimestamps), " +
+                "\"MINUTE\"(unsignedTimes) FROM " + tableName + " where \"MINUTE\"(timestamps)=20");
         assertTrue(rs.next());
         assertEquals(1, rs.getInt(1));
         assertEquals(10, rs.getInt(2));
@@ -835,7 +835,7 @@ public class DateTimeIT extends ParallelStatsDisabledIT {
     
     @Test
     public void testFunctionOnNullDate() throws Exception {
-        ResultSet rs = conn.createStatement().executeQuery("SELECT YEAR(a_date), entity_id from " + this.tableName + " WHERE entity_id = '" + ROW10 + "'");
+        ResultSet rs = conn.createStatement().executeQuery("SELECT \"YEAR\"(a_date), entity_id from " + this.tableName + " WHERE entity_id = '" + ROW10 + "'");
         assertNotNull(rs);
         assertTrue(rs.next());
         assertEquals(ROW10, rs.getString(2));

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DefaultColumnValueIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DefaultColumnValueIT.java
@@ -586,7 +586,7 @@ public class DefaultColumnValueIT extends ParallelStatsDisabledIT {
                 + "c3 DECIMAL DEFAULT TO_NUMBER('$123.33', '\u00A4###.##'),"
                 + "c4 VARCHAR DEFAULT 'AB' || 'CD',"
                 + "c5 CHAR(5) DEFAULT 'E' || 'F',"
-                + "c6 INTEGER DEFAULT MONTH(TO_TIMESTAMP('2015-6-05'))"
+                + "c6 INTEGER DEFAULT \"MONTH\"(TO_TIMESTAMP('2015-6-05'))"
                 + ")";
 
         verifyDefaultExpression(sharedTable2, ddl);
@@ -602,7 +602,7 @@ public class DefaultColumnValueIT extends ParallelStatsDisabledIT {
                 + "c3 DECIMAL NOT NULL DEFAULT TO_NUMBER('$123.33', '\u00A4###.##'),"
                 + "c4 VARCHAR NOT NULL DEFAULT 'AB' || 'CD',"
                 + "c5 CHAR(5) NOT NULL DEFAULT 'E' || 'F',"
-                + "c6 INTEGER NOT NULL DEFAULT MONTH(TO_TIMESTAMP('2015-6-05')),"
+                + "c6 INTEGER NOT NULL DEFAULT \"MONTH\"(TO_TIMESTAMP('2015-6-05')),"
                 + "CONSTRAINT pk_key PRIMARY KEY (pk,c1,c2,c3,c4,c5,c6)"
                 + ")";
 
@@ -1048,7 +1048,7 @@ public class DefaultColumnValueIT extends ParallelStatsDisabledIT {
                 + "c3 DECIMAL DEFAULT TO_NUMBER('$123.33', '\u00A4###.##'),"
                 + "c4 VARCHAR DEFAULT 'AB' || 'CD',"
                 + "c5 CHAR(5) DEFAULT 'E' || 'F',"
-                + "c6 INTEGER DEFAULT MONTH(TO_TIMESTAMP('2015-6-05'))"
+                + "c6 INTEGER DEFAULT \"MONTH\"(TO_TIMESTAMP('2015-6-05'))"
                 + ")";
 
         Connection conn = DriverManager.getConnection(getUrl());

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ToDateFunctionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ToDateFunctionIT.java
@@ -48,7 +48,7 @@ public class ToDateFunctionIT extends ParallelStatsDisabledIT {
 
     private static java.util.Date callToDateFunction(Connection conn, String invocation) throws SQLException {
         Statement stmt = conn.createStatement();
-        ResultSet rs = stmt.executeQuery(String.format("SELECT %s FROM SYSTEM.CATALOG LIMIT 1", invocation));
+        ResultSet rs = stmt.executeQuery(String.format("SELECT %s FROM \"SYSTEM\".CATALOG LIMIT 1", invocation));
         assertTrue(rs.next());
         java.util.Date returnValue = (java.util.Date)rs.getObject(1);
         rs.close();

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/UserDefinedFunctionsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/UserDefinedFunctionsIT.java
@@ -1054,28 +1054,19 @@ public class UserDefinedFunctionsIT extends BaseOwnClusterIT {
     public void testBuiltinFunctionasUDF() throws Exception {
         Connection conn = driver.connect(calciteUrl, UDF_PROPS);
         Statement stmt = conn.createStatement();
-        conn.createStatement().execute("create table t12(k date not null primary key, k1 integer, lastname varchar)");
+        conn.createStatement().execute("create table t12(k date not null primary key, k1 integer)");
         String query = "UPSERT INTO t12"
-                + "(k, k1, lastname) "
-                + "VALUES(?,?,?)";
+                + "(k, k1) "
+                + "VALUES(?,?)";
         PreparedStatement pStmt = conn.prepareStatement(query);
         pStmt.setDate(1, java.sql.Date.valueOf("2016-06-06"));
         pStmt.setInt(2, 1);
-        pStmt.setString(3, "year");
         pStmt.execute();
         conn.commit();
-        stmt.execute("create function TO_DATE(VARCHAR) returns DATE as 'org.apache.phoenix.expression.function.ToDateFunction'");// using jar "
-                //+ "'"+util.getConfiguration().get(DYNAMIC_JARS_DIR_KEY) + "/myjar7.jar"+"'");
+        stmt.execute("create function TO_DATE(VARCHAR) returns DATE as 'org.apache.phoenix.expression.function.ToDateFunction'");
         ResultSet rs = stmt.executeQuery("select k from t12");
         assertTrue(rs.next());
         assertEquals(java.sql.Date.valueOf("2016-06-06"), rs.getDate(1));
-
-        Statement s = conn.createStatement();
-        query = "SELECT k FROM t12 where k=TO_DATE('2016-06-06')";
-        rs = s.executeQuery(query);
-        while(rs.next()){
-            System.out.println(rs.getString("k"));
-        }
     }
 
     /**

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/UserDefinedFunctionsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/UserDefinedFunctionsIT.java
@@ -1050,25 +1050,6 @@ public class UserDefinedFunctionsIT extends BaseOwnClusterIT {
         assertEquals(72057594037927936l, rs.getLong(2));
     }
 
-    @Test
-    public void testBuiltinFunctionasUDF() throws Exception {
-        Connection conn = driver.connect(calciteUrl, UDF_PROPS);
-        Statement stmt = conn.createStatement();
-        conn.createStatement().execute("create table t12(k date not null primary key, k1 integer)");
-        String query = "UPSERT INTO t12"
-                + "(k, k1) "
-                + "VALUES(?,?)";
-        PreparedStatement pStmt = conn.prepareStatement(query);
-        pStmt.setDate(1, java.sql.Date.valueOf("2016-06-06"));
-        pStmt.setInt(2, 1);
-        pStmt.execute();
-        conn.commit();
-        stmt.execute("create function TO_DATE(VARCHAR) returns DATE as 'org.apache.phoenix.expression.function.ToDateFunction'");
-        ResultSet rs = stmt.executeQuery("select k from t12");
-        assertTrue(rs.next());
-        assertEquals(java.sql.Date.valueOf("2016-06-06"), rs.getDate(1));
-    }
-
     /**
      * Compiles the test class with bogus code into a .class file.
      */

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/LocalIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/LocalIndexIT.java
@@ -87,16 +87,16 @@ public class LocalIndexIT extends BaseLocalIndexIT {
         conn1.createStatement().execute(createTable);
         conn1.createStatement().execute(
             "CREATE local INDEX IF NOT EXISTS " + indexName2 + " on " + tableName2
-                    + "(HOUR(user_time))");
+                    + "(\"HOUR\"(user_time))");
         conn1.createStatement().execute(
             "upsert into " + tableName2 + " values(TO_TIME('2005-10-01 14:03:22.559'), 'foo')");
         conn1.commit();
         ResultSet rs =
                 conn1.createStatement()
                         .executeQuery(
-                            "select substr(to_char(user_time), 0, 10) as ddate, hour(user_time) as hhour, user_id, col1,col2 from "
+                            "select substr(to_char(user_time), 0, 10) as ddate, \"HOUR\"(user_time) as hhour, user_id, col1,col2 from "
                                     + tableName2
-                                    + " where hour(user_time)=14 group by user_id, col1, col2, ddate, hhour limit 1");
+                                    + " where \"HOUR\"(user_time)=14 group by user_id, col1, col2, ddate, hhour limit 1");
         assertTrue(rs.next());
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/CalciteUtils.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/CalciteUtils.java
@@ -89,6 +89,7 @@ import org.apache.phoenix.expression.function.AbsFunction;
 import org.apache.phoenix.expression.function.AggregateFunction;
 import org.apache.phoenix.expression.function.CeilDateExpression;
 import org.apache.phoenix.expression.function.CeilDecimalExpression;
+import org.apache.phoenix.expression.function.CeilFunction;
 import org.apache.phoenix.expression.function.CeilTimestampExpression;
 import org.apache.phoenix.expression.function.CoalesceFunction;
 import org.apache.phoenix.expression.function.CountAggregateFunction;
@@ -97,6 +98,7 @@ import org.apache.phoenix.expression.function.CurrentTimeFunction;
 import org.apache.phoenix.expression.function.ExpFunction;
 import org.apache.phoenix.expression.function.FloorDateExpression;
 import org.apache.phoenix.expression.function.FloorDecimalExpression;
+import org.apache.phoenix.expression.function.FloorFunction;
 import org.apache.phoenix.expression.function.FunctionExpression;
 import org.apache.phoenix.expression.function.LnFunction;
 import org.apache.phoenix.expression.function.LowerFunction;
@@ -150,7 +152,6 @@ public class CalciteUtils {
             .defaultSchema(rootSchema).build();
     }
 
-    //TODO: Add aggregate functions
     protected static final List<String> TRANSLATED_BUILT_IN_FUNCTIONS = Lists.newArrayList(
             SqrtFunction.NAME,
             PowerFunction.NAME,
@@ -161,7 +162,10 @@ public class CalciteUtils {
             CurrentTimeFunction.NAME,
             LowerFunction.NAME,
             UpperFunction.NAME,
-            CoalesceFunction.NAME);
+            CoalesceFunction.NAME,
+            TrimFunction.NAME,
+            CeilFunction.NAME,
+            FloorFunction.NAME);
 
     public static String createTempAlias() {
         return "$" + tempAliasCounter.incrementAndGet();

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/CalciteUtils.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/CalciteUtils.java
@@ -790,9 +790,9 @@ public class CalciteUtils {
                             if(scalarFunc.getBuiltInFunction() != null){
                                 try {
                                     try {
-                                        return (Expression) info.getFunc().getDeclaredConstructor(List.class).newInstance(children);
+                                        return info.getFunc().getDeclaredConstructor(List.class).newInstance(children);
                                     } catch (Exception e) {
-                                        return (Expression) info.getFunc().getDeclaredConstructor(List.class, StatementContext.class).newInstance(children, implementor.getStatementContext());
+                                        return info.getFunc().getDeclaredConstructor(List.class, StatementContext.class).newInstance(children, implementor.getStatementContext());
                                     }
                                 } catch (Exception e) {throw new RuntimeException ("Failed to create builtin function " + info.getName(), e);}
                             }

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/CalciteUtils.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/CalciteUtils.java
@@ -146,7 +146,20 @@ public class CalciteUtils {
             .parserConfig(SqlParser.Config.DEFAULT)
             .defaultSchema(rootSchema).build();
     }
-    
+
+    //TODO: Add aggregate functions
+    protected static final List<String> TRANSLATED_BUILT_IN_FUNCTIONS = Lists.newArrayList(
+            SqrtFunction.NAME,
+            PowerFunction.NAME,
+            LnFunction.NAME,
+            ExpFunction.NAME,
+            AbsFunction.NAME,
+            CurrentDateFunction.NAME,
+            CurrentTimeFunction.NAME,
+            LowerFunction.NAME,
+            UpperFunction.NAME,
+            CoalesceFunction.NAME);
+
     public static String createTempAlias() {
         return "$" + tempAliasCounter.incrementAndGet();
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixScalarFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixScalarFunction.java
@@ -47,7 +47,7 @@ public class PhoenixScalarFunction implements ScalarFunction, ImplementableFunct
     private final PDataType returnType;
     private final List<FunctionParameter> parameters;
     private final BuiltInFunctionInfo parseInfo;
-    
+
     public PhoenixScalarFunction(PFunction functionInfo) {
         this.functionInfo = functionInfo;
         this.returnType =
@@ -109,13 +109,13 @@ public class PhoenixScalarFunction implements ScalarFunction, ImplementableFunct
     }
 
     public static List<PhoenixScalarFunction> createBuiltinFunctions(BuiltInFunctionInfo parseInfo){
-        List<PhoenixScalarFunction> functionList = Lists.newArrayList();
+        List<List<FunctionArgument>> overloadedArgs = PhoenixSchema.overloadArguments(parseInfo.getArgs());
+        List<PhoenixScalarFunction> functionList = Lists.newArrayListWithExpectedSize(overloadedArgs.size());
+        Class<? extends FunctionExpression> clazz = parseInfo.getFunc();
+
         try {
-            for (List<FunctionArgument> argumentList : parseInfo.overloadArguments()) {
-                Class<? extends FunctionExpression> clazz = parseInfo.getFunc();
-                List<FunctionParameter>
-                        parameters =
-                        Lists.newArrayListWithExpectedSize(argumentList.size());
+            for (List<FunctionArgument> argumentList : overloadedArgs) {
+                List<FunctionParameter> parameters = Lists.newArrayListWithExpectedSize(argumentList.size());
                 PDataType returnType = evaluateReturnType(clazz, argumentList);
 
                 for (final FunctionArgument arg : argumentList) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixScalarFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixScalarFunction.java
@@ -30,10 +30,7 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.schema.FunctionParameter;
 import org.apache.calcite.schema.ImplementableFunction;
 import org.apache.calcite.schema.ScalarFunction;
-import org.apache.phoenix.expression.function.FunctionExpression;
-import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunctionInfo;
-import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.parse.PFunction;
 import org.apache.phoenix.parse.PFunction.FunctionArgument;
 import org.apache.phoenix.schema.types.PDataType;
@@ -89,66 +86,6 @@ public class PhoenixScalarFunction implements ScalarFunction, ImplementableFunct
         this.pFunction = null;
     }
 
-    private static PDataType evaluateReturnType(Class<? extends FunctionExpression> f, List<FunctionArgument> argumentList) {
-        BuiltInFunction d = f.getAnnotation(BuiltInFunction.class);
-        try {
-            // Direct evaluation of the return type
-            FunctionExpression func = f.newInstance();
-            return func.getDataType();
-        } catch (Exception e) {
-            // should never happen
-            if (d.classType() == FunctionClassType.ALIAS || d.classType() == FunctionClassType.ABSTRACT) {
-                throw new RuntimeException();
-            }
-            // Grab the primary argument
-            assert(argumentList.size() != 0);
-            return PDataType.fromSqlTypeName(argumentList.get(0).getArgumentType());
-        }
-    }
-
-    public static List<PhoenixScalarFunction> createBuiltinFunctions(BuiltInFunctionInfo functionInfo){
-        List<List<FunctionArgument>> overloadedArgs = PhoenixSchema.overloadArguments(functionInfo.getArgs());
-        List<PhoenixScalarFunction> functionList = Lists.newArrayListWithExpectedSize(overloadedArgs.size());
-        Class<? extends FunctionExpression> clazz = functionInfo.getFunc();
-
-        try {
-            for (List<FunctionArgument> argumentList : overloadedArgs) {
-                List<FunctionParameter> parameters = Lists.newArrayListWithExpectedSize(argumentList.size());
-                PDataType returnType = evaluateReturnType(clazz, argumentList);
-
-                for (final FunctionArgument arg : argumentList) {
-                    parameters.add(
-                            new FunctionParameter() {
-                                public int getOrdinal() {
-                                    return arg.getArgPosition();
-                                }
-
-                                public String getName() {
-                                    return getArgumentName(arg.getArgPosition());
-                                }
-
-                                @SuppressWarnings("rawtypes")
-                                public RelDataType getType(RelDataTypeFactory typeFactory) {
-                                    PDataType dataType =
-                                            arg.isArrayType() ? PDataType.fromTypeId(PDataType.sqlArrayType(SchemaUtil
-                                                    .normalizeIdentifier(SchemaUtil.normalizeIdentifier(arg
-                                                            .getArgumentType())))) : PDataType.fromSqlTypeName(SchemaUtil
-                                                    .normalizeIdentifier(arg.getArgumentType()));
-                                    return typeFactory.createJavaType(dataType.getJavaClass());
-                                }
-
-                                public boolean isOptional() {
-                                    return arg.getDefaultValue() != null;
-                                }
-                            });
-                }
-                functionList.add(new PhoenixScalarFunction(functionInfo, parameters, returnType));
-            }
-        } catch (Exception e){
-            throw new RuntimeException("Builtin function " + functionInfo.getName() + " could not be registered", e);
-        }
-        return functionList;
-    }
     @Override
     public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
         return typeFactory.createJavaType(returnType.getJavaClass());

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixSchema.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixSchema.java
@@ -148,10 +148,10 @@ public class PhoenixSchema implements Schema {
             overloadedArgs.add(new ArrayList<PFunction.FunctionArgument>());
             for(BuiltInFunctionArgInfo arg : args) {
                 Class<? extends PDataType>[] temp = arg.getAllowedTypes();
-                String inputArg = PDataTypeFactory.getInstance().instanceFromClass(temp[(i/j)%temp.length]).toString();
+                PDataType dataType = PDataTypeFactory.getInstance().instanceFromClass(temp[(i/j)%temp.length]);
                 overloadedArgs.get(i).add( new PFunction.FunctionArgument(
-                        inputArg,
-                        false,
+                        dataType.toString(),
+                        dataType.isArrayType(),
                         arg.isConstant(),
                         arg.getDefaultValue(),
                         arg.getMinValue(),

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixSchema.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixSchema.java
@@ -128,10 +128,9 @@ public class PhoenixSchema implements Schema {
         Collection<FunctionParseNode.BuiltInFunctionInfo>  infoCollection = ParseNodeFactory.getAll();
         for (FunctionParseNode.BuiltInFunctionInfo info : infoCollection) {
             try {
-                //TODO: aliasing for functions that already exist NOW, TRUNC
                 if(!CalciteUtils.TRANSLATED_BUILT_IN_FUNCTIONS.contains(info.getName())) {
                     builtinFunctions.put(info.getName(),
-                            (List<Function>)(Object)PhoenixScalarFunction.createBuiltinFunction(info));
+                            (List<Function>)(Object)PhoenixScalarFunction.createBuiltinFunctions(info));
                 }
             }
             catch(RuntimeException e){

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixSchema.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixSchema.java
@@ -75,7 +75,8 @@ public class PhoenixSchema implements Schema {
     protected final UDFExpression exp = new UDFExpression();
     private final static Function listJarsFunction = TableFunctionImpl
             .create(ListJarsTable.LIST_JARS_TABLE_METHOD);
-    private final static Map<String, PhoenixScalarFunction> builtinFunctions = Maps.newHashMap();
+    public final static Map<String, Collection<Function>> builtinFunctions = Maps.newHashMap();
+
     
     protected PhoenixSchema(String name, String schemaName,
             SchemaPlus parentSchema, PhoenixConnection pc) {
@@ -127,9 +128,10 @@ public class PhoenixSchema implements Schema {
         Collection<FunctionParseNode.BuiltInFunctionInfo>  infoCollection = ParseNodeFactory.getAll();
         for (FunctionParseNode.BuiltInFunctionInfo info : infoCollection) {
             try {
+                //TODO: aliasing for functions that already exist NOW, TRUNC
                 if(!CalciteUtils.TRANSLATED_BUILT_IN_FUNCTIONS.contains(info.getName())) {
                     builtinFunctions.put(info.getName(),
-                            PhoenixScalarFunction.createBuiltinFunction(info));
+                            (List<Function>)(Object)PhoenixScalarFunction.createBuiltinFunction(info));
                 }
             }
             catch(RuntimeException e){
@@ -183,7 +185,7 @@ public class PhoenixSchema implements Schema {
     public Collection<Function> getFunctions(String name) {
         assert(!builtinFunctions.isEmpty());
         if(builtinFunctions.get(name) != null){
-            return ImmutableList.of((Function) builtinFunctions.get(name));
+            return builtinFunctions.get(name);
         }
         Function func = views.get(name);
         if (func != null) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixSchema.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/PhoenixSchema.java
@@ -93,7 +93,7 @@ public class PhoenixSchema implements Schema {
         try {
             PhoenixStatement stmt = (PhoenixStatement) pc.createStatement();
             this.sequenceManager = new SequenceManager(stmt);
-        } catch (SQLException e) {
+        } catch (SQLException e){
             throw new RuntimeException(e);
         }
         registerBuiltinFunctions();
@@ -127,14 +127,9 @@ public class PhoenixSchema implements Schema {
         }
         Collection<FunctionParseNode.BuiltInFunctionInfo>  infoCollection = ParseNodeFactory.getAll();
         for (FunctionParseNode.BuiltInFunctionInfo info : infoCollection) {
-            try {
-                if(!CalciteUtils.TRANSLATED_BUILT_IN_FUNCTIONS.contains(info.getName())) {
-                    builtinFunctions.put(info.getName(),
-                            (List<Function>)(Object)PhoenixScalarFunction.createBuiltinFunctions(info));
-                }
-            }
-            catch(RuntimeException e){
-                System.out.println("Function not registered: " + info.getName()); // Function couldn't be registered
+            if(!CalciteUtils.TRANSLATED_BUILT_IN_FUNCTIONS.contains(info.getName())) {
+                builtinFunctions.put(info.getName(),
+                        (List<Function>) (Object) PhoenixScalarFunction.createBuiltinFunctions(info));
             }
         }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ByteBasedRegexpReplaceFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ByteBasedRegexpReplaceFunction.java
@@ -23,7 +23,18 @@ import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
 import org.apache.phoenix.expression.util.regex.JONIPattern;
 import org.joni.Option;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
+@BuiltInFunction(name=RegexpReplaceFunction.NAME,
+        args= {
+        @Argument(allowedTypes={PVarchar.class}),
+        @Argument(allowedTypes={PVarchar.class}),
+        @Argument(allowedTypes={PVarchar.class},defaultValue="null")},
+        classType = FunctionClassType.DERIVED
+)
 public class ByteBasedRegexpReplaceFunction extends RegexpReplaceFunction {
 
     public ByteBasedRegexpReplaceFunction() {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ByteBasedRegexpSplitFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ByteBasedRegexpSplitFunction.java
@@ -23,7 +23,17 @@ import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBaseSplitter;
 import org.apache.phoenix.expression.util.regex.JONIPattern;
 import org.joni.Option;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
+@BuiltInFunction(name=RegexpSplitFunction.NAME,
+        args= {
+                @Argument(allowedTypes={PVarchar.class}),
+                @Argument(allowedTypes={PVarchar.class})},
+        classType = FunctionClassType.DERIVED
+)
 public class ByteBasedRegexpSplitFunction extends RegexpSplitFunction {
     public ByteBasedRegexpSplitFunction() {
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ByteBasedRegexpSubstrFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ByteBasedRegexpSubstrFunction.java
@@ -23,7 +23,23 @@ import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
 import org.apache.phoenix.expression.util.regex.JONIPattern;
 import org.joni.Option;
+import org.apache.phoenix.expression.Expression;
+import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
+import org.apache.phoenix.expression.util.regex.JONIPattern;
+import org.joni.Option;
+import org.apache.phoenix.schema.types.PLong;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
+@BuiltInFunction(name=RegexpSubstrFunction.NAME,
+        args= {
+                @Argument(allowedTypes={PVarchar.class}),
+                @Argument(allowedTypes={PVarchar.class}),
+                @Argument(allowedTypes={PLong.class}, defaultValue="1")},
+        classType = FunctionClassType.DERIVED
+)
 public class ByteBasedRegexpSubstrFunction extends RegexpSubstrFunction {
     public ByteBasedRegexpSubstrFunction() {
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilDateExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilDateExpression.java
@@ -26,6 +26,12 @@ import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.LiteralExpression;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PDataType;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.schema.types.PDate;
+import org.apache.phoenix.schema.types.PInteger;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
 import com.google.common.collect.Lists;
 
@@ -36,6 +42,14 @@ import com.google.common.collect.Lists;
  * 
  * @since 3.0.0
  */
+@BuiltInFunction(name = CeilFunction.NAME,
+        args = {
+                @Argument(allowedTypes={PDate.class}),
+                @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
+                @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
+        },
+        classType = FunctionClassType.DERIVED
+)
 public class CeilDateExpression extends RoundDateExpression {
     
     public CeilDateExpression() {}

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilDecimalExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilDecimalExpression.java
@@ -29,6 +29,11 @@ import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.schema.types.PDecimal;
 import org.apache.phoenix.schema.types.PInteger;
 import org.apache.phoenix.schema.types.PLong;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.schema.types.PInteger;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
 import com.google.common.collect.Lists;
 
@@ -39,6 +44,14 @@ import com.google.common.collect.Lists;
  *
  * @since 3.0.0
  */
+@BuiltInFunction(name = CeilFunction.NAME,
+        args = {
+                @Argument(allowedTypes={PDecimal.class}),
+                @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
+                @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
+        },
+        classType = FunctionClassType.DERIVED
+)
 public class CeilDecimalExpression extends RoundDecimalExpression {
 
     public CeilDecimalExpression() {}

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilFunction.java
@@ -48,7 +48,7 @@ import org.apache.phoenix.schema.types.PVarchar;
                         @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
                         @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
                         },
-                 classType = FunctionParseNode.FunctionClassType.PARENT,
+                 classType = FunctionParseNode.FunctionClassType.ABSTRACT,
                  derivedFunctions = {CeilDateExpression.class, CeilTimestampExpression.class, CeilDecimalExpression.class}
                 )
 public abstract class CeilFunction extends ScalarFunction {
@@ -59,20 +59,6 @@ public abstract class CeilFunction extends ScalarFunction {
     
     public CeilFunction(List<Expression> children) {
         super(children);
-    }
-
-    public static Expression create(List<Expression> children) throws SQLException {
-        final Expression firstChild = children.get(0);
-        final PDataType firstChildDataType = firstChild.getDataType();
-        if(firstChildDataType.isCoercibleTo(PDate.INSTANCE)) {
-            return CeilDateExpression.create(children);
-        } else if (firstChildDataType == PTimestamp.INSTANCE || firstChildDataType == PUnsignedTimestamp.INSTANCE) {
-            return CeilTimestampExpression.create(children);
-        } else if(firstChildDataType.isCoercibleTo(PDecimal.INSTANCE)) {
-            return CeilDecimalExpression.create(children);
-        } else {
-            throw TypeMismatchException.newException(firstChildDataType, "1");
-        }
     }
     
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilTimestampExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilTimestampExpression.java
@@ -33,6 +33,11 @@ import org.apache.phoenix.schema.types.PDate;
 import org.apache.phoenix.schema.types.PTimestamp;
 import org.apache.phoenix.schema.types.PUnsignedDate;
 import org.apache.phoenix.schema.types.PUnsignedTimestamp;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.schema.types.PInteger;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
 import com.google.common.collect.Lists;
 
@@ -45,6 +50,14 @@ import com.google.common.collect.Lists;
  * 
  * @since 3.0.0
  */
+@BuiltInFunction(name = CeilFunction.NAME,
+        args = {
+                @Argument(allowedTypes={PTimestamp.class}),
+                @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
+                @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
+        },
+        classType = FunctionClassType.DERIVED
+)
 public class CeilTimestampExpression extends CeilDateExpression {
     
     public CeilTimestampExpression() {}

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CurrentDateFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CurrentDateFunction.java
@@ -19,12 +19,17 @@ package org.apache.phoenix.expression.function;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.CurrentDateTimeFunction;
+import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.parse.CurrentDateParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.schema.types.PDate;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.schema.tuple.Tuple;
+
+import java.sql.SQLException;
+import java.util.List;
 
 
 /**
@@ -44,6 +49,10 @@ public class CurrentDateFunction extends CurrentDateTimeFunction {
     
     public CurrentDateFunction() {
         this(System.currentTimeMillis());
+    }
+
+    public CurrentDateFunction(List<Expression> children, StatementContext context) throws SQLException {
+        this(context.getCurrentTime());
     }
 
     public CurrentDateFunction(long timeStamp) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CurrentTimeFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CurrentTimeFunction.java
@@ -19,12 +19,17 @@ package org.apache.phoenix.expression.function;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.CurrentDateTimeFunction;
+import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.parse.CurrentTimeParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.schema.types.PTime;
 import org.apache.phoenix.schema.tuple.Tuple;
+
+import java.sql.SQLException;
+import java.util.List;
 
 
 /**
@@ -44,6 +49,10 @@ public class CurrentTimeFunction extends CurrentDateTimeFunction {
     
     public CurrentTimeFunction() {
         this(System.currentTimeMillis());
+    }
+
+    public CurrentTimeFunction(List<Expression> children, StatementContext context) throws SQLException {
+        this(context.getCurrentTime());
     }
 
     public CurrentTimeFunction(long timeStamp) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FirstValueFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FirstValueFunction.java
@@ -44,6 +44,10 @@ public class FirstValueFunction extends FirstLastValueBaseFunction {
     public FirstValueFunction() {
     }
 
+    public FirstValueFunction(List<Expression> childExpressions) {
+        this(childExpressions, null);
+    }
+
     public FirstValueFunction(List<Expression> childExpressions, CountAggregateFunction delegate) {
         super(childExpressions, delegate);
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorDateExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorDateExpression.java
@@ -31,6 +31,11 @@ import org.apache.phoenix.schema.types.PDate;
 import org.apache.phoenix.schema.types.PTimestamp;
 import org.apache.phoenix.schema.types.PUnsignedDate;
 import org.apache.phoenix.schema.types.PUnsignedTimestamp;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.schema.types.PInteger;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
 import com.google.common.collect.Lists;
 
@@ -42,6 +47,14 @@ import com.google.common.collect.Lists;
  * 
  * @since 3.0.0
  */
+@BuiltInFunction(name = FloorFunction.NAME,
+         args = {
+                 @Argument(allowedTypes={PTimestamp.class}),
+                 @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
+                 @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
+         },
+         classType = FunctionClassType.DERIVED
+        )
 public class FloorDateExpression extends RoundDateExpression {
     
     public FloorDateExpression() {}

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorDecimalExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorDecimalExpression.java
@@ -29,6 +29,11 @@ import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.schema.types.PDecimal;
 import org.apache.phoenix.schema.types.PInteger;
 import org.apache.phoenix.schema.types.PLong;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.schema.types.PDecimal;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
 import com.google.common.collect.Lists;
 
@@ -40,6 +45,14 @@ import com.google.common.collect.Lists;
  *
  * @since 3.0.0
  */
+@BuiltInFunction(name = FloorFunction.NAME,
+        args = {
+                @Argument(allowedTypes={PDecimal.class}),
+                @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
+                @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
+        },
+        classType = FunctionClassType.DERIVED
+)
 public class FloorDecimalExpression extends RoundDecimalExpression {
 
     public FloorDecimalExpression() {}

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorFunction.java
@@ -17,12 +17,16 @@
  */
 package org.apache.phoenix.expression.function;
 
+import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.parse.FloorParseNode;
+import org.apache.phoenix.parse.FunctionParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.schema.TypeMismatchException;
+import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.schema.types.PDecimal;
 import org.apache.phoenix.schema.types.PInteger;
 import org.apache.phoenix.schema.types.PTimestamp;
@@ -39,7 +43,9 @@ import org.apache.phoenix.schema.types.PVarchar;
                         @Argument(allowedTypes={PTimestamp.class, PDecimal.class}),
                         @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
                         @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
-                        } 
+                        },
+                 classType = FunctionParseNode.FunctionClassType.PARENT,
+                 derivedFunctions = {FloorDateExpression.class, FloorDecimalExpression.class}
                 )
 public abstract class FloorFunction extends ScalarFunction {
     
@@ -49,6 +55,21 @@ public abstract class FloorFunction extends ScalarFunction {
     
     public FloorFunction(List<Expression> children) {
         super(children);
+    }
+
+    public static Expression create(List<Expression> children) throws SQLException {
+        final Expression firstChild = children.get(0);
+        final PDataType firstChildDataType = firstChild.getDataType();
+
+        //FLOOR on timestamp doesn't really care about the nanos part i.e. it just sets it to zero.
+        //Which is exactly what FloorDateExpression does too.
+        if(firstChildDataType.isCoercibleTo(PTimestamp.INSTANCE)) {
+            return FloorDateExpression.create(children);
+        } else if(firstChildDataType.isCoercibleTo(PDecimal.INSTANCE)) {
+            return FloorDecimalExpression.create(children);
+        } else {
+            throw TypeMismatchException.newException(firstChildDataType, "1");
+        }
     }
     
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorFunction.java
@@ -44,7 +44,7 @@ import org.apache.phoenix.schema.types.PVarchar;
                         @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
                         @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
                         },
-                 classType = FunctionParseNode.FunctionClassType.PARENT,
+                 classType = FunctionParseNode.FunctionClassType.ABSTRACT,
                  derivedFunctions = {FloorDateExpression.class, FloorDecimalExpression.class}
                 )
 public abstract class FloorFunction extends ScalarFunction {
@@ -55,21 +55,6 @@ public abstract class FloorFunction extends ScalarFunction {
     
     public FloorFunction(List<Expression> children) {
         super(children);
-    }
-
-    public static Expression create(List<Expression> children) throws SQLException {
-        final Expression firstChild = children.get(0);
-        final PDataType firstChildDataType = firstChild.getDataType();
-
-        //FLOOR on timestamp doesn't really care about the nanos part i.e. it just sets it to zero.
-        //Which is exactly what FloorDateExpression does too.
-        if(firstChildDataType.isCoercibleTo(PTimestamp.INSTANCE)) {
-            return FloorDateExpression.create(children);
-        } else if(firstChildDataType.isCoercibleTo(PDecimal.INSTANCE)) {
-            return FloorDecimalExpression.create(children);
-        } else {
-            throw TypeMismatchException.newException(firstChildDataType, "1");
-        }
     }
     
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorFunction.java
@@ -17,7 +17,6 @@
  */
 package org.apache.phoenix.expression.function;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
@@ -25,8 +24,6 @@ import org.apache.phoenix.parse.FloorParseNode;
 import org.apache.phoenix.parse.FunctionParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
-import org.apache.phoenix.schema.TypeMismatchException;
-import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.schema.types.PDecimal;
 import org.apache.phoenix.schema.types.PInteger;
 import org.apache.phoenix.schema.types.PTimestamp;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/LastValueFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/LastValueFunction.java
@@ -44,6 +44,10 @@ public class LastValueFunction extends FirstLastValueBaseFunction {
     public LastValueFunction() {
     }
 
+    public LastValueFunction(List<Expression> childExpressions) {
+        this(childExpressions, null);
+    }
+
     public LastValueFunction(List<Expression> childExpressions, CountAggregateFunction delegate) {
         super(childExpressions, delegate);
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/MaxAggregateFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/MaxAggregateFunction.java
@@ -43,6 +43,10 @@ public class MaxAggregateFunction extends MinAggregateFunction {
 
     public MaxAggregateFunction() {
     }
+
+    public MaxAggregateFunction(List<Expression> childExpressions) {
+        this(childExpressions, null);
+    }
     
     public MaxAggregateFunction(List<Expression> childExpressions, CountAggregateFunction delegate) {
         super(childExpressions, delegate);

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/MinAggregateFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/MinAggregateFunction.java
@@ -45,6 +45,10 @@ public class MinAggregateFunction extends DelegateConstantToCountAggregateFuncti
 
     public MinAggregateFunction() {
     }
+
+    public MinAggregateFunction(List<Expression> childExpressions) {
+        super(childExpressions, null);
+    }
     
     public MinAggregateFunction(List<Expression> childExpressions, CountAggregateFunction delegate) {
         super(childExpressions, delegate);

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/NowFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/NowFunction.java
@@ -45,10 +45,6 @@ public abstract class NowFunction extends ScalarFunction {
         super(children);
     }
 
-    public static FunctionExpression create(List<Expression> children, StatementContext context) throws SQLException {
-        return new CurrentDateFunction(context.getCurrentTime());
-    }
-
     @Override
     public String getName() {
         return NAME;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/NowFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/NowFunction.java
@@ -20,9 +20,12 @@ package org.apache.phoenix.expression.function;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.parse.CurrentDateParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
+
 
 /**
  * 
@@ -31,7 +34,7 @@ import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
  *
  */
 @BuiltInFunction(name = NowFunction.NAME,
-nodeClass=CurrentDateParseNode.class, args= {})
+        nodeClass=CurrentDateParseNode.class, args= {}, classType = FunctionClassType.ALIAS, derivedFunctions = {CurrentDateFunction.class})
 public abstract class NowFunction extends ScalarFunction {
     
     public static final String NAME = "NOW";
@@ -40,6 +43,10 @@ public abstract class NowFunction extends ScalarFunction {
     
     public NowFunction(List<Expression> children) throws SQLException {
         super(children);
+    }
+
+    public static FunctionExpression create(List<Expression> children, StatementContext context) throws SQLException {
+        return new CurrentDateFunction(context.getCurrentTime());
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/NthValueFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/NthValueFunction.java
@@ -47,6 +47,10 @@ public class NthValueFunction extends FirstLastValueBaseFunction {
     public NthValueFunction() {
     }
 
+    public NthValueFunction(List<Expression> childExpressions) {
+        this(childExpressions, null);
+    }
+
     public NthValueFunction(List<Expression> childExpressions, CountAggregateFunction delegate) {
         super(childExpressions, delegate);
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpReplaceFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpReplaceFunction.java
@@ -59,7 +59,7 @@ import org.apache.phoenix.schema.types.PVarchar;
     @Argument(allowedTypes={PVarchar.class}),
     @Argument(allowedTypes={PVarchar.class}),
     @Argument(allowedTypes={PVarchar.class},defaultValue="null")},
-    classType = FunctionParseNode.FunctionClassType.ALIAS,
+    classType = FunctionParseNode.FunctionClassType.ABSTRACT,
     derivedFunctions = {ByteBasedRegexpReplaceFunction.class, StringBasedRegexpReplaceFunction.class})
 public abstract class RegexpReplaceFunction extends ScalarFunction {
     public static final String NAME = "REGEXP_REPLACE";
@@ -75,19 +75,6 @@ public abstract class RegexpReplaceFunction extends ScalarFunction {
     public RegexpReplaceFunction(List<Expression> children) {
         super(children);
         init();
-    }
-
-    public static Expression create(List<Expression> children, StatementContext context)
-            throws SQLException {
-        QueryServices services = context.getConnection().getQueryServices();
-        boolean useByteBasedRegex =
-                services.getProps().getBoolean(QueryServices.USE_BYTE_BASED_REGEX_ATTRIB,
-                        QueryServicesOptions.DEFAULT_USE_BYTE_BASED_REGEX);
-        if (useByteBasedRegex) {
-            return new ByteBasedRegexpReplaceFunction(children);
-        } else {
-            return new StringBasedRegexpReplaceFunction(children);
-        }
     }
 
     protected abstract AbstractBasePattern compilePatternSpec(String value);

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpReplaceFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpReplaceFunction.java
@@ -19,15 +19,20 @@ package org.apache.phoenix.expression.function;
 
 import java.io.DataInput;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Determinism;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
+import org.apache.phoenix.parse.FunctionParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.parse.RegexpReplaceParseNode;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.SortOrder;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PDataType;
@@ -53,7 +58,9 @@ import org.apache.phoenix.schema.types.PVarchar;
     nodeClass = RegexpReplaceParseNode.class, args= {
     @Argument(allowedTypes={PVarchar.class}),
     @Argument(allowedTypes={PVarchar.class}),
-    @Argument(allowedTypes={PVarchar.class},defaultValue="null")} )
+    @Argument(allowedTypes={PVarchar.class},defaultValue="null")},
+    classType = FunctionParseNode.FunctionClassType.ALIAS,
+    derivedFunctions = {ByteBasedRegexpReplaceFunction.class, StringBasedRegexpReplaceFunction.class})
 public abstract class RegexpReplaceFunction extends ScalarFunction {
     public static final String NAME = "REGEXP_REPLACE";
 
@@ -68,6 +75,19 @@ public abstract class RegexpReplaceFunction extends ScalarFunction {
     public RegexpReplaceFunction(List<Expression> children) {
         super(children);
         init();
+    }
+
+    public static Expression create(List<Expression> children, StatementContext context)
+            throws SQLException {
+        QueryServices services = context.getConnection().getQueryServices();
+        boolean useByteBasedRegex =
+                services.getProps().getBoolean(QueryServices.USE_BYTE_BASED_REGEX_ATTRIB,
+                        QueryServicesOptions.DEFAULT_USE_BYTE_BASED_REGEX);
+        if (useByteBasedRegex) {
+            return new ByteBasedRegexpReplaceFunction(children);
+        } else {
+            return new StringBasedRegexpReplaceFunction(children);
+        }
     }
 
     protected abstract AbstractBasePattern compilePatternSpec(String value);

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpReplaceFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpReplaceFunction.java
@@ -19,11 +19,9 @@ package org.apache.phoenix.expression.function;
 
 import java.io.DataInput;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Determinism;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
@@ -31,8 +29,6 @@ import org.apache.phoenix.parse.FunctionParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.parse.RegexpReplaceParseNode;
-import org.apache.phoenix.query.QueryServices;
-import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.SortOrder;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PDataType;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSplitFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSplitFunction.java
@@ -53,7 +53,7 @@ import org.apache.phoenix.util.ByteUtil;
         nodeClass = RegexpSplitParseNode.class, args= {
         @FunctionParseNode.Argument(allowedTypes={PVarchar.class}),
         @FunctionParseNode.Argument(allowedTypes={PVarchar.class})},
-        classType = FunctionParseNode.FunctionClassType.ALIAS,
+        classType = FunctionParseNode.FunctionClassType.ABSTRACT,
         derivedFunctions = {ByteBasedRegexpSplitFunction.class, StringBasedRegexpSplitFunction.class})
 public abstract class RegexpSplitFunction extends ScalarFunction {
 
@@ -68,19 +68,6 @@ public abstract class RegexpSplitFunction extends ScalarFunction {
     public RegexpSplitFunction(List<Expression> children) {
         super(children);
         init();
-    }
-
-    public static Expression create(List<Expression> children, StatementContext context)
-            throws SQLException {
-        QueryServices services = context.getConnection().getQueryServices();
-        boolean useByteBasedRegex =
-                services.getProps().getBoolean(QueryServices.USE_BYTE_BASED_REGEX_ATTRIB,
-                        QueryServicesOptions.DEFAULT_USE_BYTE_BASED_REGEX);
-        if (useByteBasedRegex) {
-            return new ByteBasedRegexpSplitFunction(children);
-        } else {
-            return new StringBasedRegexpSplitFunction(children);
-        }
     }
 
     private void init() {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSplitFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSplitFunction.java
@@ -70,7 +70,7 @@ public abstract class RegexpSplitFunction extends ScalarFunction {
         init();
     }
 
-    public Expression create(List<Expression> children, StatementContext context)
+    public static Expression create(List<Expression> children, StatementContext context)
             throws SQLException {
         QueryServices services = context.getConnection().getQueryServices();
         boolean useByteBasedRegex =

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSplitFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSplitFunction.java
@@ -19,18 +19,14 @@ package org.apache.phoenix.expression.function;
 
 import java.io.DataInput;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Determinism;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBaseSplitter;
 import org.apache.phoenix.parse.FunctionParseNode;
 import org.apache.phoenix.parse.RegexpSplitParseNode;
-import org.apache.phoenix.query.QueryServices;
-import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.SortOrder;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PDataType;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSubstrFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSubstrFunction.java
@@ -58,7 +58,7 @@ import org.apache.phoenix.schema.types.PVarchar;
     @Argument(allowedTypes={PVarchar.class}),
     @Argument(allowedTypes={PVarchar.class}),
     @Argument(allowedTypes={PLong.class}, defaultValue="1")},
-    classType = FunctionParseNode.FunctionClassType.ALIAS,
+    classType = FunctionParseNode.FunctionClassType.ABSTRACT,
     derivedFunctions = {ByteBasedRegexpSubstrFunction.class, StringBasedRegexpSubstrFunction.class})
 public abstract class RegexpSubstrFunction extends PrefixFunction {
     public static final String NAME = "REGEXP_SUBSTR";
@@ -74,19 +74,6 @@ public abstract class RegexpSubstrFunction extends PrefixFunction {
     public RegexpSubstrFunction(List<Expression> children) {
         super(children);
         init();
-    }
-
-    public static Expression create(List<Expression> children, StatementContext context)
-            throws SQLException {
-        QueryServices services = context.getConnection().getQueryServices();
-        boolean useByteBasedRegex =
-                services.getProps().getBoolean(QueryServices.USE_BYTE_BASED_REGEX_ATTRIB,
-                        QueryServicesOptions.DEFAULT_USE_BYTE_BASED_REGEX);
-        if (useByteBasedRegex) {
-            return new ByteBasedRegexpSubstrFunction(children);
-        } else {
-            return new StringBasedRegexpSubstrFunction(children);
-        }
     }
 
     protected abstract AbstractBasePattern compilePatternSpec(String value);

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSubstrFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RegexpSubstrFunction.java
@@ -19,11 +19,9 @@ package org.apache.phoenix.expression.function;
 
 import java.io.DataInput;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Determinism;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
@@ -31,8 +29,6 @@ import org.apache.phoenix.parse.FunctionParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.parse.RegexpSubstrParseNode;
-import org.apache.phoenix.query.QueryServices;
-import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.SortOrder;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PDataType;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundDateExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundDateExpression.java
@@ -42,6 +42,10 @@ import org.apache.phoenix.schema.types.PDataType.PDataCodec;
 import org.apache.phoenix.schema.types.PInteger;
 import org.apache.phoenix.schema.types.PVarchar;
 import org.apache.phoenix.util.ByteUtil;
+import org.apache.phoenix.schema.types.PDate;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
 import com.google.common.collect.Lists;
 
@@ -55,6 +59,14 @@ import com.google.common.collect.Lists;
  * 
  * @since 0.1
  */
+@BuiltInFunction(name = RoundFunction.NAME,
+        args = {
+                @Argument(allowedTypes={PDate.class}),
+                @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
+                @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
+        },
+        classType = FunctionClassType.DERIVED
+)
 public class RoundDateExpression extends ScalarFunction {
     
     long divBy;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundDecimalExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundDecimalExpression.java
@@ -42,6 +42,10 @@ import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.schema.types.PDecimal;
 import org.apache.phoenix.schema.types.PInteger;
 import org.apache.phoenix.schema.types.PLong;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
 import com.google.common.collect.Lists;
 
@@ -53,6 +57,14 @@ import com.google.common.collect.Lists;
  *
  * @since 3.0.0
  */
+@BuiltInFunction(name = RoundFunction.NAME,
+        args = {
+                @Argument(allowedTypes={PDecimal.class}),
+                @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
+                @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
+        },
+        classType = FunctionClassType.DERIVED
+)
 public class RoundDecimalExpression extends ScalarFunction {
 
     private int scale;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundFunction.java
@@ -44,7 +44,7 @@ import org.apache.phoenix.schema.types.PVarchar;
                         @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
                         @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
                         },
-                 classType = FunctionParseNode.FunctionClassType.PARENT,
+                 classType = FunctionParseNode.FunctionClassType.ABSTRACT,
                  derivedFunctions = {RoundDateExpression.class, RoundTimestampExpression.class, RoundDecimalExpression.class}
                 )
 public abstract class RoundFunction extends ScalarFunction {
@@ -55,21 +55,6 @@ public abstract class RoundFunction extends ScalarFunction {
     
     public RoundFunction(List<Expression> children) {
         super(children);
-    }
-
-    public static Expression create(List<Expression> children) throws SQLException {
-        final Expression firstChild = children.get(0);
-        final PDataType firstChildDataType = firstChild.getDataType();
-
-        if(firstChildDataType.isCoercibleTo(PDate.INSTANCE)) {
-            return RoundDateExpression.create(children);
-        } else if (firstChildDataType.isCoercibleTo(PTimestamp.INSTANCE)) {
-            return RoundTimestampExpression.create(children);
-        } else if(firstChildDataType.isCoercibleTo(PDecimal.INSTANCE)) {
-            return RoundDecimalExpression.create(children);
-        } else {
-            throw TypeMismatchException.newException(firstChildDataType, "1");
-        }
     }
     
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundFunction.java
@@ -17,7 +17,6 @@
  */
 package org.apache.phoenix.expression.function;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
@@ -25,9 +24,6 @@ import org.apache.phoenix.parse.FunctionParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.parse.RoundParseNode;
-import org.apache.phoenix.schema.TypeMismatchException;
-import org.apache.phoenix.schema.types.PDataType;
-import org.apache.phoenix.schema.types.PDate;
 import org.apache.phoenix.schema.types.PDecimal;
 import org.apache.phoenix.schema.types.PInteger;
 import org.apache.phoenix.schema.types.PTimestamp;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundTimestampExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundTimestampExpression.java
@@ -33,6 +33,11 @@ import org.apache.phoenix.schema.types.PDate;
 import org.apache.phoenix.schema.types.PTimestamp;
 import org.apache.phoenix.schema.types.PUnsignedDate;
 import org.apache.phoenix.schema.types.PUnsignedTimestamp;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.schema.types.PInteger;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
 import com.google.common.collect.Lists;
 
@@ -47,7 +52,14 @@ import com.google.common.collect.Lists;
  * 
  * @since 3.0.0
  */
-
+@BuiltInFunction(name = RoundFunction.NAME,
+        args = {
+                @Argument(allowedTypes={PTimestamp.class}),
+                @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
+                @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
+        },
+        classType = FunctionClassType.DERIVED
+)
 public class RoundTimestampExpression extends RoundDateExpression {
     
     private static final long HALF_OF_NANOS_IN_MILLI = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(1)/2;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/StringBasedRegexpReplaceFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/StringBasedRegexpReplaceFunction.java
@@ -24,6 +24,22 @@ import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
 import org.apache.phoenix.expression.util.regex.JavaPattern;
 
+import org.apache.phoenix.expression.Expression;
+import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
+import org.apache.phoenix.expression.util.regex.JONIPattern;
+import org.joni.Option;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
+
+@BuiltInFunction(name=RegexpReplaceFunction.NAME,
+        args= {
+                @Argument(allowedTypes={PVarchar.class}),
+                @Argument(allowedTypes={PVarchar.class}),
+                @Argument(allowedTypes={PVarchar.class},defaultValue="null")},
+        classType = FunctionClassType.DERIVED
+)
 public class StringBasedRegexpReplaceFunction extends RegexpReplaceFunction {
 
     public StringBasedRegexpReplaceFunction() {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/StringBasedRegexpReplaceFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/StringBasedRegexpReplaceFunction.java
@@ -24,10 +24,6 @@ import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
 import org.apache.phoenix.expression.util.regex.JavaPattern;
 
-import org.apache.phoenix.expression.Expression;
-import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
-import org.apache.phoenix.expression.util.regex.JONIPattern;
-import org.joni.Option;
 import org.apache.phoenix.schema.types.PVarchar;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/StringBasedRegexpSplitFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/StringBasedRegexpSplitFunction.java
@@ -22,7 +22,17 @@ import java.util.List;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBaseSplitter;
 import org.apache.phoenix.expression.util.regex.GuavaSplitter;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
+@BuiltInFunction(name=RegexpSplitFunction.NAME,
+        args= {
+                @Argument(allowedTypes={PVarchar.class}),
+                @Argument(allowedTypes={PVarchar.class})},
+        classType = FunctionClassType.DERIVED
+)
 public class StringBasedRegexpSplitFunction extends RegexpSplitFunction {
     public StringBasedRegexpSplitFunction() {
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/StringBasedRegexpSubstrFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/StringBasedRegexpSubstrFunction.java
@@ -23,7 +23,19 @@ import java.util.regex.Pattern;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.util.regex.AbstractBasePattern;
 import org.apache.phoenix.expression.util.regex.JavaPattern;
+import org.apache.phoenix.schema.types.PLong;
+import org.apache.phoenix.schema.types.PVarchar;
+import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import org.apache.phoenix.parse.FunctionParseNode.Argument;
+import org.apache.phoenix.parse.FunctionParseNode.FunctionClassType;
 
+@BuiltInFunction(name=RegexpSubstrFunction.NAME,
+        args= {
+                @Argument(allowedTypes={PVarchar.class}),
+                @Argument(allowedTypes={PVarchar.class}),
+                @Argument(allowedTypes={PLong.class}, defaultValue="1")},
+        classType = FunctionClassType.DERIVED
+)
 public class StringBasedRegexpSubstrFunction extends RegexpSubstrFunction {
     public StringBasedRegexpSubstrFunction() {
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToCharFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToCharFunction.java
@@ -26,7 +26,9 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.io.WritableUtils;
 
 import com.google.common.base.Preconditions;
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Expression;
+import org.apache.phoenix.expression.LiteralExpression;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.parse.*;
@@ -55,6 +57,38 @@ public class ToCharFunction extends ScalarFunction {
     private FunctionArgumentType type;
     
     public ToCharFunction() {
+    }
+
+    public ToCharFunction(List<Expression> children, StatementContext context) throws SQLException {
+        super(children.subList(0, 1));
+        PDataType dataType = children.get(0).getDataType();
+        String formatString = (String)((LiteralExpression)children.get(1)).getValue(); // either date or number format string
+        Format formatter;
+        FunctionArgumentType type;
+        if (dataType.isCoercibleTo(PTimestamp.INSTANCE)) {
+            if (formatString == null) {
+                formatString = context.getDateFormat();
+                formatter = context.getDateFormatter();
+            } else {
+                formatter = FunctionArgumentType.TEMPORAL.getFormatter(formatString);
+            }
+            type = FunctionArgumentType.TEMPORAL;
+        }
+        else if (dataType.isCoercibleTo(PDecimal.INSTANCE)) {
+            if (formatString == null)
+                formatString = context.getNumberFormat();
+            formatter = FunctionArgumentType.NUMERIC.getFormatter(formatString);
+            type = FunctionArgumentType.NUMERIC;
+        }
+        else {
+            throw new SQLException(dataType + " type is unsupported for TO_CHAR().  Numeric and temporal types are supported.");
+        }
+        Preconditions.checkNotNull(formatString);
+        Preconditions.checkNotNull(formatter);
+        Preconditions.checkNotNull(type);
+        this.type = type;
+        this.formatString = formatString;
+        this.formatter = formatter;
     }
 
     public ToCharFunction(List<Expression> children, FunctionArgumentType type, String formatString, Format formatter) throws SQLException {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToDateFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToDateFunction.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.io.WritableUtils;
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.LiteralExpression;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
@@ -59,6 +60,19 @@ public class ToDateFunction extends ScalarFunction {
     protected String timeZoneId;
 
     public ToDateFunction() {
+    }
+
+    public ToDateFunction(List<Expression> children, StatementContext context) throws SQLException {
+        super(children);
+        String dateFormat = (String) ((LiteralExpression) children.get(1)).getValue();
+        String timeZoneId = (String) ((LiteralExpression) children.get(2)).getValue();
+        if (dateFormat == null) {
+            dateFormat = context.getDateFormat();
+        }
+        if (timeZoneId == null) {
+            timeZoneId = context.getDateFormatTimeZone().getID();
+        }
+        init(dateFormat, timeZoneId);
     }
 
     public ToDateFunction(List<Expression> children, String dateFormat, String timeZoneId) throws SQLException {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToTimeFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToTimeFunction.java
@@ -20,7 +20,9 @@ package org.apache.phoenix.expression.function;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Expression;
+import org.apache.phoenix.expression.LiteralExpression;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.parse.ToTimeParseNode;
@@ -45,6 +47,10 @@ public class ToTimeFunction extends ToDateFunction {
     public static final String NAME = "TO_TIME";
 
     public ToTimeFunction() {
+    }
+
+    public ToTimeFunction(List<Expression> children, StatementContext context) throws SQLException {
+        super(children, context);
     }
 
     public ToTimeFunction(List<Expression> children, String dateFormat, String timeZoneId) throws SQLException {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToTimestampFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToTimestampFunction.java
@@ -20,6 +20,7 @@ package org.apache.phoenix.expression.function;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
@@ -45,6 +46,10 @@ public class ToTimestampFunction extends ToDateFunction {
     public static final String NAME = "TO_TIMESTAMP";
 
     public ToTimestampFunction() {
+    }
+
+    public ToTimestampFunction(List<Expression> children, StatementContext context) throws SQLException {
+        super(children, context);
     }
 
     public ToTimestampFunction(List<Expression> children, String dateFormat, String timeZoneId) throws SQLException {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/TruncFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/TruncFunction.java
@@ -61,10 +61,6 @@ public abstract class TruncFunction extends ScalarFunction {
         super(children);
     }
 
-    public static Expression TruncFunction(List<Expression> children) throws SQLException{
-        return FloorFunction.create(children);
-    }
-
     @Override
     public String getName() {
         return NAME;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/TruncFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/TruncFunction.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.parse.FloorParseNode;
+import org.apache.phoenix.parse.FunctionParseNode;
 import org.apache.phoenix.parse.FunctionParseNode.Argument;
 import org.apache.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import org.apache.phoenix.schema.types.PDecimal;
@@ -46,7 +47,9 @@ args = {
        @Argument(allowedTypes={PTimestamp.class, PDecimal.class}),
        @Argument(allowedTypes={PVarchar.class, PInteger.class}, defaultValue = "null", isConstant=true),
        @Argument(allowedTypes={PInteger.class}, defaultValue="1", isConstant=true)
-       } 
+       },
+classType = FunctionParseNode.FunctionClassType.ALIAS,
+derivedFunctions = {FloorFunction.class}
 )
 public abstract class TruncFunction extends ScalarFunction {
     
@@ -56,6 +59,10 @@ public abstract class TruncFunction extends ScalarFunction {
     
     public TruncFunction(List<Expression> children) throws SQLException {
         super(children);
+    }
+
+    public static Expression TruncFunction(List<Expression> children) throws SQLException{
+        return FloorFunction.create(children);
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
@@ -303,7 +303,8 @@ public class FunctionParseNode extends CompoundParseNode {
     public enum FunctionClassType {
         NONE,
         PARENT,
-        ALIAS
+        ALIAS,
+        UDF
     }
 
     /**
@@ -353,7 +354,7 @@ public class FunctionParseNode extends CompoundParseNode {
             }
             this.requiredArgCount = requiredArgCount;
             this.isAggregate = AggregateFunction.class.isAssignableFrom(UDFExpression.class);
-            this.classType = FunctionClassType.NONE;
+            this.classType = FunctionClassType.UDF;
         }
 
         public int getRequiredArgCount() {

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
@@ -394,6 +394,7 @@ public class FunctionParseNode extends CompoundParseNode {
             for(int i = 0; i < args.length; solutions *= args[i].getAllowedTypes().length, i++);
             for(int i = 0; i < solutions; i++) {
                 int j = 1;
+                short k = 0;
                 overloadedArgs.add(new ArrayList<FunctionArgument>());
                 for(BuiltInFunctionArgInfo arg : args) {
                     Class<? extends PDataType>[] temp = arg.getAllowedTypes();
@@ -405,8 +406,8 @@ public class FunctionParseNode extends CompoundParseNode {
                             arg.getDefaultValue(),
                             arg.getMinValue(),
                             arg.getMaxValue(),
-                            (short)i));
-
+                            k));
+                    k++;
                     j *= temp.length;
                 }
             }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
@@ -284,6 +284,8 @@ public class FunctionParseNode extends CompoundParseNode {
         String name();
         Argument[] args() default {};
         Class<? extends FunctionParseNode> nodeClass() default FunctionParseNode.class;
+        Class<? extends FunctionExpression>[] derivedFunctions() default {};
+        FunctionClassType classType() default FunctionClassType.NONE;
     }
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -298,6 +300,12 @@ public class FunctionParseNode extends CompoundParseNode {
         String maxValue() default "";
     }
 
+    public enum FunctionClassType {
+        NONE,
+        PARENT,
+        ALIAS
+    }
+
     /**
      * Structure used to hold parse-time information about Function implementation classes
      */
@@ -310,6 +318,7 @@ public class FunctionParseNode extends CompoundParseNode {
         private final BuiltInFunctionArgInfo[] args;
         private final boolean isAggregate;
         private final int requiredArgCount;
+        private final FunctionClassType classType;
 
         public BuiltInFunctionInfo(Class<? extends FunctionExpression> f, BuiltInFunction d) {
             this.name = SchemaUtil.normalizeIdentifier(d.name());
@@ -326,6 +335,7 @@ public class FunctionParseNode extends CompoundParseNode {
             }
             this.requiredArgCount = requiredArgCount;
             this.isAggregate = AggregateFunction.class.isAssignableFrom(f);
+            this.classType = d.classType();
         }
 
         public BuiltInFunctionInfo(PFunction function) {
@@ -343,6 +353,7 @@ public class FunctionParseNode extends CompoundParseNode {
             }
             this.requiredArgCount = requiredArgCount;
             this.isAggregate = AggregateFunction.class.isAssignableFrom(UDFExpression.class);
+            this.classType = FunctionClassType.NONE;
         }
 
         public int getRequiredArgCount() {
@@ -371,6 +382,10 @@ public class FunctionParseNode extends CompoundParseNode {
 
         public BuiltInFunctionArgInfo[] getArgs() {
             return args;
+        }
+
+        public FunctionClassType getClassType() {
+            return classType;
         }
 
         public List<List<FunctionArgument>> overloadArguments(){

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
@@ -303,6 +303,7 @@ public class FunctionParseNode extends CompoundParseNode {
     @Immutable
     public static final class BuiltInFunctionInfo {
         private final String name;
+        private final Class<? extends FunctionExpression> func;
         private final Constructor<? extends FunctionExpression> funcCtor;
         private final Constructor<? extends FunctionParseNode> nodeCtor;
         private final BuiltInFunctionArgInfo[] args;
@@ -311,6 +312,7 @@ public class FunctionParseNode extends CompoundParseNode {
 
         public BuiltInFunctionInfo(Class<? extends FunctionExpression> f, BuiltInFunction d) {
             this.name = SchemaUtil.normalizeIdentifier(d.name());
+            this.func = f;
             this.funcCtor = d.nodeClass() == FunctionParseNode.class ? getExpressionCtor(f, null) : null;
             this.nodeCtor = d.nodeClass() == FunctionParseNode.class ? null : getParseNodeCtor(d.nodeClass());
             this.args = new BuiltInFunctionArgInfo[d.args().length];
@@ -327,6 +329,7 @@ public class FunctionParseNode extends CompoundParseNode {
 
         public BuiltInFunctionInfo(PFunction function) {
             this.name = SchemaUtil.normalizeIdentifier(function.getFunctionName());
+            this.func = null;
             this.funcCtor = getExpressionCtor(UDFExpression.class, function);
             this.nodeCtor = getParseNodeCtor(UDFParseNode.class);
             this.args = new BuiltInFunctionArgInfo[function.getFunctionArguments().size()];
@@ -347,6 +350,10 @@ public class FunctionParseNode extends CompoundParseNode {
 
         public String getName() {
             return name;
+        }
+
+        public Class<? extends FunctionExpression> getFunc() {
+            return func;
         }
 
         public Constructor<? extends FunctionExpression> getFuncCtor() {

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
@@ -302,7 +302,8 @@ public class FunctionParseNode extends CompoundParseNode {
 
     public enum FunctionClassType {
         NONE,
-        PARENT,
+        ABSTRACT,
+        DERIVED,
         ALIAS,
         UDF
     }
@@ -320,6 +321,7 @@ public class FunctionParseNode extends CompoundParseNode {
         private final boolean isAggregate;
         private final int requiredArgCount;
         private final FunctionClassType classType;
+        private final Class<? extends FunctionExpression>[] derivedFunctions;
 
         public BuiltInFunctionInfo(Class<? extends FunctionExpression> f, BuiltInFunction d) {
             this.name = SchemaUtil.normalizeIdentifier(d.name());
@@ -337,6 +339,7 @@ public class FunctionParseNode extends CompoundParseNode {
             this.requiredArgCount = requiredArgCount;
             this.isAggregate = AggregateFunction.class.isAssignableFrom(f);
             this.classType = d.classType();
+            this.derivedFunctions = d.derivedFunctions();
         }
 
         public BuiltInFunctionInfo(PFunction function) {
@@ -355,6 +358,7 @@ public class FunctionParseNode extends CompoundParseNode {
             this.requiredArgCount = requiredArgCount;
             this.isAggregate = AggregateFunction.class.isAssignableFrom(UDFExpression.class);
             this.classType = FunctionClassType.UDF;
+            this.derivedFunctions = null;
         }
 
         public int getRequiredArgCount() {
@@ -387,6 +391,10 @@ public class FunctionParseNode extends CompoundParseNode {
 
         public FunctionClassType getClassType() {
             return classType;
+        }
+
+        public Class<? extends FunctionExpression>[] getDerivedFunctions() {
+            return derivedFunctions;
         }
 
         public List<List<FunctionArgument>> overloadArguments(){

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Lists;
 import org.apache.http.annotation.Immutable;
 import org.apache.phoenix.compile.ColumnResolver;
 import org.apache.phoenix.compile.StatementContext;
@@ -395,32 +394,6 @@ public class FunctionParseNode extends CompoundParseNode {
 
         public Class<? extends FunctionExpression>[] getDerivedFunctions() {
             return derivedFunctions;
-        }
-
-        public List<List<FunctionArgument>> overloadArguments(){
-            List<List<FunctionArgument>> overloadedArgs = Lists.newArrayList();
-            int solutions = 1;
-            for(int i = 0; i < args.length; solutions *= args[i].getAllowedTypes().length, i++);
-            for(int i = 0; i < solutions; i++) {
-                int j = 1;
-                short k = 0;
-                overloadedArgs.add(new ArrayList<FunctionArgument>());
-                for(BuiltInFunctionArgInfo arg : args) {
-                    Class<? extends PDataType>[] temp = arg.getAllowedTypes();
-                    String inputArg = PDataTypeFactory.getInstance().instanceFromClass(temp[(i/j)%temp.length]).toString();
-                    overloadedArgs.get(i).add( new FunctionArgument(
-                            inputArg,
-                            false,
-                            arg.isConstant(),
-                            arg.getDefaultValue(),
-                            arg.getMinValue(),
-                            arg.getMaxValue(),
-                            k));
-                    k++;
-                    j *= temp.length;
-                }
-            }
-            return overloadedArgs;
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/FunctionParseNode.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.collect.Lists;
 import org.apache.http.annotation.Immutable;
 import org.apache.phoenix.compile.ColumnResolver;
 import org.apache.phoenix.compile.StatementContext;
@@ -370,6 +371,31 @@ public class FunctionParseNode extends CompoundParseNode {
 
         public BuiltInFunctionArgInfo[] getArgs() {
             return args;
+        }
+
+        public List<List<FunctionArgument>> overloadArguments(){
+            List<List<FunctionArgument>> overloadedArgs = Lists.newArrayList();
+            int solutions = 1;
+            for(int i = 0; i < args.length; solutions *= args[i].getAllowedTypes().length, i++);
+            for(int i = 0; i < solutions; i++) {
+                int j = 1;
+                overloadedArgs.add(new ArrayList<FunctionArgument>());
+                for(BuiltInFunctionArgInfo arg : args) {
+                    Class<? extends PDataType>[] temp = arg.getAllowedTypes();
+                    String inputArg = PDataTypeFactory.getInstance().instanceFromClass(temp[(i/j)%temp.length]).toString();
+                    overloadedArgs.get(i).add( new FunctionArgument(
+                            inputArg,
+                            false,
+                            arg.isConstant(),
+                            arg.getDefaultValue(),
+                            arg.getMinValue(),
+                            arg.getMaxValue(),
+                            (short)i));
+
+                    j *= temp.length;
+                }
+            }
+            return overloadedArgs;
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/PFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/PFunction.java
@@ -18,7 +18,6 @@
 package org.apache.phoenix.parse;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -26,10 +25,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.util.ByteStringer;
 import org.apache.phoenix.coprocessor.generated.PFunctionProtos;
 import org.apache.phoenix.coprocessor.generated.PFunctionProtos.PFunctionArg;
-import org.apache.phoenix.expression.ExpressionType;
 import org.apache.phoenix.expression.LiteralExpression;
-import org.apache.phoenix.expression.function.ScalarFunction;
-import org.apache.phoenix.expression.function.ToDateFunction;
 import org.apache.phoenix.schema.PMetaDataEntity;
 import org.apache.phoenix.schema.PName;
 import org.apache.phoenix.schema.PNameFactory;

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/PFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/PFunction.java
@@ -18,6 +18,7 @@
 package org.apache.phoenix.parse;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,7 +26,10 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.util.ByteStringer;
 import org.apache.phoenix.coprocessor.generated.PFunctionProtos;
 import org.apache.phoenix.coprocessor.generated.PFunctionProtos.PFunctionArg;
+import org.apache.phoenix.expression.ExpressionType;
 import org.apache.phoenix.expression.LiteralExpression;
+import org.apache.phoenix.expression.function.ScalarFunction;
+import org.apache.phoenix.expression.function.ToDateFunction;
 import org.apache.phoenix.schema.PMetaDataEntity;
 import org.apache.phoenix.schema.PName;
 import org.apache.phoenix.schema.PNameFactory;

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
@@ -129,6 +129,7 @@ public class ParseNodeFactory {
         }
         int nArgs = d.args().length;
         BuiltInFunctionInfo value = new BuiltInFunctionInfo(f, d);
+
         SINGLE_SIGNATURE_BUILT_IN_FUNCTION_MAP.put(value.getName(), value);
         do {
             // Add function to function map, throwing if conflicts found

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
@@ -185,7 +185,7 @@ public class ParseNodeFactory {
         return info;
     }
 
-    public static Collection<BuiltInFunctionInfo> getAll(){
+    public static Collection<BuiltInFunctionInfo> getSingleEntryFunctionMap(){
         initBuiltInFunctionMap();
         return SINGLE_SIGNATURE_BUILT_IN_FUNCTION_MAP.values();
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
@@ -73,6 +74,7 @@ public class ParseNodeFactory {
         AvgAggregateFunction.class
         );
     private static final Map<BuiltInFunctionKey, BuiltInFunctionInfo> BUILT_IN_FUNCTION_MAP = Maps.newHashMap();
+    private static final Map<String, BuiltInFunctionInfo> SINGLE_SIGNATURE_BUILT_IN_FUNCTION_MAP = Maps.newHashMap();
     private static final BigDecimal MAX_LONG = BigDecimal.valueOf(Long.MAX_VALUE);
 
 
@@ -127,6 +129,7 @@ public class ParseNodeFactory {
         }
         int nArgs = d.args().length;
         BuiltInFunctionInfo value = new BuiltInFunctionInfo(f, d);
+        SINGLE_SIGNATURE_BUILT_IN_FUNCTION_MAP.put(value.getName(), value);
         do {
             // Add function to function map, throwing if conflicts found
             // Add entry for each possible version of function based on arguments that are not required to be present (i.e. arg with default value)
@@ -179,6 +182,11 @@ public class ParseNodeFactory {
         initBuiltInFunctionMap();
         BuiltInFunctionInfo info = BUILT_IN_FUNCTION_MAP.get(new BuiltInFunctionKey(normalizedName,children.size()));
         return info;
+    }
+
+    public static Collection<BuiltInFunctionInfo> getAll(){
+        initBuiltInFunctionMap();
+        return SINGLE_SIGNATURE_BUILT_IN_FUNCTION_MAP.values();
     }
 
     public ParseNodeFactory() {


### PR DESCRIPTION
This patch works for nearly all built in functions. Aggregate functions are not yet supported.

Ultimately we may want to rework:
- The use of parse nodes as a factory
- Generic return types to explicit return types

These issues are hand in hand as abstract built in functions (NowFunction, FloorFunction) are where the parse node factory & generic return types are necessary.

Potential resolution from my point of view is 2 parts
- Create a link somewhere between an abstract function and its concrete implementations (maybe require inheritance, create an annotation that links the abstract function to its implementations, or include the logic in the below mentioned factory)
- Create a new factory that replaces the use of parse nodes