### PR TITLE
PHOENIX-4804 PhoenixStorageHandler ERROR: Undefined column

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -171,7 +171,7 @@ public class QueryServicesOptions {
     // latency and client-side spooling/buffering. Smaller means less initial
     // latency and less parallelization.
     public static final long DEFAULT_SCAN_RESULT_CHUNK_SIZE = 2999;
-    public static final boolean DEFAULT_IS_NAMESPACE_MAPPING_ENABLED = false;
+    public static final boolean DEFAULT_IS_NAMESPACE_MAPPING_ENABLED = true;
     public static final boolean DEFAULT_IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE = true;
 
     //

--- a/phoenix-hive/src/main/java/org/apache/phoenix/hive/query/PhoenixQueryBuilder.java
+++ b/phoenix-hive/src/main/java/org/apache/phoenix/hive/query/PhoenixQueryBuilder.java
@@ -131,7 +131,7 @@ public class PhoenixQueryBuilder {
             for(String column:columnList) {
                 if(columnMappingMap.containsKey(column)) {
                     newList.add(columnMappingMap.get(column));
-                } else {
+                } else if(!column.isEmpty()){
                     newList.add(column);
                 }
             }


### PR DESCRIPTION
1. modify DEFAULT_IS_NAMESPACE_MAPPING_ENABLED/DEFAULT_IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE to true
2. fix PHOENIX-4804 bugs (https://issues.apache.org/jira/browse/PHOENIX-4804)

In some case columnList will be start with a temp string , the replaceColumns method should filter it.

hive.io.file.readcolumn.ids is null 
hive.io.file.readcolumn.names is  , col1,col2,col3

In this case columnList is " , col1,col2,col3",when phoenix compile the query ,the result is 
SELECT "","COL1","COL2","COL3" from TABLENAME   exception throw 
java.lang.RuntimeException(org.apache.phoenix.schema.ColumnNotFoundException: ERROR 504 (42703): Undefined column. columnName=TABLENAME 

