### PR TITLE
PHOENIX-3477 Support sequence arithmetic in Calcite-Phoenix

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/calcite/CalciteIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/calcite/CalciteIT.java
@@ -1343,6 +1343,28 @@ public class CalciteIT extends BaseCalciteIT {
                         {7L, "0000000005", "T5", "0000000005", "S5"},
                         {8L, "0000000006", "T6", "0000000006", "S6"}})
                 .close();
+
+        start(false, 1000f).sql("select NEXT VALUE FOR my.seq1 + 1, entity_id from aTable where a_string = 'a'")
+                .explainIs("PhoenixToEnumerableConverter\n" +
+                        "  PhoenixClientProject(EXPR$0=[+(NEXT_VALUE('\"MY\".\"SEQ1\"'), 1)], ENTITY_ID=[$1])\n" +
+                        "    PhoenixTableScan(table=[[phoenix, ATABLE]], filter=[=($2, 'a')])\n")
+                .resultIs(1, new Object[][]{
+                        {11L, "00A123122312312"},
+                        {13L, "00A223122312312"},
+                        {15L, "00A323122312312"},
+                        {17L, "00A423122312312"}})
+                .close();
+
+        start(false, 1000f).sql("select (NEXT VALUE FOR my.seq1 * 2) + 1, entity_id from aTable where a_string = 'a'")
+                .explainIs("PhoenixToEnumerableConverter\n" +
+                        "  PhoenixClientProject(EXPR$0=[+(*(NEXT_VALUE('\"MY\".\"SEQ1\"'), 2), 1)], ENTITY_ID=[$1])\n" +
+                        "    PhoenixTableScan(table=[[phoenix, ATABLE]], filter=[=($2, 'a')])\n")
+                .resultIs(1, new Object[][]{
+                        {37L, "00A123122312312"},
+                        {41L, "00A223122312312"},
+                        {45L, "00A323122312312"},
+                        {49L, "00A423122312312"}})
+                .close();
     }
 
     @Ignore // CALCITE-1045

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/SequenceIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/SequenceIT.java
@@ -735,7 +735,7 @@ public class SequenceIT extends BaseClientManagedTimeIT {
         nextConnection();
         conn.createStatement().execute("CREATE SEQUENCE foo.bar START WITH 3 INCREMENT BY 2");
         nextConnection();
-        String query = "SELECT NEXT VALUE FOR foo.bar+1 FROM SYSTEM.\"SEQUENCE\"";
+        String query = "SELECT NEXT VALUE FOR foo.bar+1 FROM \"SYSTEM\".\"SEQUENCE\"";
         ResultSet rs = conn.prepareStatement(query).executeQuery();
         assertTrue(rs.next());
         assertEquals(4, rs.getInt(1));

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/CalciteUtils.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/CalciteUtils.java
@@ -1085,22 +1085,6 @@ public class CalciteUtils {
 		
 		return false;
 	}
-	
-	public static PhoenixSequence findSequence(Project project) {
-        SequenceValueFinder seqFinder = new SequenceValueFinder();
-        for (RexNode node : project.getProjects()) {
-            node.accept(seqFinder);
-            if (seqFinder.sequenceValueCall != null) {
-                RexLiteral operand =
-                		(RexLiteral) seqFinder.sequenceValueCall.getOperands().get(0);
-                List<String> name = Util.stringToList((String) operand.getValue2());
-                RelOptTable table = Prepare.CatalogReader.THREAD_LOCAL.get().getTable(name);
-                return table.unwrap(PhoenixSequence.class);
-            }
-        }
-        
-        return null;
-	}
     
     private static class SequenceValueFinder extends RexVisitorImpl<Void> {
         private RexCall sequenceValueCall;
@@ -1114,6 +1098,11 @@ public class CalciteUtils {
                     && (call.getKind() == SqlKind.CURRENT_VALUE
                         || call.getKind() == SqlKind.NEXT_VALUE)) {
                 sequenceValueCall = call;
+            }
+            if (sequenceValueCall == null){
+                for(RexNode node : call.getOperands()){
+                    if(node instanceof RexCall) visitCall((RexCall) node);
+                }
             }
             return null;
         }

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/rel/PhoenixRelImplementor.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/rel/PhoenixRelImplementor.java
@@ -6,7 +6,6 @@ import org.apache.calcite.util.ImmutableIntList;
 import org.apache.phoenix.calcite.PhoenixSequence;
 import org.apache.phoenix.calcite.TableMapping;
 import org.apache.phoenix.compile.QueryPlan;
-import org.apache.phoenix.compile.SequenceManager;
 import org.apache.phoenix.compile.SequenceValueExpression;
 import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.execute.RuntimeContext;
@@ -29,7 +28,6 @@ public interface PhoenixRelImplementor {
     RuntimeContext getRuntimeContext();
     void setTableMapping(TableMapping tableMapping);
     TableMapping getTableMapping();
-    void setSequenceManager(SequenceManager sequenceManager);
     void pushContext(ImplementorContext context);
     ImplementorContext popContext();
     ImplementorContext getCurrentContext();

--- a/phoenix-core/src/main/java/org/apache/phoenix/calcite/rel/PhoenixRelImplementorImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/calcite/rel/PhoenixRelImplementorImpl.java
@@ -8,7 +8,6 @@ import java.util.Stack;
 import org.apache.phoenix.calcite.PhoenixSequence;
 import org.apache.phoenix.calcite.TableMapping;
 import org.apache.phoenix.compile.QueryPlan;
-import org.apache.phoenix.compile.SequenceManager;
 import org.apache.phoenix.compile.SequenceValueExpression;
 import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.coprocessor.MetaDataProtocol;
@@ -35,7 +34,6 @@ public class PhoenixRelImplementorImpl implements PhoenixRelImplementor {
     private final StatementContext statementContext;
     private final RuntimeContext runtimeContext;
 	private Stack<ImplementorContext> contextStack;
-	private SequenceManager sequenceManager;
 	private TableMapping tableMapping;
 	
 	public PhoenixRelImplementorImpl(
@@ -73,7 +71,7 @@ public class PhoenixRelImplementorImpl implements PhoenixRelImplementor {
         PName tenantName = seq.pc.getTenantId();
         TableName tableName = TableName.create(seq.schemaName, seq.sequenceName);
         try {
-            return sequenceManager.newSequenceReference(tenantName, tableName, null, op);
+            return statementContext.getSequenceManager().newSequenceReference(tenantName, tableName, null, op);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -97,11 +95,6 @@ public class PhoenixRelImplementorImpl implements PhoenixRelImplementor {
     @Override
     public TableMapping getTableMapping() {
         return this.tableMapping;
-    }
-    
-    @Override
-    public void setSequenceManager(SequenceManager sequenceManager) {
-        this.sequenceManager = sequenceManager;
     }
 
     @Override


### PR DESCRIPTION
PhoenixConverterRules is meant to route any logical project with a sequence through PhoenixClientProject. Before, sequences were not properly being found. This patch simplifies the logic and adds that support.
-- Check for nested sequences
-- Use the Sequence Manager now available in StatementContext
-- Add relevant test cases to CalciteIT