### PR TITLE
PHOENIX-3547 Supporting more number of indices per table.

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/BaseViewIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/BaseViewIT.java
@@ -196,8 +196,8 @@ public abstract class BaseViewIT extends ParallelStatsEnabledIT {
                 queryPlan);
         } else {
             assertEquals(saltBuckets == null
-                    ? "CLIENT PARALLEL 1-WAY RANGE SCAN OVER " + viewIndexPhysicalName +" [" + Short.MIN_VALUE + ",51]"
-                            : "CLIENT PARALLEL " + saltBuckets + "-WAY RANGE SCAN OVER " + viewIndexPhysicalName + " [0," + Short.MIN_VALUE + ",51] - ["+(saltBuckets.intValue()-1)+"," + Short.MIN_VALUE + ",51]\nCLIENT MERGE SORT",
+                    ? "CLIENT PARALLEL 1-WAY RANGE SCAN OVER " + viewIndexPhysicalName +" [" + Long.MIN_VALUE + ",51]"
+                            : "CLIENT PARALLEL " + saltBuckets + "-WAY RANGE SCAN OVER " + viewIndexPhysicalName + " [0," + Long.MIN_VALUE + ",51] - ["+(saltBuckets.intValue()-1)+"," + Long.MIN_VALUE + ",51]\nCLIENT MERGE SORT",
                             queryPlan);
         }
 
@@ -237,9 +237,9 @@ public abstract class BaseViewIT extends ParallelStatsEnabledIT {
         } else {
             physicalTableName = viewIndexPhysicalName;
             assertEquals(saltBuckets == null
-                    ? "CLIENT PARALLEL 1-WAY RANGE SCAN OVER " + viewIndexPhysicalName +" [" + (Short.MIN_VALUE+1) + ",'foo']\n"
+                    ? "CLIENT PARALLEL 1-WAY RANGE SCAN OVER " + viewIndexPhysicalName +" [" + (Long.MIN_VALUE+1) + ",'foo']\n"
                             + "    SERVER FILTER BY FIRST KEY ONLY"
-                            : "CLIENT PARALLEL " + saltBuckets + "-WAY RANGE SCAN OVER " + viewIndexPhysicalName + " [0," + (Short.MIN_VALUE+1) + ",'foo'] - ["+(saltBuckets.intValue()-1)+"," + (Short.MIN_VALUE+1) + ",'foo']\n"
+                            : "CLIENT PARALLEL " + saltBuckets + "-WAY RANGE SCAN OVER " + viewIndexPhysicalName + " [0," + (Long.MIN_VALUE+1) + ",'foo'] - ["+(saltBuckets.intValue()-1)+"," + (Long.MIN_VALUE+1) + ",'foo']\n"
                                     + "    SERVER FILTER BY FIRST KEY ONLY\n"
                                     + "CLIENT MERGE SORT",
                             QueryUtil.getExplainPlan(rs));

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/IndexUsageIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/IndexUsageIT.java
@@ -496,7 +496,7 @@ public class IndexUsageIT extends ParallelStatsDisabledIT {
 	            assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER " + dataTableName + " [1,173]\n" + "CLIENT MERGE SORT",
 	                    queryPlan);
 	        } else {
-	            assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_" + dataTableName + " [" + Short.MIN_VALUE + ",173]", queryPlan);
+	            assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_" + dataTableName + " [" + Long.MIN_VALUE + ",173]", queryPlan);
 	        }
 	        rs = conn.createStatement().executeQuery(query);
 	        assertTrue(rs.next());
