### PR TITLE
PHOENIX-4322 DESC primary key column with variable length does not work in SkipScanFilter

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/SortOrderIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/SortOrderIT.java
@@ -167,6 +167,15 @@ public class SortOrderIT extends ParallelStatsDisabledIT {
         runQueryTest(ddl, upsert("oid", "code"), insertedRows, new Object[][]{{"o2", 2}}, new WhereCondition("oid", "IN", "('o2')"),
             table);
     }
+
+    @Test
+    public void inDescCompositePK3() throws Exception {
+        String table = generateUniqueName();
+        String ddl = "CREATE table " + table + " (oid INTEGER NOT NULL, code VARCHAR NOT NULL constraint pk primary key (oid DESC, code DESC))";
+        Object[][] insertedRows = new Object[][]{{1, "o1"}, {2, "o2"}, {3, "o3"}};
+        runQueryTest(ddl, upsert("oid", "code"), insertedRows, new Object[][]{{2, "o2"}, {1, "o1"}},
+            new WhereCondition("(oid, code)", "IN", "((1, 'o1'), (2, 'o2'))"), table);
+    }
     
     @Test
     public void likeDescCompositePK1() throws Exception {

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
@@ -431,8 +431,11 @@ public class ScanUtil {
             anyInclusiveUpperRangeKey |= !range.isSingleKey() && inclusiveUpper;
             // A null or empty byte array is always represented as a zero byte
             byte sepByte = SchemaUtil.getSeparatorByte(schema.rowKeyOrderOptimizable(), bytes.length == 0, field);
-            
-            if ( !isFixedWidth && ( sepByte == QueryConstants.DESC_SEPARATOR_BYTE 
+            // The result of an RVC evaluation can come with a trailing separator already, so we
+            // should avoid adding another one.
+            if ( !isFixedWidth
+                    && ( bytes.length == 0 || key[offset - 1] != sepByte )
+                    && ( sepByte == QueryConstants.DESC_SEPARATOR_BYTE
                                     || ( !exclusiveUpper 
                                          && (fieldIndex < schema.getMaxFields() || inclusiveUpper || exclusiveLower) ) ) ) {
                 key[offset++] = sepByte;

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
@@ -434,7 +434,7 @@ public class ScanUtil {
             // The result of an RVC evaluation can come with a trailing separator already, so we
             // should avoid adding another one.
             if ( !isFixedWidth
-                    && ( bytes.length == 0 || key[offset - 1] != sepByte )
+                    && ( bytes.length == 0 || slotSpan[i] == 0 || key[offset - 1] != sepByte )
                     && ( sepByte == QueryConstants.DESC_SEPARATOR_BYTE
                                     || ( !exclusiveUpper 
                                          && (fieldIndex < schema.getMaxFields() || inclusiveUpper || exclusiveLower) ) ) ) {


### PR DESCRIPTION
Changes:
Avoid adding an extra trailing separator to the key