### PR TITLE
PHOENIX-4909 Missing the phoenix-loadbalancer module dependency

### DIFF
--- a/bin/phoenix_utils.py
+++ b/bin/phoenix_utils.py
@@ -166,6 +166,8 @@ def setPath():
     global phoenix_loadbalancer_jar
     phoenix_loadbalancer_jar = find(PHOENIX_LOADBALANCER_JAR_PATTERN, os.path.join(current_dir, "..", "phoenix-loadbalancer", "target", "*"))
     if phoenix_loadbalancer_jar == "":
+        phoenix_loadbalancer_jar = findFileInPathWithoutRecursion(PHOENIX_LOADBALANCER_JAR_PATTERN, os.path.join(current_dir, "..", "lib"))
+    if phoenix_loadbalancer_jar == "":
         phoenix_loadbalancer_jar = findFileInPathWithoutRecursion(PHOENIX_LOADBALANCER_JAR_PATTERN, os.path.join(current_dir, ".."))
 
     global phoenix_traceserver_jar

--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -126,5 +126,9 @@
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix-queryserver-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-load-balancer</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Missing the phoenix-loadbalancer module dependency in phoenix-assembly/pom.xml.

Fixed phoenix-assembly.pom
Fixed phoenix_utils.py