### PR TITLE
PHOENIX-3921 Change the condition checking in ScanUtil#isReversed

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
@@ -606,7 +606,7 @@ public class ScanUtil {
     }
 
     public static boolean isReversed(Scan scan) {
-        return scan.getAttribute(BaseScannerRegionObserver.REVERSE_SCAN) != null;
+    	return Arrays.equals(scan.getAttribute(BaseScannerRegionObserver.REVERSE_SCAN),PDataType.TRUE_BYTES);
     }
     
     public static void setReversed(Scan scan) {


### PR DESCRIPTION
The current logic will return ``isReversed`` as ``true`` whether the ``BaseScannerRegionObserver.REVERSE_SCAN`` attribute is set to ``PDataType.TRUE_BYTES`` or ``PDataType.FALSE_BYTES``. The PR is to change it to return ``true`` only if  ``BaseScannerRegionObserver.REVERSE_SCAN`` attribute is set to ``PDataType.TRUE_BYTES``.