### PR TITLE
Generate empty javadoc jar to comply with Maven Central

### DIFF
--- a/phoenix-spark/pom.xml
+++ b/phoenix-spark/pom.xml
@@ -549,6 +549,24 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>empty-javadoc-jar</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                    <configuration>
+                        <classifier>javadoc</classifier>
+                        <classesDirectory>${basedir}/javadoc</classesDirectory>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>	
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Im guessing I need to add same change to the following repositories 

4.10-HBase-1.1, 4.10-HBase-1.2, 4.x-HBase-0.98, 4.x-HBase-1.1, 4.x-HBase-1.2 ?