### PR TITLE
fixed setting of jetty resource base directory in phoenix-tracing-web…

### DIFF
--- a/phoenix-tracing-webapp/src/main/java/org/apache/phoenix/tracingwebapp/http/Main.java
+++ b/phoenix-tracing-webapp/src/main/java/org/apache/phoenix/tracingwebapp/http/Main.java
@@ -62,9 +62,11 @@ public final class Main extends Configured implements Tool {
         final String home = getConf().get(TRACE_SERVER_HTTP_JETTY_HOME_KEY,
                 DEFAULT_HTTP_HOME);
         //setting up the embedded server
-        ProtectionDomain domain = Main.class.getProtectionDomain();
-        URL location = domain.getCodeSource().getLocation();
-        String webappDirLocation = location.toString().split("target")[0] +"src/main/webapp";
+
+        String webappDirLocation = Main.class.getClassLoader().getResource("src/main/webapp").toExternalForm();
+//        ProtectionDomain domain = Main.class.getProtectionDomain();
+//        URL location = domain.getCodeSource().getLocation();
+//        String webappDirLocation = location.toString().split("target")[0] +"src/main/webapp";
         Server server = new Server(port);
         WebAppContext root = new WebAppContext();
 


### PR DESCRIPTION
fixed obtaining of resource base for embedded jetty in tracing web appp - original implementation of obtaining webapp root from ProtectionDomain is not reliable and doesn't work on some JVMs. New implementation gets the correct webapp location from class loader.