### PR TITLE
 `DEFAULT_TIME_ZONE_ID`  should take value from `TimeZone.getDefault().getID()` instead of constant `GMT`

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/util/DateUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/DateUtil.java
@@ -52,7 +52,7 @@ import com.sun.istack.NotNull;
 
 @SuppressWarnings({ "serial", "deprecation" })
 public class DateUtil {
-    public static final String DEFAULT_TIME_ZONE_ID = "GMT";
+    public static final String DEFAULT_TIME_ZONE_ID = TimeZone.getDefault().getID();
     public static final String LOCAL_TIME_ZONE_ID = "LOCAL";
     private static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone(DEFAULT_TIME_ZONE_ID);
     


### PR DESCRIPTION
 `DEFAULT_TIME_ZONE_ID`  should take value from `TimeZone.getDefault().getID()` instead of constant `GMT`, so that all `DATE`  and  `TIMESTAMP`  column values are formatted  using timezone configured in JVM.