@@ -516,7 +516,7 @@ public class IndexUsageIT extends ParallelStatsDisabledIT {
 	                    + ",'foo2_bar2']\n" + "    SERVER FILTER BY FIRST KEY ONLY\n" + "CLIENT MERGE SORT",
 	                    QueryUtil.getExplainPlan(rs));
 	        } else {
-	            assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_" + dataTableName + " [" + (Short.MIN_VALUE + 1) + ",'foo2_bar2']\n"
+	            assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_" + dataTableName + " [" + (Long.MIN_VALUE + 1) + ",'foo2_bar2']\n"
 	                    + "    SERVER FILTER BY FIRST KEY ONLY", QueryUtil.getExplainPlan(rs));
 	        }
 	        rs = conn.createStatement().executeQuery(query);

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/MutableIndexFailureIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/MutableIndexFailureIT.java
@@ -591,9 +591,9 @@ public class MutableIndexFailureIT extends BaseTest {
                         if (Bytes.toString(family).startsWith(QueryConstants.LOCAL_INDEX_COLUMN_FAMILY_PREFIX)) {
                             int regionStartKeyLen = c.getEnvironment().getRegionInfo().getStartKey().length;
                             Cell firstCell = entry.getValue().get(0);
-                            short indexId = MetaDataUtil.getViewIndexIdDataType().getCodec().decodeShort(firstCell.getRowArray(), firstCell.getRowOffset() + regionStartKeyLen, SortOrder.getDefault());
+                            long indexId = MetaDataUtil.getViewIndexIdDataType().getCodec().decodeLong(firstCell.getRowArray(), firstCell.getRowOffset() + regionStartKeyLen, SortOrder.getDefault());
                             // Only throw for first local index as the test may have multiple local indexes
-                            if (indexId == Short.MIN_VALUE) {
+                            if (indexId == Long.MIN_VALUE) {
                                 throwException = true;
                                 break;
                             }

--- a/phoenix-core/src/main/java/org/apache/hadoop/hbase/regionserver/IndexHalfStoreFileReaderGenerator.java
+++ b/phoenix-core/src/main/java/org/apache/hadoop/hbase/regionserver/IndexHalfStoreFileReaderGenerator.java
@@ -160,8 +160,7 @@ public class IndexHalfStoreFileReaderGenerator extends BaseRegionObserver {
                 for (PTable index : indexes) {
                     if (index.getIndexType() == IndexType.LOCAL) {
                         IndexMaintainer indexMaintainer = index.getIndexMaintainer(dataTable, conn);
-                        indexMaintainers.put(new ImmutableBytesWritable(MetaDataUtil
-                                .getViewIndexIdDataType().toBytes(index.getViewIndexId())),
+                        indexMaintainers.put(new ImmutableBytesWritable(index.getViewIndexType().toBytes(index.getViewIndexId())),
                             indexMaintainer);
                     }
                 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/CreateTableCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/CreateTableCompiler.java
@@ -64,6 +64,7 @@ import org.apache.phoenix.schema.TableRef;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.schema.types.PVarbinary;
 import org.apache.phoenix.util.ByteUtil;
+import org.apache.phoenix.util.MetaDataUtil;
 import org.apache.phoenix.util.QueryUtil;
 
 import com.google.common.collect.Iterators;
@@ -189,7 +190,7 @@ public class CreateTableCompiler {
             @Override
             public MutationState execute() throws SQLException {
                 try {
-                    return client.createTable(finalCreate, splits, parent, viewStatement, viewType, viewColumnConstants, isViewColumnReferenced);
+                    return client.createTable(finalCreate, splits, parent, viewStatement, viewType, MetaDataUtil.getViewIndexIdDataType(), viewColumnConstants, isViewColumnReferenced);
                 } finally {
                     if (client.getConnection() != connection) {
                         client.getConnection().close();

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -156,7 +156,7 @@ public class DeleteCompiler {
         int offset = (table.getBucketNum() == null ? 0 : 1);
         byte[][] values = new byte[pkColumns.size()][];
         if (isSharedViewIndex) {
-            values[offset++] = MetaDataUtil.getViewIndexIdDataType().toBytes(table.getViewIndexId());
+            values[offset++] = table.getViewIndexType().toBytes(table.getViewIndexId());
         }
         if (isMultiTenant) {
             values[offset++] = tenantIdBytes;

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/FromCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/FromCompiler.java
@@ -821,7 +821,7 @@ public class FromCompiler {
             PTable t = PTableImpl.makePTable(null, PName.EMPTY_NAME, PName.EMPTY_NAME, PTableType.SUBQUERY, null,
                     MetaDataProtocol.MIN_TABLE_TIMESTAMP, PTable.INITIAL_SEQ_NUM, null, null, columns, null, null,
                     Collections.<PTable> emptyList(), false, Collections.<PName> emptyList(), null, null, false, false,
-                    false, null, null, null, false, null, 0, 0L, SchemaUtil
+                    false, null, null, null, null, false, null, 0, 0L, SchemaUtil
                             .isNamespaceMappingEnabled(PTableType.SUBQUERY, connection.getQueryServices().getProps()), null, false, ImmutableStorageScheme.ONE_CELL_PER_COLUMN, QualifierEncodingScheme.NON_ENCODED_QUALIFIERS, PTable.EncodedCQCounter.NULL_COUNTER, true);
 
             String alias = subselectNode.getAlias();

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/JoinCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/JoinCompiler.java
@@ -1275,7 +1275,7 @@ public class JoinCompiler {
                 left.getType(), left.getIndexState(), left.getTimeStamp(), left.getSequenceNumber(), left.getPKName(),
                 left.getBucketNum(), merged, left.getParentSchemaName(), left.getParentTableName(), left.getIndexes(),
                 left.isImmutableRows(), Collections.<PName> emptyList(), null, null, PTable.DEFAULT_DISABLE_WAL,
-                left.isMultiTenant(), left.getStoreNulls(), left.getViewType(), left.getViewIndexId(),
+                left.isMultiTenant(), left.getStoreNulls(), left.getViewType(),left.getViewIndexType(), left.getViewIndexId(),
                 left.getIndexType(), left.rowKeyOrderOptimizable(), left.getTransactionProvider(),
                 left.getUpdateCacheFrequency(), left.getIndexDisableTimestamp(), left.isNamespaceMapped(), 
                 left.getAutoPartitionSeqName(), left.isAppendOnlySchema(), ONE_CELL_PER_COLUMN, NON_ENCODED_QUALIFIERS, PTable.EncodedCQCounter.NULL_COUNTER, left.useStatsForParallelization());

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/TupleProjectionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/TupleProjectionCompiler.java
@@ -166,7 +166,7 @@ public class TupleProjectionCompiler {
                 table.getPKName(), table.getBucketNum(), projectedColumns, table.getParentSchemaName(),
                 table.getParentTableName(), table.getIndexes(), table.isImmutableRows(), Collections.<PName> emptyList(),
                 table.getDefaultFamilyName(), table.getViewStatement(), table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(),
-                table.getViewIndexId(),
+                table.getViewIndexType(), table.getViewIndexId(),
                 table.getIndexType(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), table.getUpdateCacheFrequency(), 
                 table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -198,7 +198,7 @@ public class TupleProjectionCompiler {
                 table.getBucketNum(), projectedColumns, null, null,
                 Collections.<PTable> emptyList(), table.isImmutableRows(), Collections.<PName> emptyList(), null, null,
                 table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(),
-                table.getViewIndexId(), null, table.rowKeyOrderOptimizable(), table.getTransactionProvider(),
+                table.getViewIndexType(), table.getViewIndexId(), null, table.rowKeyOrderOptimizable(), table.getTransactionProvider(),
                 table.getUpdateCacheFrequency(), table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), cqCounter, table.useStatsForParallelization());
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
@@ -100,7 +100,7 @@ public class UnionCompiler {
             UNION_SCHEMA_NAME, UNION_TABLE_NAME, PTableType.SUBQUERY, null,
             HConstants.LATEST_TIMESTAMP, scn == null ? HConstants.LATEST_TIMESTAMP : scn,
             null, null, projectedColumns, null, null, null, true, null, null, null, true,
-            true, true, null, null, null, false, null, 0, 0L,
+            true, true, null,null, null, null, false, null, 0, 0L,
             SchemaUtil.isNamespaceMappingEnabled(PTableType.SUBQUERY,
                 statement.getConnection().getQueryServices().getProps()), null, false, ImmutableStorageScheme.ONE_CELL_PER_COLUMN, QualifierEncodingScheme.NON_ENCODED_QUALIFIERS, PTable.EncodedCQCounter.NULL_COUNTER, true);
         TableRef tableRef = new TableRef(null, tempTable, 0, false);

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/UpsertCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/UpsertCompiler.java
@@ -720,7 +720,7 @@ public class UpsertCompiler {
         final byte[][] values = new byte[nValuesToSet][];
         int nodeIndex = 0;
         if (isSharedViewIndex) {
-            values[nodeIndex++] = MetaDataUtil.getViewIndexIdDataType().toBytes(table.getViewIndexId());
+            values[nodeIndex++] = table.getViewIndexType().toBytes(table.getViewIndexId());
         }
         if (isTenantSpecific) {
             PName tenantId = connection.getTenantId();

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/WhereOptimizer.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/WhereOptimizer.java
@@ -179,7 +179,7 @@ public class WhereOptimizer {
         // Add unique index ID for shared indexes on views. This ensures
         // that different indexes don't interleave.
         if (hasViewIndex) {
-            byte[] viewIndexBytes = MetaDataUtil.getViewIndexIdDataType().toBytes(table.getViewIndexId());
+            byte[] viewIndexBytes = table.getViewIndexType().toBytes(table.getViewIndexId());
             KeyRange indexIdKeyRange = KeyRange.getKeyRange(viewIndexBytes);
             cnf.add(Collections.singletonList(indexIdKeyRange));
             pkPos++;

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -20,63 +20,7 @@ package org.apache.phoenix.coprocessor;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.hadoop.hbase.KeyValueUtil.createFirstOnRow;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.APPEND_ONLY_SCHEMA_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ARRAY_SIZE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.AUTO_PARTITION_SEQ_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.CLASS_NAME_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_COUNT_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_DEF_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_NAME_INDEX;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_QUALIFIER_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_QUALIFIER_COUNTER_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_SIZE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DATA_TABLE_NAME_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DATA_TYPE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DECIMAL_DIGITS_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DEFAULT_COLUMN_FAMILY_NAME_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DEFAULT_VALUE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DISABLE_WAL_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ENCODING_SCHEME_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.FAMILY_NAME_INDEX;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IMMUTABLE_ROWS_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.INDEX_DISABLE_TIMESTAMP_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.INDEX_STATE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.INDEX_TYPE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_ARRAY_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_CONSTANT_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_NAMESPACE_MAPPED_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_ROW_TIMESTAMP_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_VIEW_REFERENCED_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.JAR_PATH_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.LINK_TYPE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.MAX_VALUE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.MIN_VALUE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.MULTI_TENANT_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.NULLABLE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.NUM_ARGS_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ORDINAL_POSITION_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.PARENT_TENANT_ID_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.PK_NAME_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.RETURN_TYPE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SALT_BUCKETS_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SCHEMA_NAME_INDEX;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SORT_ORDER_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.STORAGE_SCHEME_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.STORE_NULLS_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_FAMILY_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_NAME_INDEX;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_SEQ_NUM_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_TYPE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TENANT_ID_INDEX;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TRANSACTIONAL_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TRANSACTION_PROVIDER_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TYPE_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.UPDATE_CACHE_FREQUENCY_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.USE_STATS_FOR_PARALLELIZATION_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.VIEW_CONSTANT_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.VIEW_INDEX_ID_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.VIEW_STATEMENT_BYTES;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.VIEW_TYPE_BYTES;
+import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.*;
 import static org.apache.phoenix.query.QueryConstants.DIVERGED_VIEW_BASE_COLUMN_COUNT;
 import static org.apache.phoenix.query.QueryConstants.SEPARATOR_BYTE_ARRAY;
 import static org.apache.phoenix.schema.PTableType.INDEX;
@@ -297,6 +241,10 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
     private static final KeyValue MULTI_TENANT_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, MULTI_TENANT_BYTES);
     private static final KeyValue VIEW_TYPE_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, VIEW_TYPE_BYTES);
     private static final KeyValue VIEW_INDEX_ID_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, VIEW_INDEX_ID_BYTES);
+    /**
+     * A designator for choosing the right type for viewIndex (Short vs Long) to be backward compatible.
+     * **/
+    private static final KeyValue USE_LONG_VIEW_INDEX_ID_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, USE_LONG_VIEW_INDEX_BYTES);
     private static final KeyValue INDEX_TYPE_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, INDEX_TYPE_BYTES);
     private static final KeyValue INDEX_DISABLE_TIMESTAMP_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, INDEX_DISABLE_TIMESTAMP_BYTES);
     private static final KeyValue STORE_NULLS_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, STORE_NULLS_BYTES);
@@ -330,6 +278,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
             MULTI_TENANT_KV,
             VIEW_TYPE_KV,
             VIEW_INDEX_ID_KV,
+            USE_LONG_VIEW_INDEX_ID_KV,
             INDEX_TYPE_KV,
             INDEX_DISABLE_TIMESTAMP_KV,
             STORE_NULLS_KV,
@@ -362,6 +311,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
     private static final int DISABLE_WAL_INDEX = TABLE_KV_COLUMNS.indexOf(DISABLE_WAL_KV);
     private static final int MULTI_TENANT_INDEX = TABLE_KV_COLUMNS.indexOf(MULTI_TENANT_KV);
     private static final int VIEW_TYPE_INDEX = TABLE_KV_COLUMNS.indexOf(VIEW_TYPE_KV);
+    private static final int USE_LONG_VIEW_INDEX = TABLE_KV_COLUMNS.indexOf(USE_LONG_VIEW_INDEX_ID_KV);
     private static final int VIEW_INDEX_ID_INDEX = TABLE_KV_COLUMNS.indexOf(VIEW_INDEX_ID_KV);
     private static final int INDEX_TYPE_INDEX = TABLE_KV_COLUMNS.indexOf(INDEX_TYPE_KV);
     private static final int STORE_NULLS_INDEX = TABLE_KV_COLUMNS.indexOf(STORE_NULLS_KV);
@@ -993,8 +943,8 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
         }
         Cell viewTypeKv = tableKeyValues[VIEW_TYPE_INDEX];
         ViewType viewType = viewTypeKv == null ? null : ViewType.fromSerializedValue(viewTypeKv.getValueArray()[viewTypeKv.getValueOffset()]);
-        Cell viewIndexIdKv = tableKeyValues[VIEW_INDEX_ID_INDEX];
-        Short viewIndexId = viewIndexIdKv == null ? null : (Short)MetaDataUtil.getViewIndexIdDataType().getCodec().decodeShort(viewIndexIdKv.getValueArray(), viewIndexIdKv.getValueOffset(), SortOrder.getDefault());
+        PDataType viewIndexType = getViewIndexType(tableKeyValues);
+        Long viewIndexId = getViewIndexId(tableKeyValues, viewIndexType);
         Cell indexTypeKv = tableKeyValues[INDEX_TYPE_INDEX];
         IndexType indexType = indexTypeKv == null ? null : IndexType.fromSerializedValue(indexTypeKv.getValueArray()[indexTypeKv.getValueOffset()]);
         Cell baseColumnCountKv = tableKeyValues[BASE_COLUMN_COUNT_INDEX];
@@ -1072,11 +1022,45 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
         // server while holding this lock is a bad idea and likely to cause contention.
         return PTableImpl.makePTable(tenantId, schemaName, tableName, tableType, indexState, timeStamp, tableSeqNum,
                 pkName, saltBucketNum, columns, parentSchemaName, parentTableName, indexes, isImmutableRows, physicalTables, defaultFamilyName,
-                viewStatement, disableWAL, multiTenant, storeNulls, viewType, viewIndexId, indexType,
+                viewStatement, disableWAL, multiTenant, storeNulls, viewType, viewIndexType, viewIndexId, indexType,
                 rowKeyOrderOptimizable, transactionProvider, updateCacheFrequency, baseColumnCount,
                 indexDisableTimestamp, isNamespaceMapped, autoPartitionSeq, isAppendOnlySchema, storageScheme, encodingScheme, cqCounter, useStatsForParallelization);
     }
-    
+
+
+    private Long getViewIndexId(Cell[] tableKeyValues, PDataType viewIndexType) {
+        Cell viewIndexIdKv = tableKeyValues[VIEW_INDEX_ID_INDEX];
+        return viewIndexIdKv == null ? null :
+                decodeViewIndexId(viewIndexIdKv, viewIndexType);
+    }
+
+    /**
+     * check the value for {@value USE_LONG_VIEW_INDEX} and if its present consider viewIndexId as long otherwise
+     * read as short and convert it to long
+     *
+     * @param tableKeyValues
+     * @param viewIndexType
+     * @return
+     */
+    private Long decodeViewIndexId(Cell viewIndexIdKv,  PDataType viewIndexType) {
+        boolean useLongViewIndex = MetaDataUtil.getViewIndexIdDataType().equals(viewIndexType);
+		return new Long(
+				useLongViewIndex
+						? viewIndexType.getCodec().decodeLong(viewIndexIdKv.getValueArray(),
+						viewIndexIdKv.getValueOffset(), SortOrder.getDefault())
+						: MetaDataUtil.getLegacyViewIndexIdDataType().getCodec().decodeShort(viewIndexIdKv.getValueArray(),
+						viewIndexIdKv.getValueOffset(), SortOrder.getDefault())
+		);
+    }
+
+    private PDataType getViewIndexType(Cell[] tableKeyValues) {
+        Cell useLongViewIndexKv = tableKeyValues[USE_LONG_VIEW_INDEX];
+        boolean useLongViewIndex = useLongViewIndexKv != null;
+        return useLongViewIndex ?
+                MetaDataUtil.getViewIndexIdDataType()
+                : MetaDataUtil.getLegacyViewIndexIdDataType();
+    }
+
     private boolean isQualifierCounterKV(Cell kv) {
         int cmp =
                 Bytes.compareTo(kv.getQualifierArray(), kv.getQualifierOffset(),
@@ -1733,7 +1717,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
                         cell.getTimestamp(), Type.codeToType(cell.getTypeByte()), bytes);
                     cells.add(viewConstantCell);
                 }
-                Short indexId = null;
+                Long indexId = null;
                 if (request.hasAllocateIndexId() && request.getAllocateIndexId()) {
                     String tenantIdStr = tenantIdBytes.length == 0 ? null : Bytes.toString(tenantIdBytes);
                     try (PhoenixConnection connection = QueryUtil.getConnectionOnServer(env.getConfiguration()).unwrap(PhoenixConnection.class)) {
@@ -1747,7 +1731,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
                         long sequenceTimestamp = HConstants.LATEST_TIMESTAMP;
                         try {
                             connection.getQueryServices().createSequence(key.getTenantId(), key.getSchemaName(), key.getSequenceName(),
-                                Short.MIN_VALUE, 1, 1, Long.MIN_VALUE, Long.MAX_VALUE, false, sequenceTimestamp);
+                                Long.MIN_VALUE, 1, 1, Long.MIN_VALUE, Long.MAX_VALUE, false, sequenceTimestamp);
                         } catch (SequenceAlreadyExistsException e) {
                         }
                         long[] seqValues = new long[1];
@@ -1758,7 +1742,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
                             throw sqlExceptions[0];
                         }
                         long seqValue = seqValues[0];
-                        if (seqValue > Short.MAX_VALUE) {
+                        if (seqValue > Long.MAX_VALUE) {
                             builder.setReturnCode(MetaDataProtos.MutationCode.TOO_MANY_INDEXES);
                             builder.setMutationTime(EnvironmentEdgeManager.currentTimeMillis());
                             done.run(builder.build());
@@ -1775,7 +1759,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
                         Cell indexIdCell = new KeyValue(cell.getRow(), cell.getFamily(), VIEW_INDEX_ID_BYTES,
                             cell.getTimestamp(), Type.codeToType(cell.getTypeByte()), bytes);
                         cells.add(indexIdCell);
-                        indexId = (short) seqValue;
+                        indexId = (long) seqValue;
                     }
                 }
                 
@@ -1799,6 +1783,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements Coprocesso
                 builder.setReturnCode(MetaDataProtos.MutationCode.TABLE_NOT_FOUND);
                 if (indexId != null) {
                     builder.setViewIndexId(indexId);
+                    builder.setUseLongViewIndexId(true);
                 }
                 builder.setMutationTime(currentTimeStamp);
                 done.run(builder.build());

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataProtocol.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataProtocol.java
@@ -38,11 +38,13 @@ import org.apache.phoenix.schema.PName;
 import org.apache.phoenix.schema.PNameFactory;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTableImpl;
+import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.util.ByteUtil;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
+import org.apache.phoenix.util.MetaDataUtil;
 
 /**
  *
@@ -169,7 +171,8 @@ public abstract class MetaDataProtocol extends MetaDataService {
         private PName tableName;
         private List<PColumn> columns;
         private List<PName> physicalNames;
-        private Short viewIndexId;
+        private PDataType viewIndexType;
+        private Long viewIndexId;
         
         public SharedTableState(PTable table) {
             this.tenantId = table.getTenantId();
@@ -177,6 +180,7 @@ public abstract class MetaDataProtocol extends MetaDataService {
             this.tableName = table.getTableName();
             this.columns = table.getColumns();
             this.physicalNames = table.getPhysicalNames();
+            this.viewIndexType = table.getViewIndexType();
             this.viewIndexId = table.getViewIndexId();
         }
         
@@ -199,7 +203,10 @@ public abstract class MetaDataProtocol extends MetaDataService {
                     return PNameFactory.newName(physicalName.toByteArray());
                 }
             });
-            this.viewIndexId = (short)sharedTable.getViewIndexId();
+            this.viewIndexId = sharedTable.getViewIndexId();
+            this.viewIndexType = sharedTable.hasUseLongViewIndexId()
+                    ? MetaDataUtil.getViewIndexIdDataType()
+                    : MetaDataUtil.getLegacyViewIndexIdDataType();
         }
 
         public PName getTenantId() {
@@ -222,10 +229,13 @@ public abstract class MetaDataProtocol extends MetaDataService {
             return physicalNames;
         }
 
-        public Short getViewIndexId() {
+        public Long getViewIndexId() {
             return viewIndexId;
         }
-        
+
+        public PDataType getViewIndexType() {
+          return viewIndexType;
+        }
   }
     
   public static class MetaDataMutationResult {
@@ -238,8 +248,8 @@ public abstract class MetaDataProtocol extends MetaDataService {
         private byte[] familyName;
         private boolean wasUpdated;
         private PSchema schema;
-        private Short viewIndexId;
-
+        private Long viewIndexId;
+        private PDataType viewIndexType;
         private List<PFunction> functions = new ArrayList<PFunction>(1);
         private long autoPartitionNum;
 
@@ -284,9 +294,10 @@ public abstract class MetaDataProtocol extends MetaDataService {
             this.tableNamesToDelete = tableNamesToDelete;
         }
         
-        public MetaDataMutationResult(MutationCode returnCode, int currentTime, PTable table, int viewIndexId) {
+        public MetaDataMutationResult(MutationCode returnCode, int currentTime, PTable table, long viewIndexId, PDataType viewIndexType ) {
             this(returnCode, currentTime, table, Collections.<byte[]> emptyList());
-            this.viewIndexId = (short)viewIndexId;
+            this.viewIndexId = viewIndexId;
+            this.viewIndexType = viewIndexType;
         }
         
         public MetaDataMutationResult(MutationCode returnCode, long currentTime, PTable table, List<byte[]> tableNamesToDelete, List<SharedTableState> sharedTablesToDelete) {
@@ -342,11 +353,15 @@ public abstract class MetaDataProtocol extends MetaDataService {
             return autoPartitionNum;
         }
         
-        public Short getViewIndexId() {
+        public Long getViewIndexId() {
             return viewIndexId;
         }
 
-        public static MetaDataMutationResult constructFromProto(MetaDataResponse proto) {
+      public PDataType getViewIndexType() {
+          return viewIndexType;
+      }
+
+      public static MetaDataMutationResult constructFromProto(MetaDataResponse proto) {
           MetaDataMutationResult result = new MetaDataMutationResult();
           result.returnCode = MutationCode.values()[proto.getReturnCode().ordinal()];
           result.mutationTime = proto.getMutationTime();
@@ -387,9 +402,12 @@ public abstract class MetaDataProtocol extends MetaDataService {
           if (proto.hasAutoPartitionNum()) {
               result.autoPartitionNum = proto.getAutoPartitionNum();
           }
-            if (proto.hasViewIndexId()) {
-                result.viewIndexId = (short)proto.getViewIndexId();
-            }
+          if (proto.hasViewIndexId()) {
+              result.viewIndexId = proto.getViewIndexId();
+          }
+          result.viewIndexType = proto.hasUseLongViewIndexId()
+                  ? MetaDataUtil.getViewIndexIdDataType()
+                  : MetaDataUtil.getLegacyViewIndexIdDataType();
           return result;
         }
 
@@ -439,6 +457,7 @@ public abstract class MetaDataProtocol extends MetaDataService {
             builder.setAutoPartitionNum(result.getAutoPartitionNum());
                 if (result.getViewIndexId() != null) {
                     builder.setViewIndexId(result.getViewIndexId());
+                    builder.setUseLongViewIndexId(MetaDataUtil.getViewIndexIdDataType().equals(result.getViewIndexType()));
                 }
           }
           return builder.build();

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/MetaDataProtos.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/MetaDataProtos.java
@@ -351,15 +351,25 @@ public final class MetaDataProtos {
      */
     com.google.protobuf.ByteString getPhysicalNames(int index);
 
-    // required int32 viewIndexId = 6;
+    // required int64 viewIndexId = 6;
     /**
-     * <code>required int32 viewIndexId = 6;</code>
+     * <code>required int64 viewIndexId = 6;</code>
      */
     boolean hasViewIndexId();
     /**
-     * <code>required int32 viewIndexId = 6;</code>
+     * <code>required int64 viewIndexId = 6;</code>
      */
-    int getViewIndexId();
+    long getViewIndexId();
+
+    // optional bool useLongViewIndexId = 7;
+    /**
+     * <code>optional bool useLongViewIndexId = 7;</code>
+     */
+    boolean hasUseLongViewIndexId();
+    /**
+     * <code>optional bool useLongViewIndexId = 7;</code>
+     */
+    boolean getUseLongViewIndexId();
   }
   /**
    * Protobuf type {@code SharedTableState}
@@ -445,7 +455,12 @@ public final class MetaDataProtos {
             }
             case 48: {
               bitField0_ |= 0x00000008;
-              viewIndexId_ = input.readInt32();
+              viewIndexId_ = input.readInt64();
+              break;
+            }
+            case 56: {
+              bitField0_ |= 0x00000010;
+              useLongViewIndexId_ = input.readBool();
               break;
             }
           }
@@ -601,20 +616,36 @@ public final class MetaDataProtos {
       return physicalNames_.get(index);
     }
 
-    // required int32 viewIndexId = 6;
+    // required int64 viewIndexId = 6;
     public static final int VIEWINDEXID_FIELD_NUMBER = 6;
-    private int viewIndexId_;
+    private long viewIndexId_;
     /**
-     * <code>required int32 viewIndexId = 6;</code>
+     * <code>required int64 viewIndexId = 6;</code>
      */
     public boolean hasViewIndexId() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>required int32 viewIndexId = 6;</code>
+     * <code>required int64 viewIndexId = 6;</code>
      */
-    public int getViewIndexId() {
+    public long getViewIndexId() {
       return viewIndexId_;
+    }
+
+    // optional bool useLongViewIndexId = 7;
+    public static final int USELONGVIEWINDEXID_FIELD_NUMBER = 7;
+    private boolean useLongViewIndexId_;
+    /**
+     * <code>optional bool useLongViewIndexId = 7;</code>
+     */
+    public boolean hasUseLongViewIndexId() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional bool useLongViewIndexId = 7;</code>
+     */
+    public boolean getUseLongViewIndexId() {
+      return useLongViewIndexId_;
     }
 
     private void initFields() {
@@ -623,7 +654,8 @@ public final class MetaDataProtos {
       tableName_ = com.google.protobuf.ByteString.EMPTY;
       columns_ = java.util.Collections.emptyList();
       physicalNames_ = java.util.Collections.emptyList();
-      viewIndexId_ = 0;
+      viewIndexId_ = 0L;
+      useLongViewIndexId_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -671,7 +703,10 @@ public final class MetaDataProtos {
         output.writeBytes(5, physicalNames_.get(i));
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeInt32(6, viewIndexId_);
+        output.writeInt64(6, viewIndexId_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeBool(7, useLongViewIndexId_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -709,7 +744,11 @@ public final class MetaDataProtos {
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(6, viewIndexId_);
+          .computeInt64Size(6, viewIndexId_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(7, useLongViewIndexId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -758,6 +797,11 @@ public final class MetaDataProtos {
         result = result && (getViewIndexId()
             == other.getViewIndexId());
       }
+      result = result && (hasUseLongViewIndexId() == other.hasUseLongViewIndexId());
+      if (hasUseLongViewIndexId()) {
+        result = result && (getUseLongViewIndexId()
+            == other.getUseLongViewIndexId());
+      }
       result = result &&
           getUnknownFields().equals(other.getUnknownFields());
       return result;
@@ -793,7 +837,11 @@ public final class MetaDataProtos {
       }
       if (hasViewIndexId()) {
         hash = (37 * hash) + VIEWINDEXID_FIELD_NUMBER;
-        hash = (53 * hash) + getViewIndexId();
+        hash = (53 * hash) + hashLong(getViewIndexId());
+      }
+      if (hasUseLongViewIndexId()) {
+        hash = (37 * hash) + USELONGVIEWINDEXID_FIELD_NUMBER;
+        hash = (53 * hash) + hashBoolean(getUseLongViewIndexId());
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -919,8 +967,10 @@ public final class MetaDataProtos {
         }
         physicalNames_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000010);
-        viewIndexId_ = 0;
+        viewIndexId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000020);
+        useLongViewIndexId_ = false;
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -979,6 +1029,10 @@ public final class MetaDataProtos {
           to_bitField0_ |= 0x00000008;
         }
         result.viewIndexId_ = viewIndexId_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.useLongViewIndexId_ = useLongViewIndexId_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1042,6 +1096,9 @@ public final class MetaDataProtos {
         }
         if (other.hasViewIndexId()) {
           setViewIndexId(other.getViewIndexId());
+        }
+        if (other.hasUseLongViewIndexId()) {
+          setUseLongViewIndexId(other.getUseLongViewIndexId());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -1508,35 +1565,68 @@ public final class MetaDataProtos {
         return this;
       }
 
-      // required int32 viewIndexId = 6;
-      private int viewIndexId_ ;
+      // required int64 viewIndexId = 6;
+      private long viewIndexId_ ;
       /**
-       * <code>required int32 viewIndexId = 6;</code>
+       * <code>required int64 viewIndexId = 6;</code>
        */
       public boolean hasViewIndexId() {
         return ((bitField0_ & 0x00000020) == 0x00000020);
       }
       /**
-       * <code>required int32 viewIndexId = 6;</code>
+       * <code>required int64 viewIndexId = 6;</code>
        */
-      public int getViewIndexId() {
+      public long getViewIndexId() {
         return viewIndexId_;
       }
       /**
-       * <code>required int32 viewIndexId = 6;</code>
+       * <code>required int64 viewIndexId = 6;</code>
        */
-      public Builder setViewIndexId(int value) {
+      public Builder setViewIndexId(long value) {
         bitField0_ |= 0x00000020;
         viewIndexId_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>required int32 viewIndexId = 6;</code>
+       * <code>required int64 viewIndexId = 6;</code>
        */
       public Builder clearViewIndexId() {
         bitField0_ = (bitField0_ & ~0x00000020);
-        viewIndexId_ = 0;
+        viewIndexId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // optional bool useLongViewIndexId = 7;
+      private boolean useLongViewIndexId_ ;
+      /**
+       * <code>optional bool useLongViewIndexId = 7;</code>
+       */
+      public boolean hasUseLongViewIndexId() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 7;</code>
+       */
+      public boolean getUseLongViewIndexId() {
+        return useLongViewIndexId_;
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 7;</code>
+       */
+      public Builder setUseLongViewIndexId(boolean value) {
+        bitField0_ |= 0x00000040;
+        useLongViewIndexId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 7;</code>
+       */
+      public Builder clearUseLongViewIndexId() {
+        bitField0_ = (bitField0_ & ~0x00000040);
+        useLongViewIndexId_ = false;
         onChanged();
         return this;
       }
@@ -1707,15 +1797,25 @@ public final class MetaDataProtos {
      */
     long getAutoPartitionNum();
 
-    // optional int32 viewIndexId = 12;
+    // optional int64 viewIndexId = 12;
     /**
-     * <code>optional int32 viewIndexId = 12;</code>
+     * <code>optional int64 viewIndexId = 12;</code>
      */
     boolean hasViewIndexId();
     /**
-     * <code>optional int32 viewIndexId = 12;</code>
+     * <code>optional int64 viewIndexId = 12;</code>
      */
-    int getViewIndexId();
+    long getViewIndexId();
+
+    // optional bool useLongViewIndexId = 13;
+    /**
+     * <code>optional bool useLongViewIndexId = 13;</code>
+     */
+    boolean hasUseLongViewIndexId();
+    /**
+     * <code>optional bool useLongViewIndexId = 13;</code>
+     */
+    boolean getUseLongViewIndexId();
   }
   /**
    * Protobuf type {@code MetaDataResponse}
@@ -1856,7 +1956,12 @@ public final class MetaDataProtos {
             }
             case 96: {
               bitField0_ |= 0x00000100;
-              viewIndexId_ = input.readInt32();
+              viewIndexId_ = input.readInt64();
+              break;
+            }
+            case 104: {
+              bitField0_ |= 0x00000200;
+              useLongViewIndexId_ = input.readBool();
               break;
             }
           }
@@ -2143,20 +2248,36 @@ public final class MetaDataProtos {
       return autoPartitionNum_;
     }
 
-    // optional int32 viewIndexId = 12;
+    // optional int64 viewIndexId = 12;
     public static final int VIEWINDEXID_FIELD_NUMBER = 12;
-    private int viewIndexId_;
+    private long viewIndexId_;
     /**
-     * <code>optional int32 viewIndexId = 12;</code>
+     * <code>optional int64 viewIndexId = 12;</code>
      */
     public boolean hasViewIndexId() {
       return ((bitField0_ & 0x00000100) == 0x00000100);
     }
     /**
-     * <code>optional int32 viewIndexId = 12;</code>
+     * <code>optional int64 viewIndexId = 12;</code>
      */
-    public int getViewIndexId() {
+    public long getViewIndexId() {
       return viewIndexId_;
+    }
+
+    // optional bool useLongViewIndexId = 13;
+    public static final int USELONGVIEWINDEXID_FIELD_NUMBER = 13;
+    private boolean useLongViewIndexId_;
+    /**
+     * <code>optional bool useLongViewIndexId = 13;</code>
+     */
+    public boolean hasUseLongViewIndexId() {
+      return ((bitField0_ & 0x00000200) == 0x00000200);
+    }
+    /**
+     * <code>optional bool useLongViewIndexId = 13;</code>
+     */
+    public boolean getUseLongViewIndexId() {
+      return useLongViewIndexId_;
     }
 
     private void initFields() {
@@ -2171,7 +2292,8 @@ public final class MetaDataProtos {
       sharedTablesToDelete_ = java.util.Collections.emptyList();
       schema_ = org.apache.phoenix.coprocessor.generated.PSchemaProtos.PSchema.getDefaultInstance();
       autoPartitionNum_ = 0L;
-      viewIndexId_ = 0;
+      viewIndexId_ = 0L;
+      useLongViewIndexId_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -2243,7 +2365,10 @@ public final class MetaDataProtos {
         output.writeInt64(11, autoPartitionNum_);
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        output.writeInt32(12, viewIndexId_);
+        output.writeInt64(12, viewIndexId_);
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        output.writeBool(13, useLongViewIndexId_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -2305,7 +2430,11 @@ public final class MetaDataProtos {
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(12, viewIndexId_);
+          .computeInt64Size(12, viewIndexId_);
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(13, useLongViewIndexId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2381,6 +2510,11 @@ public final class MetaDataProtos {
         result = result && (getViewIndexId()
             == other.getViewIndexId());
       }
+      result = result && (hasUseLongViewIndexId() == other.hasUseLongViewIndexId());
+      if (hasUseLongViewIndexId()) {
+        result = result && (getUseLongViewIndexId()
+            == other.getUseLongViewIndexId());
+      }
       result = result &&
           getUnknownFields().equals(other.getUnknownFields());
       return result;
@@ -2440,7 +2574,11 @@ public final class MetaDataProtos {
       }
       if (hasViewIndexId()) {
         hash = (37 * hash) + VIEWINDEXID_FIELD_NUMBER;
-        hash = (53 * hash) + getViewIndexId();
+        hash = (53 * hash) + hashLong(getViewIndexId());
+      }
+      if (hasUseLongViewIndexId()) {
+        hash = (37 * hash) + USELONGVIEWINDEXID_FIELD_NUMBER;
+        hash = (53 * hash) + hashBoolean(getUseLongViewIndexId());
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -2593,8 +2731,10 @@ public final class MetaDataProtos {
         bitField0_ = (bitField0_ & ~0x00000200);
         autoPartitionNum_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000400);
-        viewIndexId_ = 0;
+        viewIndexId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000800);
+        useLongViewIndexId_ = false;
+        bitField0_ = (bitField0_ & ~0x00001000);
         return this;
       }
 
@@ -2690,6 +2830,10 @@ public final class MetaDataProtos {
           to_bitField0_ |= 0x00000100;
         }
         result.viewIndexId_ = viewIndexId_;
+        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
+          to_bitField0_ |= 0x00000200;
+        }
+        result.useLongViewIndexId_ = useLongViewIndexId_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2794,6 +2938,9 @@ public final class MetaDataProtos {
         }
         if (other.hasViewIndexId()) {
           setViewIndexId(other.getViewIndexId());
+        }
+        if (other.hasUseLongViewIndexId()) {
+          setUseLongViewIndexId(other.getUseLongViewIndexId());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -3842,35 +3989,68 @@ public final class MetaDataProtos {
         return this;
       }
 
-      // optional int32 viewIndexId = 12;
-      private int viewIndexId_ ;
+      // optional int64 viewIndexId = 12;
+      private long viewIndexId_ ;
       /**
-       * <code>optional int32 viewIndexId = 12;</code>
+       * <code>optional int64 viewIndexId = 12;</code>
        */
       public boolean hasViewIndexId() {
         return ((bitField0_ & 0x00000800) == 0x00000800);
       }
       /**
-       * <code>optional int32 viewIndexId = 12;</code>
+       * <code>optional int64 viewIndexId = 12;</code>
        */
-      public int getViewIndexId() {
+      public long getViewIndexId() {
         return viewIndexId_;
       }
       /**
-       * <code>optional int32 viewIndexId = 12;</code>
+       * <code>optional int64 viewIndexId = 12;</code>
        */
-      public Builder setViewIndexId(int value) {
+      public Builder setViewIndexId(long value) {
         bitField0_ |= 0x00000800;
         viewIndexId_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int32 viewIndexId = 12;</code>
+       * <code>optional int64 viewIndexId = 12;</code>
        */
       public Builder clearViewIndexId() {
         bitField0_ = (bitField0_ & ~0x00000800);
-        viewIndexId_ = 0;
+        viewIndexId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // optional bool useLongViewIndexId = 13;
+      private boolean useLongViewIndexId_ ;
+      /**
+       * <code>optional bool useLongViewIndexId = 13;</code>
+       */
+      public boolean hasUseLongViewIndexId() {
+        return ((bitField0_ & 0x00001000) == 0x00001000);
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 13;</code>
+       */
+      public boolean getUseLongViewIndexId() {
+        return useLongViewIndexId_;
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 13;</code>
+       */
+      public Builder setUseLongViewIndexId(boolean value) {
+        bitField0_ |= 0x00001000;
+        useLongViewIndexId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 13;</code>
+       */
+      public Builder clearUseLongViewIndexId() {
+        bitField0_ = (bitField0_ & ~0x00001000);
+        useLongViewIndexId_ = false;
         onChanged();
         return this;
       }
@@ -17146,99 +17326,100 @@ public final class MetaDataProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n\025MetaDataService.proto\032\014PTable.proto\032\017P" +
-      "Function.proto\032\rPSchema.proto\"\222\001\n\020Shared" +
+      "Function.proto\032\rPSchema.proto\"\256\001\n\020Shared" +
       "TableState\022\020\n\010tenantId\030\001 \001(\014\022\022\n\nschemaNa" +
       "me\030\002 \002(\014\022\021\n\ttableName\030\003 \002(\014\022\031\n\007columns\030\004" +
       " \003(\0132\010.PColumn\022\025\n\rphysicalNames\030\005 \003(\014\022\023\n" +
-      "\013viewIndexId\030\006 \002(\005\"\321\002\n\020MetaDataResponse\022" +
-      "!\n\nreturnCode\030\001 \001(\0162\r.MutationCode\022\024\n\014mu" +
-      "tationTime\030\002 \001(\003\022\026\n\005table\030\003 \001(\0132\007.PTable" +
-      "\022\026\n\016tablesToDelete\030\004 \003(\014\022\022\n\ncolumnName\030\005" +
-      " \001(\014\022\022\n\nfamilyName\030\006 \001(\014\022\024\n\014functionName",
-      "\030\007 \001(\014\022\034\n\010function\030\010 \003(\0132\n.PFunction\022/\n\024" +
-      "sharedTablesToDelete\030\t \003(\0132\021.SharedTable" +
-      "State\022\030\n\006schema\030\n \001(\0132\010.PSchema\022\030\n\020autoP" +
-      "artitionNum\030\013 \001(\003\022\023\n\013viewIndexId\030\014 \001(\005\"\222" +
-      "\001\n\017GetTableRequest\022\020\n\010tenantId\030\001 \002(\014\022\022\n\n" +
-      "schemaName\030\002 \002(\014\022\021\n\ttableName\030\003 \002(\014\022\026\n\016t" +
-      "ableTimestamp\030\004 \002(\003\022\027\n\017clientTimestamp\030\005" +
-      " \002(\003\022\025\n\rclientVersion\030\006 \001(\005\"\212\001\n\023GetFunct" +
-      "ionsRequest\022\020\n\010tenantId\030\001 \002(\014\022\025\n\rfunctio" +
-      "nNames\030\002 \003(\014\022\032\n\022functionTimestamps\030\003 \003(\003",
-      "\022\027\n\017clientTimestamp\030\004 \002(\003\022\025\n\rclientVersi" +
-      "on\030\005 \001(\005\"V\n\020GetSchemaRequest\022\022\n\nschemaNa" +
-      "me\030\001 \002(\t\022\027\n\017clientTimestamp\030\002 \002(\003\022\025\n\rcli" +
-      "entVersion\030\003 \002(\005\"d\n\022CreateTableRequest\022\036" +
-      "\n\026tableMetadataMutations\030\001 \003(\014\022\025\n\rclient" +
-      "Version\030\002 \001(\005\022\027\n\017allocateIndexId\030\003 \001(\010\"r" +
-      "\n\025CreateFunctionRequest\022\036\n\026tableMetadata" +
-      "Mutations\030\001 \003(\014\022\021\n\ttemporary\030\002 \002(\010\022\017\n\007re" +
-      "place\030\003 \001(\010\022\025\n\rclientVersion\030\004 \001(\005\"`\n\023Cr" +
-      "eateSchemaRequest\022\036\n\026tableMetadataMutati",
-      "ons\030\001 \003(\014\022\022\n\nschemaName\030\002 \002(\t\022\025\n\rclientV" +
-      "ersion\030\003 \002(\005\"m\n\020DropTableRequest\022\036\n\026tabl" +
-      "eMetadataMutations\030\001 \003(\014\022\021\n\ttableType\030\002 " +
-      "\002(\t\022\017\n\007cascade\030\003 \001(\010\022\025\n\rclientVersion\030\004 " +
-      "\001(\005\"_\n\021DropSchemaRequest\022\037\n\027schemaMetada" +
-      "taMutations\030\001 \003(\014\022\022\n\nschemaName\030\002 \002(\t\022\025\n" +
-      "\rclientVersion\030\003 \002(\005\"I\n\020AddColumnRequest" +
-      "\022\036\n\026tableMetadataMutations\030\001 \003(\014\022\025\n\rclie" +
-      "ntVersion\030\002 \001(\005\"J\n\021DropColumnRequest\022\036\n\026" +
-      "tableMetadataMutations\030\001 \003(\014\022\025\n\rclientVe",
-      "rsion\030\002 \001(\005\"^\n\023DropFunctionRequest\022\036\n\026ta" +
-      "bleMetadataMutations\030\001 \003(\014\022\020\n\010ifExists\030\002" +
-      " \001(\010\022\025\n\rclientVersion\030\003 \001(\005\"P\n\027UpdateInd" +
-      "exStateRequest\022\036\n\026tableMetadataMutations" +
-      "\030\001 \003(\014\022\025\n\rclientVersion\030\002 \001(\005\"*\n\021ClearCa" +
-      "cheRequest\022\025\n\rclientVersion\030\001 \001(\005\"*\n\022Cle" +
-      "arCacheResponse\022\024\n\014unfreedBytes\030\001 \001(\003\"*\n" +
-      "\021GetVersionRequest\022\025\n\rclientVersion\030\001 \001(" +
-      "\005\"E\n\022GetVersionResponse\022\017\n\007version\030\001 \002(\003" +
-      "\022\036\n\026systemCatalogTimestamp\030\002 \001(\003\"\205\001\n\032Cle",
-      "arTableFromCacheRequest\022\020\n\010tenantId\030\001 \002(" +
-      "\014\022\022\n\nschemaName\030\002 \002(\014\022\021\n\ttableName\030\003 \002(\014" +
-      "\022\027\n\017clientTimestamp\030\004 \002(\003\022\025\n\rclientVersi" +
-      "on\030\005 \001(\005\"\035\n\033ClearTableFromCacheResponse*" +
-      "\365\004\n\014MutationCode\022\030\n\024TABLE_ALREADY_EXISTS" +
-      "\020\000\022\023\n\017TABLE_NOT_FOUND\020\001\022\024\n\020COLUMN_NOT_FO" +
-      "UND\020\002\022\031\n\025COLUMN_ALREADY_EXISTS\020\003\022\035\n\031CONC" +
-      "URRENT_TABLE_MUTATION\020\004\022\027\n\023TABLE_NOT_IN_" +
-      "REGION\020\005\022\025\n\021NEWER_TABLE_FOUND\020\006\022\034\n\030UNALL" +
-      "OWED_TABLE_MUTATION\020\007\022\021\n\rNO_PK_COLUMNS\020\010",
-      "\022\032\n\026PARENT_TABLE_NOT_FOUND\020\t\022\033\n\027FUNCTION" +
-      "_ALREADY_EXISTS\020\n\022\026\n\022FUNCTION_NOT_FOUND\020" +
-      "\013\022\030\n\024NEWER_FUNCTION_FOUND\020\014\022\032\n\026FUNCTION_" +
-      "NOT_IN_REGION\020\r\022\031\n\025SCHEMA_ALREADY_EXISTS" +
-      "\020\016\022\026\n\022NEWER_SCHEMA_FOUND\020\017\022\024\n\020SCHEMA_NOT" +
-      "_FOUND\020\020\022\030\n\024SCHEMA_NOT_IN_REGION\020\021\022\032\n\026TA" +
-      "BLES_EXIST_ON_SCHEMA\020\022\022\035\n\031UNALLOWED_SCHE" +
-      "MA_MUTATION\020\023\022%\n!AUTO_PARTITION_SEQUENCE" +
-      "_NOT_FOUND\020\024\022#\n\037CANNOT_COERCE_AUTO_PARTI" +
-      "TION_ID\020\025\022\024\n\020TOO_MANY_INDEXES\020\0262\345\006\n\017Meta",
-      "DataService\022/\n\010getTable\022\020.GetTableReques" +
-      "t\032\021.MetaDataResponse\0227\n\014getFunctions\022\024.G" +
-      "etFunctionsRequest\032\021.MetaDataResponse\0221\n" +
-      "\tgetSchema\022\021.GetSchemaRequest\032\021.MetaData" +
-      "Response\0225\n\013createTable\022\023.CreateTableReq" +
-      "uest\032\021.MetaDataResponse\022;\n\016createFunctio" +
-      "n\022\026.CreateFunctionRequest\032\021.MetaDataResp" +
-      "onse\0227\n\014createSchema\022\024.CreateSchemaReque" +
-      "st\032\021.MetaDataResponse\0221\n\tdropTable\022\021.Dro" +
-      "pTableRequest\032\021.MetaDataResponse\0223\n\ndrop",
-      "Schema\022\022.DropSchemaRequest\032\021.MetaDataRes" +
-      "ponse\0227\n\014dropFunction\022\024.DropFunctionRequ" +
-      "est\032\021.MetaDataResponse\0221\n\taddColumn\022\021.Ad" +
-      "dColumnRequest\032\021.MetaDataResponse\0223\n\ndro" +
-      "pColumn\022\022.DropColumnRequest\032\021.MetaDataRe" +
-      "sponse\022?\n\020updateIndexState\022\030.UpdateIndex" +
-      "StateRequest\032\021.MetaDataResponse\0225\n\nclear" +
-      "Cache\022\022.ClearCacheRequest\032\023.ClearCacheRe" +
-      "sponse\0225\n\ngetVersion\022\022.GetVersionRequest" +
-      "\032\023.GetVersionResponse\022P\n\023clearTableFromC",
-      "ache\022\033.ClearTableFromCacheRequest\032\034.Clea" +
-      "rTableFromCacheResponseBB\n(org.apache.ph" +
-      "oenix.coprocessor.generatedB\016MetaDataPro" +
-      "tosH\001\210\001\001\240\001\001"
+      "\013viewIndexId\030\006 \002(\003\022\032\n\022useLongViewIndexId" +
+      "\030\007 \001(\010\"\355\002\n\020MetaDataResponse\022!\n\nreturnCod" +
+      "e\030\001 \001(\0162\r.MutationCode\022\024\n\014mutationTime\030\002" +
+      " \001(\003\022\026\n\005table\030\003 \001(\0132\007.PTable\022\026\n\016tablesTo" +
+      "Delete\030\004 \003(\014\022\022\n\ncolumnName\030\005 \001(\014\022\022\n\nfami",
+      "lyName\030\006 \001(\014\022\024\n\014functionName\030\007 \001(\014\022\034\n\010fu" +
+      "nction\030\010 \003(\0132\n.PFunction\022/\n\024sharedTables" +
+      "ToDelete\030\t \003(\0132\021.SharedTableState\022\030\n\006sch" +
+      "ema\030\n \001(\0132\010.PSchema\022\030\n\020autoPartitionNum\030" +
+      "\013 \001(\003\022\023\n\013viewIndexId\030\014 \001(\003\022\032\n\022useLongVie" +
+      "wIndexId\030\r \001(\010\"\222\001\n\017GetTableRequest\022\020\n\010te" +
+      "nantId\030\001 \002(\014\022\022\n\nschemaName\030\002 \002(\014\022\021\n\ttabl" +
+      "eName\030\003 \002(\014\022\026\n\016tableTimestamp\030\004 \002(\003\022\027\n\017c" +
+      "lientTimestamp\030\005 \002(\003\022\025\n\rclientVersion\030\006 " +
+      "\001(\005\"\212\001\n\023GetFunctionsRequest\022\020\n\010tenantId\030",
+      "\001 \002(\014\022\025\n\rfunctionNames\030\002 \003(\014\022\032\n\022function" +
+      "Timestamps\030\003 \003(\003\022\027\n\017clientTimestamp\030\004 \002(" +
+      "\003\022\025\n\rclientVersion\030\005 \001(\005\"V\n\020GetSchemaReq" +
+      "uest\022\022\n\nschemaName\030\001 \002(\t\022\027\n\017clientTimest" +
+      "amp\030\002 \002(\003\022\025\n\rclientVersion\030\003 \002(\005\"d\n\022Crea" +
+      "teTableRequest\022\036\n\026tableMetadataMutations" +
+      "\030\001 \003(\014\022\025\n\rclientVersion\030\002 \001(\005\022\027\n\017allocat" +
+      "eIndexId\030\003 \001(\010\"r\n\025CreateFunctionRequest\022" +
+      "\036\n\026tableMetadataMutations\030\001 \003(\014\022\021\n\ttempo" +
+      "rary\030\002 \002(\010\022\017\n\007replace\030\003 \001(\010\022\025\n\rclientVer",
+      "sion\030\004 \001(\005\"`\n\023CreateSchemaRequest\022\036\n\026tab" +
+      "leMetadataMutations\030\001 \003(\014\022\022\n\nschemaName\030" +
+      "\002 \002(\t\022\025\n\rclientVersion\030\003 \002(\005\"m\n\020DropTabl" +
+      "eRequest\022\036\n\026tableMetadataMutations\030\001 \003(\014" +
+      "\022\021\n\ttableType\030\002 \002(\t\022\017\n\007cascade\030\003 \001(\010\022\025\n\r" +
+      "clientVersion\030\004 \001(\005\"_\n\021DropSchemaRequest" +
+      "\022\037\n\027schemaMetadataMutations\030\001 \003(\014\022\022\n\nsch" +
+      "emaName\030\002 \002(\t\022\025\n\rclientVersion\030\003 \002(\005\"I\n\020" +
+      "AddColumnRequest\022\036\n\026tableMetadataMutatio" +
+      "ns\030\001 \003(\014\022\025\n\rclientVersion\030\002 \001(\005\"J\n\021DropC",
+      "olumnRequest\022\036\n\026tableMetadataMutations\030\001" +
+      " \003(\014\022\025\n\rclientVersion\030\002 \001(\005\"^\n\023DropFunct" +
+      "ionRequest\022\036\n\026tableMetadataMutations\030\001 \003" +
+      "(\014\022\020\n\010ifExists\030\002 \001(\010\022\025\n\rclientVersion\030\003 " +
+      "\001(\005\"P\n\027UpdateIndexStateRequest\022\036\n\026tableM" +
+      "etadataMutations\030\001 \003(\014\022\025\n\rclientVersion\030" +
+      "\002 \001(\005\"*\n\021ClearCacheRequest\022\025\n\rclientVers" +
+      "ion\030\001 \001(\005\"*\n\022ClearCacheResponse\022\024\n\014unfre" +
+      "edBytes\030\001 \001(\003\"*\n\021GetVersionRequest\022\025\n\rcl" +
+      "ientVersion\030\001 \001(\005\"E\n\022GetVersionResponse\022",
+      "\017\n\007version\030\001 \002(\003\022\036\n\026systemCatalogTimesta" +
+      "mp\030\002 \001(\003\"\205\001\n\032ClearTableFromCacheRequest\022" +
+      "\020\n\010tenantId\030\001 \002(\014\022\022\n\nschemaName\030\002 \002(\014\022\021\n" +
+      "\ttableName\030\003 \002(\014\022\027\n\017clientTimestamp\030\004 \002(" +
+      "\003\022\025\n\rclientVersion\030\005 \001(\005\"\035\n\033ClearTableFr" +
+      "omCacheResponse*\365\004\n\014MutationCode\022\030\n\024TABL" +
+      "E_ALREADY_EXISTS\020\000\022\023\n\017TABLE_NOT_FOUND\020\001\022" +
+      "\024\n\020COLUMN_NOT_FOUND\020\002\022\031\n\025COLUMN_ALREADY_" +
+      "EXISTS\020\003\022\035\n\031CONCURRENT_TABLE_MUTATION\020\004\022" +
+      "\027\n\023TABLE_NOT_IN_REGION\020\005\022\025\n\021NEWER_TABLE_",
+      "FOUND\020\006\022\034\n\030UNALLOWED_TABLE_MUTATION\020\007\022\021\n" +
+      "\rNO_PK_COLUMNS\020\010\022\032\n\026PARENT_TABLE_NOT_FOU" +
+      "ND\020\t\022\033\n\027FUNCTION_ALREADY_EXISTS\020\n\022\026\n\022FUN" +
+      "CTION_NOT_FOUND\020\013\022\030\n\024NEWER_FUNCTION_FOUN" +
+      "D\020\014\022\032\n\026FUNCTION_NOT_IN_REGION\020\r\022\031\n\025SCHEM" +
+      "A_ALREADY_EXISTS\020\016\022\026\n\022NEWER_SCHEMA_FOUND" +
+      "\020\017\022\024\n\020SCHEMA_NOT_FOUND\020\020\022\030\n\024SCHEMA_NOT_I" +
+      "N_REGION\020\021\022\032\n\026TABLES_EXIST_ON_SCHEMA\020\022\022\035" +
+      "\n\031UNALLOWED_SCHEMA_MUTATION\020\023\022%\n!AUTO_PA" +
+      "RTITION_SEQUENCE_NOT_FOUND\020\024\022#\n\037CANNOT_C",
+      "OERCE_AUTO_PARTITION_ID\020\025\022\024\n\020TOO_MANY_IN" +
+      "DEXES\020\0262\345\006\n\017MetaDataService\022/\n\010getTable\022" +
+      "\020.GetTableRequest\032\021.MetaDataResponse\0227\n\014" +
+      "getFunctions\022\024.GetFunctionsRequest\032\021.Met" +
+      "aDataResponse\0221\n\tgetSchema\022\021.GetSchemaRe" +
+      "quest\032\021.MetaDataResponse\0225\n\013createTable\022" +
+      "\023.CreateTableRequest\032\021.MetaDataResponse\022" +
+      ";\n\016createFunction\022\026.CreateFunctionReques" +
+      "t\032\021.MetaDataResponse\0227\n\014createSchema\022\024.C" +
+      "reateSchemaRequest\032\021.MetaDataResponse\0221\n",
+      "\tdropTable\022\021.DropTableRequest\032\021.MetaData" +
+      "Response\0223\n\ndropSchema\022\022.DropSchemaReque" +
+      "st\032\021.MetaDataResponse\0227\n\014dropFunction\022\024." +
+      "DropFunctionRequest\032\021.MetaDataResponse\0221" +
+      "\n\taddColumn\022\021.AddColumnRequest\032\021.MetaDat" +
+      "aResponse\0223\n\ndropColumn\022\022.DropColumnRequ" +
+      "est\032\021.MetaDataResponse\022?\n\020updateIndexSta" +
+      "te\022\030.UpdateIndexStateRequest\032\021.MetaDataR" +
+      "esponse\0225\n\nclearCache\022\022.ClearCacheReques" +
+      "t\032\023.ClearCacheResponse\0225\n\ngetVersion\022\022.G",
+      "etVersionRequest\032\023.GetVersionResponse\022P\n" +
+      "\023clearTableFromCache\022\033.ClearTableFromCac" +
+      "heRequest\032\034.ClearTableFromCacheResponseB" +
+      "B\n(org.apache.phoenix.coprocessor.genera" +
+      "tedB\016MetaDataProtosH\001\210\001\001\240\001\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -17250,13 +17431,13 @@ public final class MetaDataProtos {
           internal_static_SharedTableState_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_SharedTableState_descriptor,
-              new java.lang.String[] { "TenantId", "SchemaName", "TableName", "Columns", "PhysicalNames", "ViewIndexId", });
+              new java.lang.String[] { "TenantId", "SchemaName", "TableName", "Columns", "PhysicalNames", "ViewIndexId", "UseLongViewIndexId", });
           internal_static_MetaDataResponse_descriptor =
             getDescriptor().getMessageTypes().get(1);
           internal_static_MetaDataResponse_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_MetaDataResponse_descriptor,
-              new java.lang.String[] { "ReturnCode", "MutationTime", "Table", "TablesToDelete", "ColumnName", "FamilyName", "FunctionName", "Function", "SharedTablesToDelete", "Schema", "AutoPartitionNum", "ViewIndexId", });
+              new java.lang.String[] { "ReturnCode", "MutationTime", "Table", "TablesToDelete", "ColumnName", "FamilyName", "FunctionName", "Function", "SharedTablesToDelete", "Schema", "AutoPartitionNum", "ViewIndexId", "UseLongViewIndexId", });
           internal_static_GetTableRequest_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_GetTableRequest_fieldAccessorTable = new

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/PTableProtos.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/PTableProtos.java
@@ -3331,15 +3331,15 @@ public final class PTableProtos {
      */
     com.google.protobuf.ByteString getTenantId();
 
-    // optional int32 viewIndexId = 21;
+    // optional int64 viewIndexId = 21;
     /**
-     * <code>optional int32 viewIndexId = 21;</code>
+     * <code>optional int64 viewIndexId = 21;</code>
      */
     boolean hasViewIndexId();
     /**
-     * <code>optional int32 viewIndexId = 21;</code>
+     * <code>optional int64 viewIndexId = 21;</code>
      */
-    int getViewIndexId();
+    long getViewIndexId();
 
     // optional bytes indexType = 22;
     /**
@@ -3530,6 +3530,16 @@ public final class PTableProtos {
      * <code>optional int32 transactionProvider = 38;</code>
      */
     int getTransactionProvider();
+
+    // optional bool useLongViewIndexId = 39;
+    /**
+     * <code>optional bool useLongViewIndexId = 39;</code>
+     */
+    boolean hasUseLongViewIndexId();
+    /**
+     * <code>optional bool useLongViewIndexId = 39;</code>
+     */
+    boolean getUseLongViewIndexId();
   }
   /**
    * Protobuf type {@code PTable}
@@ -3695,7 +3705,7 @@ public final class PTableProtos {
             }
             case 168: {
               bitField0_ |= 0x00010000;
-              viewIndexId_ = input.readInt32();
+              viewIndexId_ = input.readInt64();
               break;
             }
             case 178: {
@@ -3784,6 +3794,11 @@ public final class PTableProtos {
             case 304: {
               bitField1_ |= 0x00000001;
               transactionProvider_ = input.readInt32();
+              break;
+            }
+            case 312: {
+              bitField1_ |= 0x00000002;
+              useLongViewIndexId_ = input.readBool();
               break;
             }
           }
@@ -4231,19 +4246,19 @@ public final class PTableProtos {
       return tenantId_;
     }
 
-    // optional int32 viewIndexId = 21;
+    // optional int64 viewIndexId = 21;
     public static final int VIEWINDEXID_FIELD_NUMBER = 21;
-    private int viewIndexId_;
+    private long viewIndexId_;
     /**
-     * <code>optional int32 viewIndexId = 21;</code>
+     * <code>optional int64 viewIndexId = 21;</code>
      */
     public boolean hasViewIndexId() {
       return ((bitField0_ & 0x00010000) == 0x00010000);
     }
     /**
-     * <code>optional int32 viewIndexId = 21;</code>
+     * <code>optional int64 viewIndexId = 21;</code>
      */
-    public int getViewIndexId() {
+    public long getViewIndexId() {
       return viewIndexId_;
     }
 
@@ -4566,6 +4581,22 @@ public final class PTableProtos {
       return transactionProvider_;
     }
 
+    // optional bool useLongViewIndexId = 39;
+    public static final int USELONGVIEWINDEXID_FIELD_NUMBER = 39;
+    private boolean useLongViewIndexId_;
+    /**
+     * <code>optional bool useLongViewIndexId = 39;</code>
+     */
+    public boolean hasUseLongViewIndexId() {
+      return ((bitField1_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional bool useLongViewIndexId = 39;</code>
+     */
+    public boolean getUseLongViewIndexId() {
+      return useLongViewIndexId_;
+    }
+
     private void initFields() {
       schemaNameBytes_ = com.google.protobuf.ByteString.EMPTY;
       tableNameBytes_ = com.google.protobuf.ByteString.EMPTY;
@@ -4586,7 +4617,7 @@ public final class PTableProtos {
       viewStatement_ = com.google.protobuf.ByteString.EMPTY;
       physicalNames_ = java.util.Collections.emptyList();
       tenantId_ = com.google.protobuf.ByteString.EMPTY;
-      viewIndexId_ = 0;
+      viewIndexId_ = 0L;
       indexType_ = com.google.protobuf.ByteString.EMPTY;
       statsTimeStamp_ = 0L;
       storeNulls_ = false;
@@ -4604,6 +4635,7 @@ public final class PTableProtos {
       encodedCQCounters_ = java.util.Collections.emptyList();
       useStatsForParallelization_ = false;
       transactionProvider_ = 0;
+      useLongViewIndexId_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4729,7 +4761,7 @@ public final class PTableProtos {
         output.writeBytes(20, tenantId_);
       }
       if (((bitField0_ & 0x00010000) == 0x00010000)) {
-        output.writeInt32(21, viewIndexId_);
+        output.writeInt64(21, viewIndexId_);
       }
       if (((bitField0_ & 0x00020000) == 0x00020000)) {
         output.writeBytes(22, indexType_);
@@ -4781,6 +4813,9 @@ public final class PTableProtos {
       }
       if (((bitField1_ & 0x00000001) == 0x00000001)) {
         output.writeInt32(38, transactionProvider_);
+      }
+      if (((bitField1_ & 0x00000002) == 0x00000002)) {
+        output.writeBool(39, useLongViewIndexId_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -4874,7 +4909,7 @@ public final class PTableProtos {
       }
       if (((bitField0_ & 0x00010000) == 0x00010000)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(21, viewIndexId_);
+          .computeInt64Size(21, viewIndexId_);
       }
       if (((bitField0_ & 0x00020000) == 0x00020000)) {
         size += com.google.protobuf.CodedOutputStream
@@ -4943,6 +4978,10 @@ public final class PTableProtos {
       if (((bitField1_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(38, transactionProvider_);
+      }
+      if (((bitField1_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(39, useLongViewIndexId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -5140,6 +5179,11 @@ public final class PTableProtos {
         result = result && (getTransactionProvider()
             == other.getTransactionProvider());
       }
+      result = result && (hasUseLongViewIndexId() == other.hasUseLongViewIndexId());
+      if (hasUseLongViewIndexId()) {
+        result = result && (getUseLongViewIndexId()
+            == other.getUseLongViewIndexId());
+      }
       result = result &&
           getUnknownFields().equals(other.getUnknownFields());
       return result;
@@ -5231,7 +5275,7 @@ public final class PTableProtos {
       }
       if (hasViewIndexId()) {
         hash = (37 * hash) + VIEWINDEXID_FIELD_NUMBER;
-        hash = (53 * hash) + getViewIndexId();
+        hash = (53 * hash) + hashLong(getViewIndexId());
       }
       if (hasIndexType()) {
         hash = (37 * hash) + INDEXTYPE_FIELD_NUMBER;
@@ -5300,6 +5344,10 @@ public final class PTableProtos {
       if (hasTransactionProvider()) {
         hash = (37 * hash) + TRANSACTIONPROVIDER_FIELD_NUMBER;
         hash = (53 * hash) + getTransactionProvider();
+      }
+      if (hasUseLongViewIndexId()) {
+        hash = (37 * hash) + USELONGVIEWINDEXID_FIELD_NUMBER;
+        hash = (53 * hash) + hashBoolean(getUseLongViewIndexId());
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -5459,7 +5507,7 @@ public final class PTableProtos {
         bitField0_ = (bitField0_ & ~0x00020000);
         tenantId_ = com.google.protobuf.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00040000);
-        viewIndexId_ = 0;
+        viewIndexId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00080000);
         indexType_ = com.google.protobuf.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00100000);
@@ -5499,6 +5547,8 @@ public final class PTableProtos {
         bitField1_ = (bitField1_ & ~0x00000008);
         transactionProvider_ = 0;
         bitField1_ = (bitField1_ & ~0x00000010);
+        useLongViewIndexId_ = false;
+        bitField1_ = (bitField1_ & ~0x00000020);
         return this;
       }
 
@@ -5693,6 +5743,10 @@ public final class PTableProtos {
           to_bitField1_ |= 0x00000001;
         }
         result.transactionProvider_ = transactionProvider_;
+        if (((from_bitField1_ & 0x00000020) == 0x00000020)) {
+          to_bitField1_ |= 0x00000002;
+        }
+        result.useLongViewIndexId_ = useLongViewIndexId_;
         result.bitField0_ = to_bitField0_;
         result.bitField1_ = to_bitField1_;
         onBuilt();
@@ -5900,6 +5954,9 @@ public final class PTableProtos {
         }
         if (other.hasTransactionProvider()) {
           setTransactionProvider(other.getTransactionProvider());
+        }
+        if (other.hasUseLongViewIndexId()) {
+          setUseLongViewIndexId(other.getUseLongViewIndexId());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -7159,35 +7216,35 @@ public final class PTableProtos {
         return this;
       }
 
-      // optional int32 viewIndexId = 21;
-      private int viewIndexId_ ;
+      // optional int64 viewIndexId = 21;
+      private long viewIndexId_ ;
       /**
-       * <code>optional int32 viewIndexId = 21;</code>
+       * <code>optional int64 viewIndexId = 21;</code>
        */
       public boolean hasViewIndexId() {
         return ((bitField0_ & 0x00080000) == 0x00080000);
       }
       /**
-       * <code>optional int32 viewIndexId = 21;</code>
+       * <code>optional int64 viewIndexId = 21;</code>
        */
-      public int getViewIndexId() {
+      public long getViewIndexId() {
         return viewIndexId_;
       }
       /**
-       * <code>optional int32 viewIndexId = 21;</code>
+       * <code>optional int64 viewIndexId = 21;</code>
        */
-      public Builder setViewIndexId(int value) {
+      public Builder setViewIndexId(long value) {
         bitField0_ |= 0x00080000;
         viewIndexId_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int32 viewIndexId = 21;</code>
+       * <code>optional int64 viewIndexId = 21;</code>
        */
       public Builder clearViewIndexId() {
         bitField0_ = (bitField0_ & ~0x00080000);
-        viewIndexId_ = 0;
+        viewIndexId_ = 0L;
         onChanged();
         return this;
       }
@@ -8013,6 +8070,39 @@ public final class PTableProtos {
         return this;
       }
 
+      // optional bool useLongViewIndexId = 39;
+      private boolean useLongViewIndexId_ ;
+      /**
+       * <code>optional bool useLongViewIndexId = 39;</code>
+       */
+      public boolean hasUseLongViewIndexId() {
+        return ((bitField1_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 39;</code>
+       */
+      public boolean getUseLongViewIndexId() {
+        return useLongViewIndexId_;
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 39;</code>
+       */
+      public Builder setUseLongViewIndexId(boolean value) {
+        bitField1_ |= 0x00000020;
+        useLongViewIndexId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool useLongViewIndexId = 39;</code>
+       */
+      public Builder clearUseLongViewIndexId() {
+        bitField1_ = (bitField1_ & ~0x00000020);
+        useLongViewIndexId_ = false;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:PTable)
     }
 
@@ -8680,7 +8770,7 @@ public final class PTableProtos {
       "\"\232\001\n\013PTableStats\022\013\n\003key\030\001 \002(\014\022\016\n\006values\030",
       "\002 \003(\014\022\033\n\023guidePostsByteCount\030\003 \001(\003\022\025\n\rke" +
       "yBytesCount\030\004 \001(\003\022\027\n\017guidePostsCount\030\005 \001" +
-      "(\005\022!\n\013pGuidePosts\030\006 \001(\0132\014.PGuidePosts\"\255\007" +
+      "(\005\022!\n\013pGuidePosts\030\006 \001(\0132\014.PGuidePosts\"\311\007" +
       "\n\006PTable\022\027\n\017schemaNameBytes\030\001 \002(\014\022\026\n\016tab" +
       "leNameBytes\030\002 \002(\014\022\036\n\ttableType\030\003 \002(\0162\013.P" +
       "TableType\022\022\n\nindexState\030\004 \001(\t\022\026\n\016sequenc" +
@@ -8692,7 +8782,7 @@ public final class PTableProtos {
       "\016 \001(\014\022\022\n\ndisableWAL\030\017 \002(\010\022\023\n\013multiTenant" +
       "\030\020 \002(\010\022\020\n\010viewType\030\021 \001(\014\022\025\n\rviewStatemen" +
       "t\030\022 \001(\014\022\025\n\rphysicalNames\030\023 \003(\014\022\020\n\010tenant" +
-      "Id\030\024 \001(\014\022\023\n\013viewIndexId\030\025 \001(\005\022\021\n\tindexTy" +
+      "Id\030\024 \001(\014\022\023\n\013viewIndexId\030\025 \001(\003\022\021\n\tindexTy" +
       "pe\030\026 \001(\014\022\026\n\016statsTimeStamp\030\027 \001(\003\022\022\n\nstor" +
       "eNulls\030\030 \001(\010\022\027\n\017baseColumnCount\030\031 \001(\005\022\036\n" +
       "\026rowKeyOrderOptimizable\030\032 \001(\010\022\025\n\rtransac" +
@@ -8704,12 +8794,12 @@ public final class PTableProtos {
       "\030\" \001(\014\022\026\n\016encodingScheme\030# \001(\014\022,\n\021encode" +
       "dCQCounters\030$ \003(\0132\021.EncodedCQCounter\022\"\n\032" +
       "useStatsForParallelization\030% \001(\010\022\033\n\023tran" +
-      "sactionProvider\030& \001(\005\"6\n\020EncodedCQCounte" +
-      "r\022\021\n\tcolFamily\030\001 \002(\t\022\017\n\007counter\030\002 \002(\005*A\n" +
-      "\nPTableType\022\n\n\006SYSTEM\020\000\022\010\n\004USER\020\001\022\010\n\004VIE" +
-      "W\020\002\022\t\n\005INDEX\020\003\022\010\n\004JOIN\020\004B@\n(org.apache.p",
-      "hoenix.coprocessor.generatedB\014PTableProt" +
-      "osH\001\210\001\001\240\001\001"
+      "sactionProvider\030& \001(\005\022\032\n\022useLongViewInde" +
+      "xId\030\' \001(\010\"6\n\020EncodedCQCounter\022\021\n\tcolFami" +
+      "ly\030\001 \002(\t\022\017\n\007counter\030\002 \002(\005*A\n\nPTableType\022" +
+      "\n\n\006SYSTEM\020\000\022\010\n\004USER\020\001\022\010\n\004VIEW\020\002\022\t\n\005INDEX",
+      "\020\003\022\010\n\004JOIN\020\004B@\n(org.apache.phoenix.copro" +
+      "cessor.generatedB\014PTableProtosH\001\210\001\001\240\001\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -8733,7 +8823,7 @@ public final class PTableProtos {
           internal_static_PTable_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_PTable_descriptor,
-              new java.lang.String[] { "SchemaNameBytes", "TableNameBytes", "TableType", "IndexState", "SequenceNumber", "TimeStamp", "PkNameBytes", "BucketNum", "Columns", "Indexes", "IsImmutableRows", "DataTableNameBytes", "DefaultFamilyName", "DisableWAL", "MultiTenant", "ViewType", "ViewStatement", "PhysicalNames", "TenantId", "ViewIndexId", "IndexType", "StatsTimeStamp", "StoreNulls", "BaseColumnCount", "RowKeyOrderOptimizable", "Transactional", "UpdateCacheFrequency", "IndexDisableTimestamp", "IsNamespaceMapped", "AutoParititonSeqName", "IsAppendOnlySchema", "ParentNameBytes", "StorageScheme", "EncodingScheme", "EncodedCQCounters", "UseStatsForParallelization", "TransactionProvider", });
+              new java.lang.String[] { "SchemaNameBytes", "TableNameBytes", "TableType", "IndexState", "SequenceNumber", "TimeStamp", "PkNameBytes", "BucketNum", "Columns", "Indexes", "IsImmutableRows", "DataTableNameBytes", "DefaultFamilyName", "DisableWAL", "MultiTenant", "ViewType", "ViewStatement", "PhysicalNames", "TenantId", "ViewIndexId", "IndexType", "StatsTimeStamp", "StoreNulls", "BaseColumnCount", "RowKeyOrderOptimizable", "Transactional", "UpdateCacheFrequency", "IndexDisableTimestamp", "IsNamespaceMapped", "AutoParititonSeqName", "IsAppendOnlySchema", "ParentNameBytes", "StorageScheme", "EncodingScheme", "EncodedCQCounters", "UseStatsForParallelization", "TransactionProvider", "UseLongViewIndexId", });
           internal_static_EncodedCQCounter_descriptor =
             getDescriptor().getMessageTypes().get(3);
           internal_static_EncodedCQCounter_fieldAccessorTable = new

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/ServerCachingProtos.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/ServerCachingProtos.java
@@ -2157,6 +2157,16 @@ public final class ServerCachingProtos {
      * <code>required int32 immutableStorageScheme = 21;</code>
      */
     int getImmutableStorageScheme();
+
+    // optional bool useLongViewIndex = 22;
+    /**
+     * <code>optional bool useLongViewIndex = 22;</code>
+     */
+    boolean hasUseLongViewIndex();
+    /**
+     * <code>optional bool useLongViewIndex = 22;</code>
+     */
+    boolean getUseLongViewIndex();
   }
   /**
    * Protobuf type {@code IndexMaintainer}
@@ -2348,6 +2358,11 @@ public final class ServerCachingProtos {
             case 168: {
               bitField0_ |= 0x00008000;
               immutableStorageScheme_ = input.readInt32();
+              break;
+            }
+            case 176: {
+              bitField0_ |= 0x00010000;
+              useLongViewIndex_ = input.readBool();
               break;
             }
           }
@@ -2834,6 +2849,22 @@ public final class ServerCachingProtos {
       return immutableStorageScheme_;
     }
 
+    // optional bool useLongViewIndex = 22;
+    public static final int USELONGVIEWINDEX_FIELD_NUMBER = 22;
+    private boolean useLongViewIndex_;
+    /**
+     * <code>optional bool useLongViewIndex = 22;</code>
+     */
+    public boolean hasUseLongViewIndex() {
+      return ((bitField0_ & 0x00010000) == 0x00010000);
+    }
+    /**
+     * <code>optional bool useLongViewIndex = 22;</code>
+     */
+    public boolean getUseLongViewIndex() {
+      return useLongViewIndex_;
+    }
+
     private void initFields() {
       saltBuckets_ = 0;
       isMultiTenant_ = false;
@@ -2856,6 +2887,7 @@ public final class ServerCachingProtos {
       indexedColumnInfo_ = java.util.Collections.emptyList();
       encodingScheme_ = 0;
       immutableStorageScheme_ = 0;
+      useLongViewIndex_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3016,6 +3048,9 @@ public final class ServerCachingProtos {
       if (((bitField0_ & 0x00008000) == 0x00008000)) {
         output.writeInt32(21, immutableStorageScheme_);
       }
+      if (((bitField0_ & 0x00010000) == 0x00010000)) {
+        output.writeBool(22, useLongViewIndex_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -3113,6 +3148,10 @@ public final class ServerCachingProtos {
       if (((bitField0_ & 0x00008000) == 0x00008000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(21, immutableStorageScheme_);
+      }
+      if (((bitField0_ & 0x00010000) == 0x00010000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(22, useLongViewIndex_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -3227,6 +3266,11 @@ public final class ServerCachingProtos {
         result = result && (getImmutableStorageScheme()
             == other.getImmutableStorageScheme());
       }
+      result = result && (hasUseLongViewIndex() == other.hasUseLongViewIndex());
+      if (hasUseLongViewIndex()) {
+        result = result && (getUseLongViewIndex()
+            == other.getUseLongViewIndex());
+      }
       result = result &&
           getUnknownFields().equals(other.getUnknownFields());
       return result;
@@ -3323,6 +3367,10 @@ public final class ServerCachingProtos {
       if (hasImmutableStorageScheme()) {
         hash = (37 * hash) + IMMUTABLESTORAGESCHEME_FIELD_NUMBER;
         hash = (53 * hash) + getImmutableStorageScheme();
+      }
+      if (hasUseLongViewIndex()) {
+        hash = (37 * hash) + USELONGVIEWINDEX_FIELD_NUMBER;
+        hash = (53 * hash) + hashBoolean(getUseLongViewIndex());
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -3500,6 +3548,8 @@ public final class ServerCachingProtos {
         bitField0_ = (bitField0_ & ~0x00080000);
         immutableStorageScheme_ = 0;
         bitField0_ = (bitField0_ & ~0x00100000);
+        useLongViewIndex_ = false;
+        bitField0_ = (bitField0_ & ~0x00200000);
         return this;
       }
 
@@ -3637,6 +3687,10 @@ public final class ServerCachingProtos {
           to_bitField0_ |= 0x00008000;
         }
         result.immutableStorageScheme_ = immutableStorageScheme_;
+        if (((from_bitField0_ & 0x00200000) == 0x00200000)) {
+          to_bitField0_ |= 0x00010000;
+        }
+        result.useLongViewIndex_ = useLongViewIndex_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3814,6 +3868,9 @@ public final class ServerCachingProtos {
         }
         if (other.hasImmutableStorageScheme()) {
           setImmutableStorageScheme(other.getImmutableStorageScheme());
+        }
+        if (other.hasUseLongViewIndex()) {
+          setUseLongViewIndex(other.getUseLongViewIndex());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -5575,6 +5632,39 @@ public final class ServerCachingProtos {
       public Builder clearImmutableStorageScheme() {
         bitField0_ = (bitField0_ & ~0x00100000);
         immutableStorageScheme_ = 0;
+        onChanged();
+        return this;
+      }
+
+      // optional bool useLongViewIndex = 22;
+      private boolean useLongViewIndex_ ;
+      /**
+       * <code>optional bool useLongViewIndex = 22;</code>
+       */
+      public boolean hasUseLongViewIndex() {
+        return ((bitField0_ & 0x00200000) == 0x00200000);
+      }
+      /**
+       * <code>optional bool useLongViewIndex = 22;</code>
+       */
+      public boolean getUseLongViewIndex() {
+        return useLongViewIndex_;
+      }
+      /**
+       * <code>optional bool useLongViewIndex = 22;</code>
+       */
+      public Builder setUseLongViewIndex(boolean value) {
+        bitField0_ |= 0x00200000;
+        useLongViewIndex_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool useLongViewIndex = 22;</code>
+       */
+      public Builder clearUseLongViewIndex() {
+        bitField0_ = (bitField0_ & ~0x00200000);
+        useLongViewIndex_ = false;
         onChanged();
         return this;
       }
@@ -8615,7 +8705,7 @@ public final class ServerCachingProtos {
       "ength\030\003 \002(\005\"4\n\017ColumnReference\022\016\n\006family" +
       "\030\001 \002(\014\022\021\n\tqualifier\030\002 \002(\014\"4\n\nColumnInfo\022" +
       "\022\n\nfamilyName\030\001 \001(\t\022\022\n\ncolumnName\030\002 \002(\t\"" +
-      "\306\005\n\017IndexMaintainer\022\023\n\013saltBuckets\030\001 \002(\005" +
+      "\340\005\n\017IndexMaintainer\022\023\n\013saltBuckets\030\001 \002(\005" +
       "\022\025\n\risMultiTenant\030\002 \002(\010\022\023\n\013viewIndexId\030\003" +
       " \001(\014\022(\n\016indexedColumns\030\004 \003(\0132\020.ColumnRef" +
       "erence\022 \n\030indexedColumnTypeOrdinal\030\005 \003(\005",
@@ -8632,23 +8722,23 @@ public final class ServerCachingProtos {
       "ed\030\020 \002(\010\022\033\n\023indexRowKeyByteSize\030\021 \002(\005\022\021\n" +
       "\timmutable\030\022 \002(\010\022&\n\021indexedColumnInfo\030\023 " +
       "\003(\0132\013.ColumnInfo\022\026\n\016encodingScheme\030\024 \002(\005" +
-      "\022\036\n\026immutableStorageScheme\030\025 \002(\005\"\334\001\n\025Add" +
-      "ServerCacheRequest\022\020\n\010tenantId\030\001 \001(\014\022\017\n\007" +
-      "cacheId\030\002 \002(\014\022)\n\010cachePtr\030\003 \002(\0132\027.Immuta" +
-      "bleBytesWritable\022)\n\014cacheFactory\030\004 \002(\0132\023" +
-      ".ServerCacheFactory\022\017\n\007txState\030\005 \001(\014\022\"\n\032" +
-      "hasProtoBufIndexMaintainer\030\006 \001(\010\022\025\n\rclie" +
-      "ntVersion\030\007 \001(\005\"(\n\026AddServerCacheRespons",
-      "e\022\016\n\006return\030\001 \002(\010\"=\n\030RemoveServerCacheRe" +
-      "quest\022\020\n\010tenantId\030\001 \001(\014\022\017\n\007cacheId\030\002 \002(\014" +
-      "\"+\n\031RemoveServerCacheResponse\022\016\n\006return\030" +
-      "\001 \002(\0102\245\001\n\024ServerCachingService\022A\n\016addSer" +
-      "verCache\022\026.AddServerCacheRequest\032\027.AddSe" +
-      "rverCacheResponse\022J\n\021removeServerCache\022\031" +
-      ".RemoveServerCacheRequest\032\032.RemoveServer" +
-      "CacheResponseBG\n(org.apache.phoenix.copr" +
-      "ocessor.generatedB\023ServerCachingProtosH\001" +
-      "\210\001\001\240\001\001"
+      "\022\036\n\026immutableStorageScheme\030\025 \002(\005\022\030\n\020useL" +
+      "ongViewIndex\030\026 \001(\010\"\334\001\n\025AddServerCacheReq" +
+      "uest\022\020\n\010tenantId\030\001 \001(\014\022\017\n\007cacheId\030\002 \002(\014\022" +
+      ")\n\010cachePtr\030\003 \002(\0132\027.ImmutableBytesWritab" +
+      "le\022)\n\014cacheFactory\030\004 \002(\0132\023.ServerCacheFa" +
+      "ctory\022\017\n\007txState\030\005 \001(\014\022\"\n\032hasProtoBufInd" +
+      "exMaintainer\030\006 \001(\010\022\025\n\rclientVersion\030\007 \001(",
+      "\005\"(\n\026AddServerCacheResponse\022\016\n\006return\030\001 " +
+      "\002(\010\"=\n\030RemoveServerCacheRequest\022\020\n\010tenan" +
+      "tId\030\001 \001(\014\022\017\n\007cacheId\030\002 \002(\014\"+\n\031RemoveServ" +
+      "erCacheResponse\022\016\n\006return\030\001 \002(\0102\245\001\n\024Serv" +
+      "erCachingService\022A\n\016addServerCache\022\026.Add" +
+      "ServerCacheRequest\032\027.AddServerCacheRespo" +
+      "nse\022J\n\021removeServerCache\022\031.RemoveServerC" +
+      "acheRequest\032\032.RemoveServerCacheResponseB" +
+      "G\n(org.apache.phoenix.coprocessor.genera" +
+      "tedB\023ServerCachingProtosH\001\210\001\001\240\001\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -8678,7 +8768,7 @@ public final class ServerCachingProtos {
           internal_static_IndexMaintainer_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_IndexMaintainer_descriptor,
-              new java.lang.String[] { "SaltBuckets", "IsMultiTenant", "ViewIndexId", "IndexedColumns", "IndexedColumnTypeOrdinal", "DataTableColRefForCoveredColumns", "IndexTableColRefForCoveredColumns", "IsLocalIndex", "IndexTableName", "RowKeyOrderOptimizable", "DataTableEmptyKeyValueColFamily", "EmptyKeyValueColFamily", "IndexedExpressions", "RowKeyMetadata", "NumDataTableColFamilies", "IndexWalDisabled", "IndexRowKeyByteSize", "Immutable", "IndexedColumnInfo", "EncodingScheme", "ImmutableStorageScheme", });
+              new java.lang.String[] { "SaltBuckets", "IsMultiTenant", "ViewIndexId", "IndexedColumns", "IndexedColumnTypeOrdinal", "DataTableColRefForCoveredColumns", "IndexTableColRefForCoveredColumns", "IsLocalIndex", "IndexTableName", "RowKeyOrderOptimizable", "DataTableEmptyKeyValueColFamily", "EmptyKeyValueColFamily", "IndexedExpressions", "RowKeyMetadata", "NumDataTableColFamilies", "IndexWalDisabled", "IndexRowKeyByteSize", "Immutable", "IndexedColumnInfo", "EncodingScheme", "ImmutableStorageScheme", "UseLongViewIndex", });
           internal_static_AddServerCacheRequest_descriptor =
             getDescriptor().getMessageTypes().get(4);
           internal_static_AddServerCacheRequest_fieldAccessorTable = new

--- a/phoenix-core/src/main/java/org/apache/phoenix/index/PhoenixIndexFailurePolicy.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/index/PhoenixIndexFailurePolicy.java
@@ -312,7 +312,7 @@ public class PhoenixIndexFailurePolicy extends DelegateIndexFailurePolicy {
                     new HashMap<ImmutableBytesWritable, String>();
             for (PTable index : indexes) {
                 if (localIndex == null) localIndex = index;
-                localIndexNames.put(new ImmutableBytesWritable(MetaDataUtil.getViewIndexIdDataType().toBytes(
+                localIndexNames.put(new ImmutableBytesWritable(index.getViewIndexType().toBytes(
                         index.getViewIndexId())), index.getName().getString());
             }
             if (localIndex == null) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixDatabaseMetaData.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixDatabaseMetaData.java
@@ -206,6 +206,8 @@ public class PhoenixDatabaseMetaData implements DatabaseMetaData {
     public static final byte[] IS_VIEW_REFERENCED_BYTES = Bytes.toBytes(IS_VIEW_REFERENCED);
     public static final String VIEW_INDEX_ID = "VIEW_INDEX_ID";
     public static final byte[] VIEW_INDEX_ID_BYTES = Bytes.toBytes(VIEW_INDEX_ID);
+    public static final String USE_LONG_VIEW_INDEX = "USE_LONG_VIEW_INDEX";
+    public static final byte[] USE_LONG_VIEW_INDEX_BYTES = Bytes.toBytes(USE_LONG_VIEW_INDEX);
     public static final String BASE_COLUMN_COUNT = "BASE_COLUMN_COUNT";
     public static final byte[] BASE_COLUMN_COUNT_BYTES = Bytes.toBytes(BASE_COLUMN_COUNT);
     public static final String IS_ROW_TIMESTAMP = "IS_ROW_TIMESTAMP";

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionlessQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionlessQueryServicesImpl.java
@@ -289,7 +289,7 @@ public class ConnectionlessQueryServicesImpl extends DelegateQueryServices imple
         if (!allocateIndexId) {
             return new MetaDataMutationResult(MutationCode.TABLE_NOT_FOUND, 0, null);
         } else {
-            return new MetaDataMutationResult(MutationCode.TABLE_NOT_FOUND, 0, null, Short.MIN_VALUE);
+            return new MetaDataMutationResult(MutationCode.TABLE_NOT_FOUND, 0, null, Long.MIN_VALUE, MetaDataUtil.getViewIndexIdDataType());
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryConstants.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryConstants.java
@@ -191,7 +191,8 @@ public interface QueryConstants {
             DISABLE_WAL + " BOOLEAN,\n" +
             MULTI_TENANT + " BOOLEAN,\n" +
             VIEW_TYPE + " UNSIGNED_TINYINT,\n" +
-            VIEW_INDEX_ID + " SMALLINT,\n" +
+            VIEW_INDEX_ID + " BIGINT,\n" +
+            USE_LONG_VIEW_INDEX + " BOOLEAN,\n" +
             // Column metadata (will be null for table row)
             DATA_TYPE + " INTEGER," +
             COLUMN_SIZE + " INTEGER," +

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/DelegateTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/DelegateTable.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.phoenix.hbase.index.util.KeyValueBuilder;
 import org.apache.phoenix.index.IndexMaintainer;
 import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.transaction.TransactionFactory;
 
 public class DelegateTable implements PTable {
@@ -207,8 +208,13 @@ public class DelegateTable implements PTable {
     }
 
     @Override
-    public Short getViewIndexId() {
+    public Long getViewIndexId() {
         return delegate.getViewIndexId();
+    }
+
+    @Override
+    public PDataType getViewIndexType() {
+        return delegate.getViewIndexType();
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -23,74 +23,7 @@ import static org.apache.hadoop.hbase.HColumnDescriptor.TTL;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.ANALYZE_TABLE;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.RUN_UPDATE_STATS_ASYNC_ATTRIB;
 import static org.apache.phoenix.exception.SQLExceptionCode.INSUFFICIENT_MULTI_TENANT_COLUMNS;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.APPEND_ONLY_SCHEMA;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ARG_POSITION;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ARRAY_SIZE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ASYNC_CREATED_DATE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ASYNC_REBUILD_TIMESTAMP;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.AUTO_PARTITION_SEQ;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.BASE_COLUMN_COUNT;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.CLASS_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_COUNT;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_DEF;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_FAMILY;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_QUALIFIER;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_QUALIFIER_COUNTER;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.COLUMN_SIZE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DATA_TABLE_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DATA_TYPE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DECIMAL_DIGITS;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DEFAULT_COLUMN_FAMILY_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DEFAULT_VALUE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.DISABLE_WAL;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ENCODING_SCHEME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.FUNCTION_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.GUIDE_POSTS_WIDTH;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IMMUTABLE_ROWS;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IMMUTABLE_STORAGE_SCHEME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.INDEX_DISABLE_TIMESTAMP;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.INDEX_STATE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.INDEX_TYPE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_ARRAY;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_CONSTANT;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_NAMESPACE_MAPPED;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_ROW_TIMESTAMP;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.IS_VIEW_REFERENCED;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.JAR_PATH;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.KEY_SEQ;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.LAST_STATS_UPDATE_TIME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.LINK_TYPE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.MAX_VALUE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.MIN_VALUE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.MULTI_TENANT;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.NULLABLE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.NUM_ARGS;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.ORDINAL_POSITION;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.PARENT_TENANT_ID;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.PHYSICAL_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.PK_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.RETURN_TYPE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SALT_BUCKETS;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SORT_ORDER;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.STORE_NULLS;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYNC_INDEX_CREATED_DATE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CATALOG_SCHEMA;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CATALOG_TABLE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_FUNCTION_TABLE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_SCHEM;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_SEQ_NUM;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_TYPE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TENANT_ID;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TRANSACTIONAL;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TRANSACTION_PROVIDER;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TYPE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.UPDATE_CACHE_FREQUENCY;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.USE_STATS_FOR_PARALLELIZATION;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.VIEW_CONSTANT;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.VIEW_STATEMENT;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.VIEW_TYPE;
+import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.*;
 import static org.apache.phoenix.query.QueryConstants.BASE_TABLE_BASE_COLUMN_COUNT;
 import static org.apache.phoenix.query.QueryConstants.DEFAULT_COLUMN_FAMILY;
 import static org.apache.phoenix.query.QueryConstants.ENCODED_CQ_COUNTER_INITIAL_VALUE;
@@ -302,8 +235,9 @@ public class MetaDataClient {
                     GUIDE_POSTS_WIDTH + "," +
                     IMMUTABLE_STORAGE_SCHEME + "," +
                     ENCODING_SCHEME + "," +
-                    USE_STATS_FOR_PARALLELIZATION +
-                    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                    USE_STATS_FOR_PARALLELIZATION +"," +
+                    USE_LONG_VIEW_INDEX +
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
     private static final String CREATE_SCHEMA = "UPSERT INTO " + SYSTEM_CATALOG_SCHEMA + ".\"" + SYSTEM_CATALOG_TABLE
             + "\"( " + TABLE_SCHEM + "," + TABLE_NAME + ") VALUES (?,?)";
@@ -1050,7 +984,7 @@ public class MetaDataClient {
         }
     }
     
-    public MutationState createTable(CreateTableStatement statement, byte[][] splits, PTable parent, String viewStatement, ViewType viewType, byte[][] viewColumnConstants, BitSet isViewColumnReferenced) throws SQLException {
+    public MutationState createTable(CreateTableStatement statement, byte[][] splits, PTable parent, String viewStatement, ViewType viewType, PDataType viewIndexType, byte[][] viewColumnConstants, BitSet isViewColumnReferenced) throws SQLException {
         TableName tableName = statement.getTableName();
         Map<String,Object> tableProps = Maps.newHashMapWithExpectedSize(statement.getProps().size());
         Map<String,Object> commonFamilyProps = Maps.newHashMapWithExpectedSize(statement.getProps().size() + 1);
@@ -1111,7 +1045,7 @@ public class MetaDataClient {
                         true, NamedTableNode.create(statement.getTableName()), statement.getTableType());
             }
         }
-        table = createTableInternal(statement, splits, parent, viewStatement, viewType, viewColumnConstants, isViewColumnReferenced, false, null, null, tableProps, commonFamilyProps);
+        table = createTableInternal(statement, splits, parent, viewStatement, viewType, viewIndexType, viewColumnConstants, isViewColumnReferenced, false, null, null, tableProps, commonFamilyProps);
 
         if (table == null || table.getType() == PTableType.VIEW /*|| table.isTransactional()*/) {
             return new MutationState(0, 0, connection);
@@ -1669,7 +1603,7 @@ public class MetaDataClient {
                 PrimaryKeyConstraint pk = FACTORY.primaryKey(null, allPkColumns);
                 tableProps.put(MetaDataUtil.DATA_TABLE_NAME_PROP_NAME, dataTable.getName().getString());
                 CreateTableStatement tableStatement = FACTORY.createTable(indexTableName, statement.getProps(), columnDefs, pk, statement.getSplitNodes(), PTableType.INDEX, statement.ifNotExists(), null, null, statement.getBindCount(), null);
-                table = createTableInternal(tableStatement, splits, dataTable, null, null, null, null, allocateIndexId, statement.getIndexType(), asyncCreatedDate, tableProps, commonFamilyProps);
+                table = createTableInternal(tableStatement, splits, dataTable, null, null, MetaDataUtil.getViewIndexIdDataType(),null, null, allocateIndexId, statement.getIndexType(), asyncCreatedDate, tableProps, commonFamilyProps);
                 break;
             } catch (ConcurrentTableMutationException e) { // Can happen if parent data table changes while above is in progress
                 if (numRetries<5) {
@@ -1865,7 +1799,7 @@ public class MetaDataClient {
     }
 
     private PTable createTableInternal(CreateTableStatement statement, byte[][] splits,
-            final PTable parent, String viewStatement, ViewType viewType,
+            final PTable parent, String viewStatement, ViewType viewType, PDataType viewIndexType,
             final byte[][] viewColumnConstants, final BitSet isViewColumnReferenced, boolean allocateIndexId,
             IndexType indexType, Date asyncCreatedDate,
             Map<String,Object> tableProps,
@@ -2524,7 +2458,7 @@ public class MetaDataClient {
                         Collections.<PTable>emptyList(), isImmutableRows,
                         Collections.<PName>emptyList(), defaultFamilyName == null ? null :
                                 PNameFactory.newName(defaultFamilyName), null,
-                        Boolean.TRUE.equals(disableWAL), false, false, null, null, indexType, true, null, 0, 0L, isNamespaceMapped, autoPartitionSeq, isAppendOnlySchema, ONE_CELL_PER_COLUMN, NON_ENCODED_QUALIFIERS, PTable.EncodedCQCounter.NULL_COUNTER, true);
+                        Boolean.TRUE.equals(disableWAL), false, false, null, null, null, indexType, true, null, 0, 0L, isNamespaceMapped, autoPartitionSeq, isAppendOnlySchema, ONE_CELL_PER_COLUMN, NON_ENCODED_QUALIFIERS, PTable.EncodedCQCounter.NULL_COUNTER, true);
                 connection.addTable(table, MetaDataProtocol.MIN_TABLE_TIMESTAMP);
             }
             
@@ -2689,6 +2623,7 @@ public class MetaDataClient {
             } else {
                 tableUpsert.setBoolean(28, useStatsForParallelizationProp);
             }
+            tableUpsert.setBoolean(29, true);
             tableUpsert.execute();
 
             if (asyncCreatedDate != null) {
@@ -2802,7 +2737,7 @@ public class MetaDataClient {
                         PTable.INITIAL_SEQ_NUM, pkName == null ? null : PNameFactory.newName(pkName), saltBucketNum, columns.values(),
                         parent == null ? null : parent.getSchemaName(), parent == null ? null : parent.getTableName(), Collections.<PTable>emptyList(), isImmutableRows,
                         physicalNames, defaultFamilyName == null ? null : PNameFactory.newName(defaultFamilyName), viewStatement, Boolean.TRUE.equals(disableWAL), multiTenant, storeNulls, viewType,
-                        result.getViewIndexId(), indexType, rowKeyOrderOptimizable, transactionProvider, updateCacheFrequency, 0L, isNamespaceMapped, autoPartitionSeq, isAppendOnlySchema, immutableStorageScheme, encodingScheme, cqCounterToBe, useStatsForParallelizationProp);
+                        viewIndexType, result.getViewIndexId(), indexType, rowKeyOrderOptimizable, transactionProvider, updateCacheFrequency, 0L, isNamespaceMapped, autoPartitionSeq, isAppendOnlySchema, immutableStorageScheme, encodingScheme, cqCounterToBe, useStatsForParallelizationProp);
                 result = new MetaDataMutationResult(code, result.getMutationTime(), table, true);
                 addTableToCache(result);
                 return table;
@@ -3815,7 +3750,7 @@ public class MetaDataClient {
                                 PTableImpl viewIndexTable = new PTableImpl(sharedTableState.getTenantId(),
                                         sharedTableState.getSchemaName(), sharedTableState.getTableName(), ts,
                                         table.getColumnFamilies(), sharedTableState.getColumns(),
-                                        sharedTableState.getPhysicalNames(), sharedTableState.getViewIndexId(),
+                                        sharedTableState.getPhysicalNames(), sharedTableState.getViewIndexType(), sharedTableState.getViewIndexId(),
                                         table.isMultiTenant(), table.isNamespaceMapped(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
                                 TableRef indexTableRef = new TableRef(viewIndexTable);
                                 PName indexTableTenantId = sharedTableState.getTenantId();

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/PTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/PTable.java
@@ -685,7 +685,8 @@ public interface PTable extends PMetaDataEntity {
 
     ViewType getViewType();
     String getViewStatement();
-    Short getViewIndexId();
+    Long getViewIndexId();
+    PDataType getViewIndexType();
     PTableKey getKey();
 
     IndexType getIndexType();

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/PTableImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/PTableImpl.java
@@ -70,12 +70,7 @@ import org.apache.phoenix.schema.types.PDouble;
 import org.apache.phoenix.schema.types.PFloat;
 import org.apache.phoenix.schema.types.PVarchar;
 import org.apache.phoenix.transaction.TransactionFactory;
-import org.apache.phoenix.util.ByteUtil;
-import org.apache.phoenix.util.EncodedColumnsUtil;
-import org.apache.phoenix.util.PhoenixRuntime;
-import org.apache.phoenix.util.SchemaUtil;
-import org.apache.phoenix.util.SizedUtil;
-import org.apache.phoenix.util.TrustedByteArrayOutputStream;
+import org.apache.phoenix.util.*;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -137,7 +132,8 @@ public class PTableImpl implements PTable {
     private boolean storeNulls;
     private TransactionFactory.Provider transactionProvider;
     private ViewType viewType;
-    private Short viewIndexId;
+    private PDataType viewIndexType;
+    private Long viewIndexId;
     private int estimatedSize;
     private IndexType indexType;
     private int baseColumnCount;
@@ -213,7 +209,7 @@ public class PTableImpl implements PTable {
     
     // For indexes stored in shared physical tables
     public PTableImpl(PName tenantId, PName schemaName, PName tableName, long timestamp, List<PColumnFamily> families, 
-            List<PColumn> columns, List<PName> physicalNames, Short viewIndexId, boolean multiTenant, boolean isNamespaceMpped, ImmutableStorageScheme storageScheme, QualifierEncodingScheme qualifierEncodingScheme, 
+            List<PColumn> columns, List<PName> physicalNames,PDataType viewIndexType, Long viewIndexId, boolean multiTenant, boolean isNamespaceMpped, ImmutableStorageScheme storageScheme, QualifierEncodingScheme qualifierEncodingScheme,
             EncodedCQCounter encodedCQCounter, Boolean useStatsForParallelization) throws SQLException {
         this.pkColumns = this.allColumns = Collections.emptyList();
         this.rowKeySchema = RowKeySchema.EMPTY_SCHEMA;
@@ -227,7 +223,7 @@ public class PTableImpl implements PTable {
         this.families = families;
         init(tenantId, this.schemaName, this.tableName, PTableType.INDEX, state, timeStamp, sequenceNumber, pkName, bucketNum, columns,
             this.schemaName, parentTableName, indexes, isImmutableRows, physicalNames, defaultFamilyName,
-            null, disableWAL, multiTenant, storeNulls, viewType, viewIndexId, indexType, baseColumnCount, rowKeyOrderOptimizable,
+            null, disableWAL, multiTenant, storeNulls, viewType, viewIndexType, viewIndexId, indexType, baseColumnCount, rowKeyOrderOptimizable,
             transactionProvider, updateCacheFrequency, indexDisableTimestamp, isNamespaceMpped, null, false, storageScheme, qualifierEncodingScheme, encodedCQCounter, useStatsForParallelization);
     }
 
@@ -270,7 +266,7 @@ public class PTableImpl implements PTable {
                     tenantId, table.getSchemaName(), tableName, table.getType(), table.getIndexState(), timeStamp,
                     table.getSequenceNumber(), table.getPKName(), table.getBucketNum(), getColumnsToClone(table), table.getParentSchemaName(), table.getParentTableName(),
                     indexes, table.isImmutableRows(), physicalNames, table.getDefaultFamilyName(), viewStatement,
-                    table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                    table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                     table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), updateCacheFrequency,
                     table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
         }
@@ -280,7 +276,7 @@ public class PTableImpl implements PTable {
                 table.getTenantId(), table.getSchemaName(), table.getTableName(), table.getType(), table.getIndexState(), timeStamp,
                 table.getSequenceNumber(), table.getPKName(), table.getBucketNum(), getColumnsToClone(table), parentSchemaName, table.getParentTableName(),
                 indexes, table.isImmutableRows(), table.getPhysicalNames(), table.getDefaultFamilyName(), viewStatement,
-                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), table.getUpdateCacheFrequency(),
                 table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -290,7 +286,7 @@ public class PTableImpl implements PTable {
                 table.getTenantId(), table.getSchemaName(), table.getTableName(), table.getType(), table.getIndexState(), table.getTimeStamp(),
                 table.getSequenceNumber(), table.getPKName(), table.getBucketNum(), columns, table.getParentSchemaName(), table.getParentTableName(),
                 table.getIndexes(), table.isImmutableRows(), table.getPhysicalNames(), table.getDefaultFamilyName(), table.getViewStatement(),
-                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), table.getUpdateCacheFrequency(),
                 table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -300,7 +296,7 @@ public class PTableImpl implements PTable {
                 table.getTenantId(), table.getSchemaName(), table.getTableName(), type, table.getIndexState(), table.getTimeStamp(),
                 table.getSequenceNumber(), table.getPKName(), table.getBucketNum(), columns, table.getParentSchemaName(), table.getParentTableName(),
                 table.getIndexes(), table.isImmutableRows(), table.getPhysicalNames(), table.getDefaultFamilyName(), table.getViewStatement(),
-                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), table.getUpdateCacheFrequency(),
                 table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -310,7 +306,7 @@ public class PTableImpl implements PTable {
                 table.getTenantId(), table.getSchemaName(), table.getTableName(), table.getType(), table.getIndexState(), table.getTimeStamp(),
                 table.getSequenceNumber(), table.getPKName(), table.getBucketNum(), columns, table.getParentSchemaName(), table.getParentTableName(),
                 table.getIndexes(), table.isImmutableRows(), table.getPhysicalNames(), defaultFamily, table.getViewStatement(),
-                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), table.getUpdateCacheFrequency(),
                 table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -320,7 +316,7 @@ public class PTableImpl implements PTable {
                 table.getTenantId(), table.getSchemaName(), table.getTableName(), table.getType(), table.getIndexState(), timeStamp,
                 sequenceNumber, table.getPKName(), table.getBucketNum(), columns, table.getParentSchemaName(), table.getParentTableName(), table.getIndexes(),
                 table.isImmutableRows(), table.getPhysicalNames(), table.getDefaultFamilyName(), table.getViewStatement(), table.isWALDisabled(),
-                table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), table.getUpdateCacheFrequency(), table.getIndexDisableTimestamp(), 
                 table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -330,7 +326,7 @@ public class PTableImpl implements PTable {
                 table.getTenantId(), table.getSchemaName(), table.getTableName(), table.getType(), table.getIndexState(), timeStamp,
                 sequenceNumber, table.getPKName(), table.getBucketNum(), columns, table.getParentSchemaName(), table.getParentTableName(),
                 table.getIndexes(), isImmutableRows, table.getPhysicalNames(), table.getDefaultFamilyName(), table.getViewStatement(),
-                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(),
+                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(),
                 table.getIndexType(), table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(),
                 table.getUpdateCacheFrequency(), table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -341,7 +337,7 @@ public class PTableImpl implements PTable {
                 table.getTenantId(), table.getSchemaName(), table.getTableName(), table.getType(), table.getIndexState(), timeStamp,
                 sequenceNumber, table.getPKName(), table.getBucketNum(), columns, table.getParentSchemaName(), table.getParentTableName(),
                 table.getIndexes(), isImmutableRows, table.getPhysicalNames(), table.getDefaultFamilyName(), table.getViewStatement(),
-                isWalDisabled, isMultitenant, storeNulls, table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                isWalDisabled, isMultitenant, storeNulls, table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), transactionProvider, updateCacheFrequency, table.getIndexDisableTimestamp(), 
                 isNamespaceMapped, table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -352,7 +348,7 @@ public class PTableImpl implements PTable {
                 table.getSequenceNumber(), table.getPKName(), table.getBucketNum(), getColumnsToClone(table),
                 table.getParentSchemaName(), table.getParentTableName(), table.getIndexes(),
                 table.isImmutableRows(), table.getPhysicalNames(), table.getDefaultFamilyName(), table.getViewStatement(),
-                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), table.getUpdateCacheFrequency(),
                 table.getIndexDisableTimestamp(), table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -363,7 +359,7 @@ public class PTableImpl implements PTable {
                 table.getSequenceNumber(), table.getPKName(), table.getBucketNum(), getColumnsToClone(table),
                 table.getParentSchemaName(), table.getParentTableName(), table.getIndexes(),
                 table.isImmutableRows(), table.getPhysicalNames(), table.getDefaultFamilyName(), table.getViewStatement(),
-                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), rowKeyOrderOptimizable, table.getTransactionProvider(), table.getUpdateCacheFrequency(), table.getIndexDisableTimestamp(), table.isNamespaceMapped(), 
                 table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -374,7 +370,7 @@ public class PTableImpl implements PTable {
                 table.getSequenceNumber(), table.getPKName(), table.getBucketNum(), getColumnsToClone(table),
                 table.getParentSchemaName(), table.getParentTableName(), table.getIndexes(),
                 table.isImmutableRows(), table.getPhysicalNames(), table.getDefaultFamilyName(), table.getViewStatement(),
-                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexId(), table.getIndexType(),
+                table.isWALDisabled(), table.isMultiTenant(), table.getStoreNulls(), table.getViewType(), table.getViewIndexType(), table.getViewIndexId(), table.getIndexType(),
                 table.getBaseColumnCount(), table.rowKeyOrderOptimizable(), table.getTransactionProvider(), table.getUpdateCacheFrequency(), table.getIndexDisableTimestamp(), 
                 table.isNamespaceMapped(), table.getAutoPartitionSeqName(), table.isAppendOnlySchema(), table.getImmutableStorageScheme(), table.getEncodingScheme(), table.getEncodedCQCounter(), table.useStatsForParallelization());
     }
@@ -383,12 +379,12 @@ public class PTableImpl implements PTable {
             PIndexState state, long timeStamp, long sequenceNumber, PName pkName, Integer bucketNum,
             Collection<PColumn> columns, PName dataSchemaName, PName dataTableName, List<PTable> indexes,
             boolean isImmutableRows, List<PName> physicalNames, PName defaultFamilyName, String viewExpression,
-            boolean disableWAL, boolean multiTenant, boolean storeNulls, ViewType viewType, Short viewIndexId,
+            boolean disableWAL, boolean multiTenant, boolean storeNulls, ViewType viewType, PDataType viewIndexType, Long viewIndexId,
             IndexType indexType, boolean rowKeyOrderOptimizable, TransactionFactory.Provider transactionProvider, long updateCacheFrequency,
             long indexDisableTimestamp, boolean isNamespaceMapped, String autoPartitionSeqName, boolean isAppendOnlySchema, ImmutableStorageScheme storageScheme, QualifierEncodingScheme qualifierEncodingScheme, EncodedCQCounter encodedCQCounter, Boolean useStatsForParallelization) throws SQLException {
         return new PTableImpl(tenantId, schemaName, tableName, type, state, timeStamp, sequenceNumber, pkName, bucketNum, columns, dataSchemaName,
                 dataTableName, indexes, isImmutableRows, physicalNames, defaultFamilyName,
-                viewExpression, disableWAL, multiTenant, storeNulls, viewType, viewIndexId,
+                viewExpression, disableWAL, multiTenant, storeNulls, viewType, viewIndexType, viewIndexId,
                 indexType, QueryConstants.BASE_TABLE_BASE_COLUMN_COUNT, rowKeyOrderOptimizable, transactionProvider,
                 updateCacheFrequency,indexDisableTimestamp, isNamespaceMapped, autoPartitionSeqName, isAppendOnlySchema, storageScheme, qualifierEncodingScheme, encodedCQCounter, useStatsForParallelization);
     }
@@ -397,7 +393,7 @@ public class PTableImpl implements PTable {
             PIndexState state, long timeStamp, long sequenceNumber, PName pkName, Integer bucketNum,
             Collection<PColumn> columns, PName dataSchemaName, PName dataTableName, List<PTable> indexes,
             boolean isImmutableRows, List<PName> physicalNames, PName defaultFamilyName, String viewExpression,
-            boolean disableWAL, boolean multiTenant, boolean storeNulls, ViewType viewType, Short viewIndexId,
+            boolean disableWAL, boolean multiTenant, boolean storeNulls, ViewType viewType, PDataType viewIndexType, Long viewIndexId,
             IndexType indexType, boolean rowKeyOrderOptimizable, TransactionFactory.Provider transactionProvider, long updateCacheFrequency,
             int baseColumnCount, long indexDisableTimestamp, boolean isNamespaceMapped,
             String autoPartitionSeqName, boolean isAppendOnlySchema, ImmutableStorageScheme storageScheme,
@@ -405,7 +401,7 @@ public class PTableImpl implements PTable {
             throws SQLException {
         return new PTableImpl(tenantId, schemaName, tableName, type, state, timeStamp, sequenceNumber, pkName,
                 bucketNum, columns, dataSchemaName, dataTableName, indexes, isImmutableRows, physicalNames,
-                defaultFamilyName, viewExpression, disableWAL, multiTenant, storeNulls, viewType, viewIndexId,
+                defaultFamilyName, viewExpression, disableWAL, multiTenant, storeNulls, viewType,viewIndexType,  viewIndexId,
                 indexType, baseColumnCount, rowKeyOrderOptimizable, transactionProvider, updateCacheFrequency, 
                 indexDisableTimestamp, isNamespaceMapped, autoPartitionSeqName, isAppendOnlySchema, storageScheme, qualifierEncodingScheme, encodedCQCounter, useStatsForParallelization);
     }
@@ -414,13 +410,13 @@ public class PTableImpl implements PTable {
             long timeStamp, long sequenceNumber, PName pkName, Integer bucketNum, Collection<PColumn> columns,
             PName parentSchemaName, PName parentTableName, List<PTable> indexes, boolean isImmutableRows,
             List<PName> physicalNames, PName defaultFamilyName, String viewExpression, boolean disableWAL, boolean multiTenant,
-            boolean storeNulls, ViewType viewType, Short viewIndexId, IndexType indexType,
+            boolean storeNulls, ViewType viewType, PDataType viewIndexType, Long viewIndexId, IndexType indexType,
             int baseColumnCount, boolean rowKeyOrderOptimizable, TransactionFactory.Provider transactionProvider, long updateCacheFrequency,
             long indexDisableTimestamp, boolean isNamespaceMapped, String autoPartitionSeqName, boolean isAppendOnlySchema, ImmutableStorageScheme storageScheme, 
             QualifierEncodingScheme qualifierEncodingScheme, EncodedCQCounter encodedCQCounter, Boolean useStatsForParallelization) throws SQLException {
         init(tenantId, schemaName, tableName, type, state, timeStamp, sequenceNumber, pkName, bucketNum, columns,
                 parentSchemaName, parentTableName, indexes, isImmutableRows, physicalNames, defaultFamilyName,
-                viewExpression, disableWAL, multiTenant, storeNulls, viewType, viewIndexId, indexType, baseColumnCount, rowKeyOrderOptimizable,
+                viewExpression, disableWAL, multiTenant, storeNulls, viewType, viewIndexType, viewIndexId, indexType, baseColumnCount, rowKeyOrderOptimizable,
                 transactionProvider, updateCacheFrequency, indexDisableTimestamp, isNamespaceMapped, autoPartitionSeqName, isAppendOnlySchema, storageScheme, 
                 qualifierEncodingScheme, encodedCQCounter, useStatsForParallelization);
     }
@@ -454,7 +450,7 @@ public class PTableImpl implements PTable {
     private void init(PName tenantId, PName schemaName, PName tableName, PTableType type, PIndexState state, long timeStamp, long sequenceNumber,
             PName pkName, Integer bucketNum, Collection<PColumn> columns, PName parentSchemaName, PName parentTableName,
             List<PTable> indexes, boolean isImmutableRows, List<PName> physicalNames, PName defaultFamilyName, String viewExpression, boolean disableWAL,
-            boolean multiTenant, boolean storeNulls, ViewType viewType, Short viewIndexId,
+            boolean multiTenant, boolean storeNulls, ViewType viewType,PDataType viewIndexType,  Long viewIndexId,
             IndexType indexType , int baseColumnCount, boolean rowKeyOrderOptimizable, TransactionFactory.Provider transactionProvider, long updateCacheFrequency, long indexDisableTimestamp, 
             boolean isNamespaceMapped, String autoPartitionSeqName, boolean isAppendOnlySchema, ImmutableStorageScheme storageScheme, QualifierEncodingScheme qualifierEncodingScheme, 
             EncodedCQCounter encodedCQCounter, Boolean useStatsForParallelization) throws SQLException {
@@ -485,6 +481,7 @@ public class PTableImpl implements PTable {
         this.multiTenant = multiTenant;
         this.storeNulls = storeNulls;
         this.viewType = viewType;
+        this.viewIndexType = viewIndexType;
         this.viewIndexId = viewIndexId;
         this.indexType = indexType;
         this.transactionProvider = transactionProvider;
@@ -1211,8 +1208,13 @@ public class PTableImpl implements PTable {
     }
 
     @Override
-    public Short getViewIndexId() {
+    public Long getViewIndexId() {
         return viewIndexId;
+    }
+
+    @Override
+    public PDataType getViewIndexType() {
+        return viewIndexType;
     }
 
     @Override
@@ -1241,10 +1243,13 @@ public class PTableImpl implements PTable {
         if (table.hasIndexState()) {
             indexState = PIndexState.fromSerializedValue(table.getIndexState());
         }
-        Short viewIndexId = null;
+        Long viewIndexId = null;
         if(table.hasViewIndexId()){
-            viewIndexId = (short)table.getViewIndexId();
+            viewIndexId = (long)table.getViewIndexId();
         }
+        PDataType viewIndexType = table.hasUseLongViewIndexId()
+                ? MetaDataUtil.getViewIndexIdDataType()
+                : MetaDataUtil.getLegacyViewIndexIdDataType();
         IndexType indexType = IndexType.getDefault();
         if(table.hasIndexType()){
             indexType = IndexType.fromSerializedValue(table.getIndexType().toByteArray()[0]);
@@ -1358,7 +1363,7 @@ public class PTableImpl implements PTable {
             result.init(tenantId, schemaName, tableName, tableType, indexState, timeStamp, sequenceNumber, pkName,
                 (bucketNum == NO_SALTING) ? null : bucketNum, columns, parentSchemaName, parentTableName, indexes,
                         isImmutableRows, physicalNames, defaultFamilyName, viewStatement, disableWAL,
-                        multiTenant, storeNulls, viewType, viewIndexId, indexType, baseColumnCount, rowKeyOrderOptimizable,
+                        multiTenant, storeNulls, viewType, viewIndexType, viewIndexId, indexType, baseColumnCount, rowKeyOrderOptimizable,
                         transactionProvider, updateCacheFrequency, indexDisableTimestamp, isNamespaceMapped, autoParititonSeqName, 
                         isAppendOnlySchema, storageScheme, qualifierEncodingScheme, encodedColumnQualifierCounter, useStatsForParallelization);
             return result;
@@ -1381,6 +1386,7 @@ public class PTableImpl implements PTable {
     	}
     	if(table.getViewIndexId() != null) {
     	  builder.setViewIndexId(table.getViewIndexId());
+          builder.setUseLongViewIndexId(MetaDataUtil.getViewIndexIdDataType().equals(table.getViewIndexType()));
     	}
     	if(table.getIndexType() != null) {
     	    builder.setIndexType(ByteStringer.wrap(new byte[]{table.getIndexType().getSerializedValue()}));

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/TableProperty.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/TableProperty.java
@@ -222,8 +222,24 @@ public enum TableProperty {
         public Object getPTableValue(PTable table) {
             return table.useStatsForParallelization();
         }
-    }
-    ;
+    },
+    USE_LONG_VIEW_INDEX(PhoenixDatabaseMetaData.USE_LONG_VIEW_INDEX, true, true, true) {
+        @Override
+        public Object getValue(Object value) {
+            if (value == null) {
+                return false;
+            } else if (value instanceof Boolean) {
+                return value;
+            } else {
+                throw new IllegalArgumentException("Use long view index can only be either true or false");
+            }
+        }
+
+        @Override
+        public Object getPTableValue(PTable table) {
+            return table.getImmutableStorageScheme();
+        }
+    };
 
     private final String propertyName;
     private final SQLExceptionCode colFamSpecifiedException;

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/MetaDataUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/MetaDataUtil.java
@@ -445,6 +445,10 @@ public class MetaDataUtil {
     }
 
     public static PDataType getViewIndexIdDataType() {
+       return PLong.INSTANCE;
+    }
+
+    public static PDataType getLegacyViewIndexIdDataType() {
         return PSmallint.INSTANCE;
     }
 

--- a/phoenix-core/src/test/java/org/apache/phoenix/compile/TenantSpecificViewIndexCompileTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/compile/TenantSpecificViewIndexCompileTest.java
@@ -50,7 +50,7 @@ public class TenantSpecificViewIndexCompileTest extends BaseConnectionlessQueryT
         conn.createStatement().execute("CREATE INDEX i1 ON v(v2) INCLUDE(v1)");
         
         ResultSet rs = conn.createStatement().executeQuery("EXPLAIN SELECT v1,v2 FROM v WHERE v2 > 'a' ORDER BY v2");
-        assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_T [-32768,'me','a'] - [-32768,'me',*]",
+        assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_T [-9223372036854775808,'me','a'] - [-9223372036854775808,'me',*]",
                 QueryUtil.getExplainPlan(rs));
     }
 
@@ -194,7 +194,7 @@ public class TenantSpecificViewIndexCompileTest extends BaseConnectionlessQueryT
         conn.createStatement().execute("CREATE INDEX i1 ON v(v2)");
         
         ResultSet rs = conn.createStatement().executeQuery("EXPLAIN SELECT v2 FROM v WHERE v2 > 'a' and k2 = 'a' ORDER BY v2,k2");
-        assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_T [-32768,'me','a'] - [-32768,'me',*]\n" + 
+        assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_T [-9223372036854775808,'me','a'] - [-9223372036854775808,'me',*]\n" +
                 "    SERVER FILTER BY FIRST KEY ONLY",
                 QueryUtil.getExplainPlan(rs));
         
@@ -227,7 +227,7 @@ public class TenantSpecificViewIndexCompileTest extends BaseConnectionlessQueryT
         
         // Confirm that a read-only view on an updatable view still optimizes out the read-only parts of the updatable view
         ResultSet rs = conn.createStatement().executeQuery("EXPLAIN SELECT v2 FROM v2 WHERE v3 > 'a' and k2 = 'a' ORDER BY v3,k2");
-        assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_T [-32768,'me','a'] - [-32768,'me',*]",
+        assertEquals("CLIENT PARALLEL 1-WAY RANGE SCAN OVER _IDX_T [-9223372036854775808,'me','a'] - [-9223372036854775808,'me',*]",
                 QueryUtil.getExplainPlan(rs));
     }
     

--- a/phoenix-core/src/test/java/org/apache/phoenix/execute/CorrelatePlanTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/execute/CorrelatePlanTest.java
@@ -260,7 +260,7 @@ public class CorrelatePlanTest {
             PTable pTable = PTableImpl.makePTable(null, PName.EMPTY_NAME, PName.EMPTY_NAME,
                     PTableType.SUBQUERY, null, MetaDataProtocol.MIN_TABLE_TIMESTAMP, PTable.INITIAL_SEQ_NUM,
                     null, null, columns, null, null, Collections.<PTable>emptyList(),
-                    false, Collections.<PName>emptyList(), null, null, false, false, false, null,
+                    false, Collections.<PName>emptyList(), null, null, false, false, false, null, null,
                     null, null, true, null, 0, 0L, Boolean.FALSE, null, false, ImmutableStorageScheme.ONE_CELL_PER_COLUMN, QualifierEncodingScheme.NON_ENCODED_QUALIFIERS, EncodedCQCounter.NULL_COUNTER, true);
             TableRef sourceTable = new TableRef(pTable);
             List<ColumnRef> sourceColumnRefs = Lists.<ColumnRef> newArrayList();

--- a/phoenix-core/src/test/java/org/apache/phoenix/execute/LiteralResultIteratorPlanTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/execute/LiteralResultIteratorPlanTest.java
@@ -182,7 +182,7 @@ public class LiteralResultIteratorPlanTest {
             PTable pTable = PTableImpl.makePTable(null, PName.EMPTY_NAME, PName.EMPTY_NAME, PTableType.SUBQUERY, null,
                     MetaDataProtocol.MIN_TABLE_TIMESTAMP, PTable.INITIAL_SEQ_NUM, null, null, columns, null, null,
                     Collections.<PTable> emptyList(), false, Collections.<PName> emptyList(), null, null, false, false,
-                    false, null, null, null, true, null, 0, 0L, false, null, false, ImmutableStorageScheme.ONE_CELL_PER_COLUMN, QualifierEncodingScheme.NON_ENCODED_QUALIFIERS, EncodedCQCounter.NULL_COUNTER, true);
+                    false, null, null, null, null, true, null, 0, 0L, false, null, false, ImmutableStorageScheme.ONE_CELL_PER_COLUMN, QualifierEncodingScheme.NON_ENCODED_QUALIFIERS, EncodedCQCounter.NULL_COUNTER, true);
             TableRef sourceTable = new TableRef(pTable);
             List<ColumnRef> sourceColumnRefs = Lists.<ColumnRef> newArrayList();
             for (PColumn column : sourceTable.getTable().getColumns()) {

--- a/phoenix-protocol/src/main/MetaDataService.proto
+++ b/phoenix-protocol/src/main/MetaDataService.proto
@@ -58,7 +58,8 @@ message SharedTableState {
   required bytes tableName = 3;
   repeated PColumn columns = 4;  
   repeated bytes physicalNames = 5;
-  required int32 viewIndexId = 6;
+  required int64 viewIndexId = 6;
+  optional bool useLongViewIndexId = 7;
 }
 
 message MetaDataResponse {
@@ -73,7 +74,8 @@ message MetaDataResponse {
   repeated SharedTableState sharedTablesToDelete = 9;
   optional PSchema schema = 10;
   optional int64 autoPartitionNum = 11;
-  optional int32 viewIndexId = 12;
+  optional int64 viewIndexId = 12;
+  optional bool useLongViewIndexId = 13;
 }
 
 message GetTableRequest {

--- a/phoenix-protocol/src/main/PTable.proto
+++ b/phoenix-protocol/src/main/PTable.proto
@@ -83,7 +83,7 @@ message PTable {
   optional bytes viewStatement = 18;
   repeated bytes physicalNames = 19;
   optional bytes tenantId = 20;
-  optional int32 viewIndexId = 21;
+  optional int64 viewIndexId = 21;
   optional bytes indexType = 22;
   optional int64 statsTimeStamp = 23;
   optional bool storeNulls = 24;
@@ -101,6 +101,7 @@ message PTable {
   repeated EncodedCQCounter encodedCQCounters = 36;
   optional bool useStatsForParallelization = 37;
   optional int32 transactionProvider = 38;
+  optional bool useLongViewIndexId = 39;
 }
 
 message EncodedCQCounter {

--- a/phoenix-protocol/src/main/ServerCachingService.proto
+++ b/phoenix-protocol/src/main/ServerCachingService.proto
@@ -62,6 +62,7 @@ message IndexMaintainer {
   repeated ColumnInfo indexedColumnInfo = 19;
   required int32 encodingScheme = 20;
   required int32 immutableStorageScheme = 21;
+  optional bool useLongViewIndex = 22;
 }
 
 message AddServerCacheRequest {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/PHOENIX-3547
Currently the number of indices per Phoenix table is bound to maximum of 65535 (java.lang.short) which may limit some application requiring to have arbitrary unlimited number of indices. 
This change will consider any new table created in Phoenix to support indices ids to be in  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807 (java.lang.Long) range which is undoubtably big enough to cover this requirement.
Any existing Phoenix Phoenix table will still continue to support only maximum of 65535 of indices and will be able to maintain this limits as enforced before. 