### PR TITLE
PHOENIX-4902 Use only compressed portion of hash cache memory buffer

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/join/HashCacheClient.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/join/HashCacheClient.java
@@ -20,6 +20,7 @@ package org.apache.phoenix.join;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
@@ -162,7 +163,7 @@ public class HashCacheClient  {
                 byte[] compressed = new byte[maxCompressedSize]; // size for worst case
                 int compressedSize = Snappy.compress(baOut.getBuffer(), 0, baOut.size(), compressed, 0);
                 // Last realloc to size of compressed buffer.
-                ptr.set(compressed,0,compressedSize);
+                ptr.set(Arrays.copyOfRange(compressed, 0, compressedSize));
             } finally {
                 dataOut.close();
             }


### PR DESCRIPTION
See ticket https://issues.apache.org/jira/browse/PHOENIX-4902 for description of issue. Current code loses Snappy compression benefits, this change makes sure only the compressed portion is sent in the RPC message.a