### PR TITLE
PHOENIX-3917 Change to calculate query projection size

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ProjectionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ProjectionCompiler.java
@@ -467,6 +467,15 @@ public class ProjectionCompiler {
             }
         }
 
+        boolean isProjectEmptyKeyValue = false;
+        if (isWildcard) {
+            projectAllColumnFamilies(table, scan);
+        } else {
+            isProjectEmptyKeyValue = where == null || LiteralExpression.isTrue(where) || where.requiresFinalEvaluation();
+            for (byte[] family : projectedFamilies) {
+                projectColumnFamily(table, scan, family);
+            }
+        }
         // TODO make estimatedByteSize more accurate by counting the joined columns.
         int estimatedKeySize = table.getRowKeySchema().getEstimatedValueLength();
         int estimatedByteSize = 0;
@@ -489,15 +498,8 @@ public class ProjectionCompiler {
                 //}
             }
         }
-        boolean isProjectEmptyKeyValue = false;
-        if (isWildcard) {
-            projectAllColumnFamilies(table, scan);
-        } else {
-            isProjectEmptyKeyValue = where == null || LiteralExpression.isTrue(where) || where.requiresFinalEvaluation();
-            for (byte[] family : projectedFamilies) {
-                projectColumnFamily(table, scan, family);
-            }
-        }
+        if (estimatedByteSize == 0)
+            estimatedByteSize = estimatedKeySize;
         return new RowProjector(projectedColumns, estimatedByteSize, isProjectEmptyKeyValue, resolver.hasUDFs(), isWildcard);
     }
 


### PR DESCRIPTION
Change to perform the size estimation of query row projector after all the conditions to add ``column families`` to the query ``scan`` object are done. 