### PR TITLE
PHOENIX-4763: Changing a base table property value should be reflected in child views (if the property wasn't changed)

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ExplainPlanWithStatsEnabledIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ExplainPlanWithStatsEnabledIT.java
@@ -1230,12 +1230,8 @@ public class ExplainPlanWithStatsEnabledIT extends ParallelStatsEnabledIT {
                 tenantConn.createStatement().execute("CREATE VIEW " + tenantViewName + " AS SELECT * FROM " + viewName);
                 conn.createStatement()
                         .execute("ALTER TABLE " + tableName + " set USE_STATS_FOR_PARALLELIZATION=" + useStats);
-                // changing a property on a base table does not change the property on a view
-                validatePropertyOnViewIndex(viewName, viewIndexName, !useStats, conn, tenantConn);
-
-                // need to explicitly change the property on the view
-                conn.createStatement()
-                        .execute("ALTER VIEW " + viewName + " set USE_STATS_FOR_PARALLELIZATION=" + useStats);
+                // changing a property on a base table is propagated to its view
+                // if the view has not previously modified the property
                 validatePropertyOnViewIndex(viewName, viewIndexName, useStats, conn, tenantConn);
             }
         }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/PropertiesInSyncIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/PropertiesInSyncIT.java
@@ -374,8 +374,10 @@ public class PropertiesInSyncIT extends ParallelStatsDisabledIT {
             }
         }
         // Now synchronize required properties and verify HBase metadata property values
-        syncTableAndIndexProperties(conn.unwrap(PhoenixConnection.class),
-                conn.unwrap(PhoenixConnection.class).getQueryServices().getAdmin());
+        PhoenixConnection upgradeConn = conn.unwrap(PhoenixConnection.class);
+        // Simulate an upgrade by setting the upgrade flag
+        upgradeConn.setRunningUpgrade(true);
+        syncTableAndIndexProperties(upgradeConn, upgradeConn.getQueryServices().getAdmin());
         for (String t: createdTables) {
             verifyHBaseColumnFamilyProperties(t, conn, false, false);
         }

--- a/phoenix-core/src/main/java/org/apache/hadoop/hbase/regionserver/IndexHalfStoreFileReaderGenerator.java
+++ b/phoenix-core/src/main/java/org/apache/hadoop/hbase/regionserver/IndexHalfStoreFileReaderGenerator.java
@@ -65,7 +65,6 @@ import org.apache.phoenix.schema.PTable.IndexType;
 import org.apache.phoenix.schema.PTableType;
 import org.apache.phoenix.util.ByteUtil;
 import org.apache.phoenix.util.IndexUtil;
-import org.apache.phoenix.util.MetaDataUtil;
 import org.apache.phoenix.util.QueryUtil;
 import org.apache.phoenix.util.RepairUtil;
 
@@ -164,7 +163,7 @@ public class IndexHalfStoreFileReaderGenerator implements RegionObserver, Region
                 for (PTable index : indexes) {
                     if (index.getIndexType() == IndexType.LOCAL) {
                         IndexMaintainer indexMaintainer = index.getIndexMaintainer(dataTable, conn);
-                        indexMaintainers.put(new ImmutableBytesWritable(index.getViewIndexType().toBytes(index.getViewIndexId())),
+                        indexMaintainers.put(new ImmutableBytesWritable(index.getviewIndexIdType().toBytes(index.getViewIndexId())),
                             indexMaintainer);
                     }
                 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -156,7 +156,7 @@ public class DeleteCompiler {
         int offset = (table.getBucketNum() == null ? 0 : 1);
         byte[][] values = new byte[pkColumns.size()][];
         if (isSharedViewIndex) {
-            values[offset++] = table.getViewIndexType().toBytes(table.getViewIndexId());
+            values[offset++] = table.getviewIndexIdType().toBytes(table.getViewIndexId());
         }
         if (isMultiTenant) {
             values[offset++] = tenantIdBytes;

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/JoinCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/JoinCompiler.java
@@ -1282,7 +1282,7 @@ public class JoinCompiler {
                 .setMultiTenant(left.isMultiTenant())
                 .setStoreNulls(left.getStoreNulls())
                 .setViewType(left.getViewType())
-                .setViewIndexType(left.getViewIndexType())
+                .setViewIndexIdType(left.getviewIndexIdType())
                 .setViewIndexId(left.getViewIndexId())
                 .setIndexType(left.getIndexType())
                 .setTransactionProvider(left.getTransactionProvider())

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/TupleProjectionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/TupleProjectionCompiler.java
@@ -18,7 +18,6 @@
 package org.apache.phoenix.compile;
 import static org.apache.phoenix.query.QueryConstants.VALUE_COLUMN_FAMILY;
 import static org.apache.phoenix.query.QueryConstants.BASE_TABLE_BASE_COLUMN_COUNT;
-import static org.apache.phoenix.schema.PTable.ImmutableStorageScheme;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -203,7 +202,7 @@ public class TupleProjectionCompiler {
                 .setMultiTenant(table.isMultiTenant())
                 .setStoreNulls(table.getStoreNulls())
                 .setViewType(table.getViewType())
-                .setViewIndexType(table.getViewIndexType())
+                .setViewIndexIdType(table.getviewIndexIdType())
                 .setViewIndexId(table.getViewIndexId())
                 .setTransactionProvider(table.getTransactionProvider())
                 .setUpdateCacheFrequency(table.getUpdateCacheFrequency())

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/UpsertCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/UpsertCompiler.java
@@ -753,7 +753,7 @@ public class UpsertCompiler {
         final byte[][] values = new byte[nValuesToSet][];
         int nodeIndex = 0;
         if (isSharedViewIndex) {
-            values[nodeIndex++] = table.getViewIndexType().toBytes(table.getViewIndexId());
+            values[nodeIndex++] = table.getviewIndexIdType().toBytes(table.getViewIndexId());
         }
         if (isTenantSpecific) {
             PName tenantId = connection.getTenantId();

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/WhereOptimizer.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/WhereOptimizer.java
@@ -69,7 +69,6 @@ import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.schema.types.PVarbinary;
 import org.apache.phoenix.schema.types.PVarchar;
 import org.apache.phoenix.util.ByteUtil;
-import org.apache.phoenix.util.MetaDataUtil;
 import org.apache.phoenix.util.ScanUtil;
 import org.apache.phoenix.util.SchemaUtil;
 
@@ -179,7 +178,7 @@ public class WhereOptimizer {
         // Add unique index ID for shared indexes on views. This ensures
         // that different indexes don't interleave.
         if (hasViewIndex) {
-            byte[] viewIndexBytes = table.getViewIndexType().toBytes(table.getViewIndexId());
+            byte[] viewIndexBytes = table.getviewIndexIdType().toBytes(table.getViewIndexId());
             KeyRange indexIdKeyRange = KeyRange.getKeyRange(viewIndexBytes);
             cnf.add(Collections.singletonList(indexIdKeyRange));
             pkPos++;

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -87,7 +87,6 @@ import java.security.PrivilegedExceptionAction;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -109,11 +108,13 @@ import org.apache.hadoop.hbase.CellComparatorImpl;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
+import org.apache.hadoop.hbase.ExtendedCellBuilder;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.KeyValue.Type;
 import org.apache.hadoop.hbase.KeyValueUtil;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TagUtil;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Mutation;
@@ -465,6 +466,9 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
 
     // index for link type key value that is used to store linking rows
     private static final int LINK_TYPE_INDEX = 0;
+    // Used to add a tag to a cell when a view modifies a table property to indicate that this
+    // property should not be derived from the base table
+    private static final byte[] VIEW_MODIFIED_PROPERTY_BYTES = Bytes.toBytes(1);
 
     private static final Cell CLASS_NAME_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, CLASS_NAME_BYTES);
     private static final Cell JAR_PATH_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY, TABLE_FAMILY_BYTES, JAR_PATH_BYTES);
@@ -787,11 +791,12 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
 
         // now go up from child to parent all the way to the base table:
         PTable baseTable = null;
+        PTable immediateParent = null;
         long maxTableTimestamp = -1;
         int numPKCols = table.getPKColumns().size();
         for (int i = 0; i < ancestorList.size(); i++) {
             TableInfo parentTableInfo = ancestorList.get(i);
-            PTable pTable = null;
+            PTable pTable;
             String fullParentTableName = SchemaUtil.getTableName(parentTableInfo.getSchemaName(),
                 parentTableInfo.getTableName());
             PName parentTenantId =
@@ -816,6 +821,9 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
             if (pTable == null) {
                 throw new ParentTableNotFoundException(parentTableInfo, fullTableName);
             } else {
+                if (immediateParent == null) {
+                    immediateParent = pTable;
+                }
                 // only combine columns for view indexes (and not local indexes on regular tables
                 // which also have a viewIndexId)
                 if (i == 0 && hasIndexId && pTable.getType() != PTableType.VIEW) {
@@ -952,13 +960,21 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
                 isDiverged ? QueryConstants.DIVERGED_VIEW_BASE_COLUMN_COUNT
                         : columnsToAdd.size() - myColumns.size() + (isSalted ? 1 : 0);
 
+        // Inherit view-modifiable properties from the parent table/view if the current view has
+        // not previously modified this property
+        Long updateCacheFreq = (table.getType() != PTableType.VIEW ||
+                table.hasViewModifiedUpdateCacheFrequency()) ?
+                table.getUpdateCacheFrequency() : immediateParent.getUpdateCacheFrequency();
+        Boolean useStatsForParallelization = (table.getType() != PTableType.VIEW ||
+                table.hasViewModifiedUseStatsForParallelization()) ?
+                table.useStatsForParallelization() : immediateParent.useStatsForParallelization();
         // When creating a PTable for views or view indexes, use the baseTable PTable for attributes
         // inherited from the physical base table.
         // if a TableProperty is not valid on a view we set it to the base table value
         // if a TableProperty is valid on a view and is not mutable on a view we set it to the base table value
-        // if a TableProperty is valid on a view and is mutable on a view we use the value set on the view
-        // TODO Implement PHOENIX-4763 to set the view properties correctly instead of just
-        // setting them same as the base table
+        // if a TableProperty is valid on a view and is mutable on a view, we use the value set
+        // on the view if the view had previously modified the property, otherwise we propagate the
+        // value from the base table (see PHOENIX-4763)
         PTableImpl pTable = PTableImpl.builderWithColumns(table, columnsToAdd)
                 .setImmutableRows(baseTable.isImmutableRows())
                 .setDisableWAL(baseTable.isWALDisabled())
@@ -975,6 +991,8 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
                 .setTimeStamp(maxTableTimestamp)
                 .setExcludedColumns(excludedColumns == null ?
                         ImmutableList.of() : ImmutableList.copyOf(excludedColumns))
+                .setUpdateCacheFrequency(updateCacheFreq)
+                .setUseStatsForParallelization(useStatsForParallelization)
                 .build();
         return WhereConstantParser.addViewInfoToPColumnsIfNeeded(pTable);
     }
@@ -1440,8 +1458,8 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
         }
         Cell viewTypeKv = tableKeyValues[VIEW_TYPE_INDEX];
         ViewType viewType = viewTypeKv == null ? null : ViewType.fromSerializedValue(viewTypeKv.getValueArray()[viewTypeKv.getValueOffset()]);
-        PDataType viewIndexType = getViewIndexType(tableKeyValues);
-        Long viewIndexId = getViewIndexId(tableKeyValues, viewIndexType);
+        PDataType viewIndexIdType = getViewIndexIdType(tableKeyValues);
+        Long viewIndexId = getViewIndexId(tableKeyValues, viewIndexIdType);
         Cell indexTypeKv = tableKeyValues[INDEX_TYPE_INDEX];
         IndexType indexType = indexTypeKv == null ? null : IndexType.fromSerializedValue(indexTypeKv.getValueArray()[indexTypeKv.getValueOffset()]);
         Cell baseColumnCountKv = tableKeyValues[BASE_COLUMN_COUNT_INDEX];
@@ -1453,6 +1471,12 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
         long updateCacheFrequency = updateCacheFrequencyKv == null ? 0 :
             PLong.INSTANCE.getCodec().decodeLong(updateCacheFrequencyKv.getValueArray(),
                     updateCacheFrequencyKv.getValueOffset(), SortOrder.getDefault());
+
+        // Check the cell tag to see whether the view has modified this property
+        byte[] tagUpdateCacheFreq = (updateCacheFrequencyKv == null) ? HConstants.EMPTY_BYTE_ARRAY :
+                TagUtil.concatTags(HConstants.EMPTY_BYTE_ARRAY, updateCacheFrequencyKv);
+        boolean viewModifiedUpdateCacheFrequency = (PTableType.VIEW.equals(tableType)) &&
+                Bytes.contains(tagUpdateCacheFreq, VIEW_MODIFIED_PROPERTY_BYTES);
         Cell indexDisableTimestampKv = tableKeyValues[INDEX_DISABLE_TIMESTAMP];
         long indexDisableTimestamp = indexDisableTimestampKv == null ? 0L : PLong.INSTANCE.getCodec().decodeLong(indexDisableTimestampKv.getValueArray(),
                 indexDisableTimestampKv.getValueOffset(), SortOrder.getDefault());
@@ -1478,6 +1502,13 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
                     encodingSchemeKv.getValueOffset(), encodingSchemeKv.getValueLength()));
         Cell useStatsForParallelizationKv = tableKeyValues[USE_STATS_FOR_PARALLELIZATION_INDEX];
         Boolean useStatsForParallelization = useStatsForParallelizationKv == null ? null : Boolean.TRUE.equals(PBoolean.INSTANCE.toObject(useStatsForParallelizationKv.getValueArray(), useStatsForParallelizationKv.getValueOffset(), useStatsForParallelizationKv.getValueLength()));
+
+        // Check the cell tag to see whether the view has modified this property
+        byte[] tagUseStatsForParallelization = (useStatsForParallelizationKv == null) ?
+                HConstants.EMPTY_BYTE_ARRAY :
+                TagUtil.concatTags(HConstants.EMPTY_BYTE_ARRAY, useStatsForParallelizationKv);
+        boolean viewModifiedUseStatsForParallelization = (PTableType.VIEW.equals(tableType)) &&
+                Bytes.contains(tagUseStatsForParallelization, VIEW_MODIFIED_PROPERTY_BYTES);
         
         List<PColumn> columns = Lists.newArrayListWithExpectedSize(columnCount);
         List<PTable> indexes = Lists.newArrayList();
@@ -1533,7 +1564,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
                 .setMultiTenant(multiTenant)
                 .setStoreNulls(storeNulls)
                 .setViewType(viewType)
-                .setViewIndexType(viewIndexType)
+                .setViewIndexIdType(viewIndexIdType)
                 .setViewIndexId(viewIndexId)
                 .setIndexType(indexType)
                 .setTransactionProvider(transactionProvider)
@@ -1561,28 +1592,30 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
                 .setParentTableName(parentTableName)
                 .setPhysicalNames(physicalTables == null ?
                         ImmutableList.of() : ImmutableList.copyOf(physicalTables))
+                .setViewModifiedUpdateCacheFrequency(viewModifiedUpdateCacheFrequency)
+                .setViewModifiedUseStatsForParallelization(viewModifiedUseStatsForParallelization)
                 .setColumns(columns)
                 .build();
     }
-    private Long getViewIndexId(Cell[] tableKeyValues, PDataType viewIndexType) {
+    private Long getViewIndexId(Cell[] tableKeyValues, PDataType viewIndexIdType) {
         Cell viewIndexIdKv = tableKeyValues[VIEW_INDEX_ID_INDEX];
         return viewIndexIdKv == null ? null :
-                decodeViewIndexId(viewIndexIdKv, viewIndexType);
+                decodeViewIndexId(viewIndexIdKv, viewIndexIdType);
     }
 
     /**
      * Returns viewIndexId based on its underlying data type
      *
-     * @param tableKeyValues
-     * @param viewIndexType
+     * @param viewIndexIdKv
+     * @param viewIndexIdType
      * @return
      */
-    private Long decodeViewIndexId(Cell viewIndexIdKv, PDataType viewIndexType) {
-        return viewIndexType.getCodec().decodeLong(viewIndexIdKv.getValueArray(),
+    private Long decodeViewIndexId(Cell viewIndexIdKv, PDataType viewIndexIdType) {
+        return viewIndexIdType.getCodec().decodeLong(viewIndexIdKv.getValueArray(),
                 viewIndexIdKv.getValueOffset(), SortOrder.getDefault());
     }
 
-    private PDataType getViewIndexType(Cell[] tableKeyValues) {
+    private PDataType getViewIndexIdType(Cell[] tableKeyValues) {
         Cell dataTypeKv = tableKeyValues[VIEW_INDEX_ID_DATA_TYPE_INDEX];
         return dataTypeKv == null ?
                 MetaDataUtil.getLegacyViewIndexIdDataType() :
@@ -2367,6 +2400,12 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
                     return;
                 }
 
+                if (tableType == PTableType.VIEW) {
+                    // Pass in the parent's PTable so that we only tag cells corresponding to the
+                    // view's property in case they are different from the parent
+                    addTagsToPutsForViewAlteredProperties(tableMetadata, parentTable);
+                }
+
                 // When we drop a view we first drop the view metadata and then drop the parent->child linking row
                 List<Mutation> localMutations =
                         Lists.newArrayListWithExpectedSize(tableMetadata.size());
@@ -2424,7 +2463,7 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
                 builder.setReturnCode(MetaDataProtos.MutationCode.TABLE_NOT_FOUND);
                 if (indexId != null) {
                    builder.setViewIndexId(indexId);
-                   builder.setViewIndexType(PLong.INSTANCE.getSqlType());
+                   builder.setViewIndexIdType(PLong.INSTANCE.getSqlType());
                 }
                 builder.setMutationTime(currentTimeStamp);
                 done.run(builder.build());
@@ -3529,19 +3568,23 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
                         }
                     }
                     tableMetaData.addAll(additionalTableMetadataMutations);
-                    if (type == PTableType.VIEW
-                                && EncodedColumnsUtil.usesEncodedColumnNames(table) && addingCol
+                    if (type == PTableType.VIEW) {
+                        if (EncodedColumnsUtil.usesEncodedColumnNames(table) && addingCol
                                 && !table.isAppendOnlySchema()) {
-                                // When adding a column to a view that uses encoded column name
-                                // scheme, we need to modify the CQ counters stored in the view's
-                                // physical table. So to make sure clients get the latest PTable, we
-                                // need to invalidate the cache entry.
-                                // If the table uses APPEND_ONLY_SCHEMA we use the position of the
-                                // column as the encoded column qualifier and so we don't need to
-                                // update the CQ counter in the view physical table (see
-                                // PHOENIX-4737)
-                                invalidateList.add(new ImmutableBytesPtr(
-                                        MetaDataUtil.getPhysicalTableRowForView(table)));
+                            // When adding a column to a view that uses encoded column name
+                            // scheme, we need to modify the CQ counters stored in the view's
+                            // physical table. So to make sure clients get the latest PTable, we
+                            // need to invalidate the cache entry.
+                            // If the table uses APPEND_ONLY_SCHEMA we use the position of the
+                            // column as the encoded column qualifier and so we don't need to
+                            // update the CQ counter in the view physical table (see
+                            // PHOENIX-4737)
+                            invalidateList.add(new ImmutableBytesPtr(
+                                    MetaDataUtil.getPhysicalTableRowForView(table)));
+                        }
+                        // Pass in null as the parent PTable, since we always want to tag the cells
+                        // in this case, irrespective of the property values of the parent
+                        addTagsToPutsForViewAlteredProperties(tableMetaData, null);
                     }
                     return null;
                 }
@@ -3553,6 +3596,46 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
             logger.error("Add column failed: ", e);
             ProtobufUtil.setControllerException(controller,
                 ServerUtil.createIOException("Error when adding column: ", e));
+        }
+    }
+
+    /**
+     * See PHOENIX-4763. If we are modifying any table-level properties that are mutable on a view,
+     * we mark these cells in SYSTEM.CATALOG with tags to indicate that this view property should
+     * not be kept in-sync with the base table and so we shouldn't propagate the base table's
+     * property value when resolving the view
+     * @param tableMetaData list of mutations on the view
+     * @param parent PTable of the parent or null
+     */
+    private void addTagsToPutsForViewAlteredProperties(List<Mutation> tableMetaData,
+            PTable parent) {
+        byte[] parentUpdateCacheFreqBytes = null;
+        byte[] parentUseStatsForParallelizationBytes = null;
+        if (parent != null) {
+            parentUpdateCacheFreqBytes = new byte[PLong.INSTANCE.getByteSize()];
+            PLong.INSTANCE.getCodec().encodeLong(parent.getUpdateCacheFrequency(),
+                    parentUpdateCacheFreqBytes, 0);
+            if (parent.useStatsForParallelization() != null) {
+                parentUseStatsForParallelizationBytes =
+                        PBoolean.INSTANCE.toBytes(parent.useStatsForParallelization());
+            }
+        }
+        for (Mutation m: tableMetaData) {
+            if (m instanceof Put) {
+                MetaDataUtil.conditionallyAddTagsToPutCells((Put)m,
+                        PhoenixDatabaseMetaData.TABLE_FAMILY_BYTES,
+                        PhoenixDatabaseMetaData.UPDATE_CACHE_FREQUENCY_BYTES,
+                        ((ExtendedCellBuilder) env.getCellBuilder()),
+                        parentUpdateCacheFreqBytes,
+                        VIEW_MODIFIED_PROPERTY_BYTES);
+                MetaDataUtil.conditionallyAddTagsToPutCells((Put)m,
+                        PhoenixDatabaseMetaData.TABLE_FAMILY_BYTES,
+                        PhoenixDatabaseMetaData.USE_STATS_FOR_PARALLELIZATION_BYTES,
+                        ((ExtendedCellBuilder) env.getCellBuilder()),
+                        parentUseStatsForParallelizationBytes,
+                        VIEW_MODIFIED_PROPERTY_BYTES);
+            }
+
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataProtocol.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataProtocol.java
@@ -180,7 +180,7 @@ public abstract class MetaDataProtocol extends MetaDataService {
         private PName tableName;
         private List<PColumn> columns;
         private List<PName> physicalNames;
-        private PDataType viewIndexType;
+        private PDataType viewIndexIdType;
         private Long viewIndexId;
         
         public SharedTableState(PTable table) {
@@ -189,7 +189,7 @@ public abstract class MetaDataProtocol extends MetaDataService {
             this.tableName = table.getTableName();
             this.columns = table.getColumns();
             this.physicalNames = table.getPhysicalNames();
-            this.viewIndexType = table.getViewIndexType();
+            this.viewIndexIdType = table.getviewIndexIdType();
             this.viewIndexId = table.getViewIndexId();
         }
         
@@ -213,8 +213,8 @@ public abstract class MetaDataProtocol extends MetaDataService {
                 }
             });
             this.viewIndexId = sharedTable.getViewIndexId();
-            this.viewIndexType = sharedTable.hasViewIndexType()
-                    ? PDataType.fromTypeId(sharedTable.getViewIndexType())
+            this.viewIndexIdType = sharedTable.hasViewIndexIdType()
+                    ? PDataType.fromTypeId(sharedTable.getViewIndexIdType())
                     : MetaDataUtil.getLegacyViewIndexIdDataType();
         }
 
@@ -242,8 +242,8 @@ public abstract class MetaDataProtocol extends MetaDataService {
             return viewIndexId;
         }
 
-        public PDataType getViewIndexType() {
-          return viewIndexType;
+        public PDataType getViewIndexIdType() {
+          return viewIndexIdType;
         }
   }
     
@@ -258,7 +258,7 @@ public abstract class MetaDataProtocol extends MetaDataService {
         private boolean wasUpdated;
         private PSchema schema;
         private Long viewIndexId;
-        private PDataType viewIndexType;
+        private PDataType viewIndexIdType;
         private List<PFunction> functions = new ArrayList<PFunction>(1);
         private long autoPartitionNum;
 
@@ -303,10 +303,10 @@ public abstract class MetaDataProtocol extends MetaDataService {
             this.tableNamesToDelete = tableNamesToDelete;
         }
         
-        public MetaDataMutationResult(MutationCode returnCode, int currentTime, PTable table, long viewIndexId, PDataType viewIndexType ) {
+        public MetaDataMutationResult(MutationCode returnCode, int currentTime, PTable table, long viewIndexId, PDataType viewIndexIdType) {
             this(returnCode, currentTime, table, Collections.<byte[]> emptyList());
             this.viewIndexId = viewIndexId;
-            this.viewIndexType = viewIndexType;
+            this.viewIndexIdType = viewIndexIdType;
         }
         
         public MetaDataMutationResult(MutationCode returnCode, long currentTime, PTable table, List<byte[]> tableNamesToDelete, List<SharedTableState> sharedTablesToDelete) {
@@ -366,8 +366,8 @@ public abstract class MetaDataProtocol extends MetaDataService {
             return viewIndexId;
         }
 
-      public PDataType getViewIndexType() {
-          return viewIndexType;
+      public PDataType getViewIndexIdType() {
+          return viewIndexIdType;
       }
 
         public static MetaDataMutationResult constructFromProto(MetaDataResponse proto) {
@@ -415,8 +415,8 @@ public abstract class MetaDataProtocol extends MetaDataService {
                result.viewIndexId = proto.getViewIndexId();
           }
 
-          result.viewIndexType = proto.hasViewIndexType()
-                    ? PDataType.fromTypeId(proto.getViewIndexType())
+          result.viewIndexIdType = proto.hasViewIndexIdType()
+                    ? PDataType.fromTypeId(proto.getViewIndexIdType())
                     : MetaDataUtil.getLegacyViewIndexIdDataType();
           return result;
         }
@@ -458,7 +458,7 @@ public abstract class MetaDataProtocol extends MetaDataService {
                 sharedTableStateBuilder.setSchemaName(ByteStringer.wrap(sharedTableState.getSchemaName().getBytes()));
                 sharedTableStateBuilder.setTableName(ByteStringer.wrap(sharedTableState.getTableName().getBytes()));
                 sharedTableStateBuilder.setViewIndexId(sharedTableState.getViewIndexId());
-                sharedTableStateBuilder.setViewIndexType(sharedTableState.viewIndexType.getSqlType());
+                sharedTableStateBuilder.setViewIndexIdType(sharedTableState.viewIndexIdType.getSqlType());
                 builder.addSharedTablesToDelete(sharedTableStateBuilder.build());
               }
             }
@@ -469,9 +469,9 @@ public abstract class MetaDataProtocol extends MetaDataService {
             if (result.getViewIndexId() != null) {
                 builder.setViewIndexId(result.getViewIndexId());
             }
-            builder.setViewIndexType(result.getViewIndexType() == null
+            builder.setViewIndexIdType(result.getViewIndexIdType() == null
 					  ? MetaDataUtil.getLegacyViewIndexIdDataType().getSqlType()
-					  : result.getViewIndexType().getSqlType());
+					  : result.getViewIndexIdType().getSqlType());
           }
           return builder.build();
         }

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/MetaDataProtos.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/MetaDataProtos.java
@@ -379,15 +379,15 @@ public final class MetaDataProtos {
      */
     long getViewIndexId();
 
-    // optional int32 viewIndexType = 7 [default = 5];
+    // optional int32 viewIndexIdType = 7 [default = 5];
     /**
-     * <code>optional int32 viewIndexType = 7 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 7 [default = 5];</code>
      */
-    boolean hasViewIndexType();
+    boolean hasViewIndexIdType();
     /**
-     * <code>optional int32 viewIndexType = 7 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 7 [default = 5];</code>
      */
-    int getViewIndexType();
+    int getViewIndexIdType();
   }
   /**
    * Protobuf type {@code SharedTableState}
@@ -478,7 +478,7 @@ public final class MetaDataProtos {
             }
             case 56: {
               bitField0_ |= 0x00000010;
-              viewIndexType_ = input.readInt32();
+              viewIndexIdType_ = input.readInt32();
               break;
             }
           }
@@ -650,20 +650,20 @@ public final class MetaDataProtos {
       return viewIndexId_;
     }
 
-    // optional int32 viewIndexType = 7 [default = 5];
-    public static final int VIEWINDEXTYPE_FIELD_NUMBER = 7;
-    private int viewIndexType_;
+    // optional int32 viewIndexIdType = 7 [default = 5];
+    public static final int VIEWINDEXIDTYPE_FIELD_NUMBER = 7;
+    private int viewIndexIdType_;
     /**
-     * <code>optional int32 viewIndexType = 7 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 7 [default = 5];</code>
      */
-    public boolean hasViewIndexType() {
+    public boolean hasViewIndexIdType() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional int32 viewIndexType = 7 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 7 [default = 5];</code>
      */
-    public int getViewIndexType() {
-      return viewIndexType_;
+    public int getViewIndexIdType() {
+      return viewIndexIdType_;
     }
 
     private void initFields() {
@@ -673,7 +673,7 @@ public final class MetaDataProtos {
       columns_ = java.util.Collections.emptyList();
       physicalNames_ = java.util.Collections.emptyList();
       viewIndexId_ = 0L;
-      viewIndexType_ = 5;
+      viewIndexIdType_ = 5;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -724,7 +724,7 @@ public final class MetaDataProtos {
         output.writeInt64(6, viewIndexId_);
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeInt32(7, viewIndexType_);
+        output.writeInt32(7, viewIndexIdType_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -766,7 +766,7 @@ public final class MetaDataProtos {
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(7, viewIndexType_);
+          .computeInt32Size(7, viewIndexIdType_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -815,10 +815,10 @@ public final class MetaDataProtos {
         result = result && (getViewIndexId()
             == other.getViewIndexId());
       }
-      result = result && (hasViewIndexType() == other.hasViewIndexType());
-      if (hasViewIndexType()) {
-        result = result && (getViewIndexType()
-            == other.getViewIndexType());
+      result = result && (hasViewIndexIdType() == other.hasViewIndexIdType());
+      if (hasViewIndexIdType()) {
+        result = result && (getViewIndexIdType()
+            == other.getViewIndexIdType());
       }
       result = result &&
           getUnknownFields().equals(other.getUnknownFields());
@@ -857,9 +857,9 @@ public final class MetaDataProtos {
         hash = (37 * hash) + VIEWINDEXID_FIELD_NUMBER;
         hash = (53 * hash) + hashLong(getViewIndexId());
       }
-      if (hasViewIndexType()) {
-        hash = (37 * hash) + VIEWINDEXTYPE_FIELD_NUMBER;
-        hash = (53 * hash) + getViewIndexType();
+      if (hasViewIndexIdType()) {
+        hash = (37 * hash) + VIEWINDEXIDTYPE_FIELD_NUMBER;
+        hash = (53 * hash) + getViewIndexIdType();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -987,7 +987,7 @@ public final class MetaDataProtos {
         bitField0_ = (bitField0_ & ~0x00000010);
         viewIndexId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000020);
-        viewIndexType_ = 5;
+        viewIndexIdType_ = 5;
         bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
@@ -1050,7 +1050,7 @@ public final class MetaDataProtos {
         if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
           to_bitField0_ |= 0x00000010;
         }
-        result.viewIndexType_ = viewIndexType_;
+        result.viewIndexIdType_ = viewIndexIdType_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1115,8 +1115,8 @@ public final class MetaDataProtos {
         if (other.hasViewIndexId()) {
           setViewIndexId(other.getViewIndexId());
         }
-        if (other.hasViewIndexType()) {
-          setViewIndexType(other.getViewIndexType());
+        if (other.hasViewIndexIdType()) {
+          setViewIndexIdType(other.getViewIndexIdType());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -1616,35 +1616,35 @@ public final class MetaDataProtos {
         return this;
       }
 
-      // optional int32 viewIndexType = 7 [default = 5];
-      private int viewIndexType_ = 5;
+      // optional int32 viewIndexIdType = 7 [default = 5];
+      private int viewIndexIdType_ = 5;
       /**
-       * <code>optional int32 viewIndexType = 7 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 7 [default = 5];</code>
        */
-      public boolean hasViewIndexType() {
+      public boolean hasViewIndexIdType() {
         return ((bitField0_ & 0x00000040) == 0x00000040);
       }
       /**
-       * <code>optional int32 viewIndexType = 7 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 7 [default = 5];</code>
        */
-      public int getViewIndexType() {
-        return viewIndexType_;
+      public int getViewIndexIdType() {
+        return viewIndexIdType_;
       }
       /**
-       * <code>optional int32 viewIndexType = 7 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 7 [default = 5];</code>
        */
-      public Builder setViewIndexType(int value) {
+      public Builder setViewIndexIdType(int value) {
         bitField0_ |= 0x00000040;
-        viewIndexType_ = value;
+        viewIndexIdType_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int32 viewIndexType = 7 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 7 [default = 5];</code>
        */
-      public Builder clearViewIndexType() {
+      public Builder clearViewIndexIdType() {
         bitField0_ = (bitField0_ & ~0x00000040);
-        viewIndexType_ = 5;
+        viewIndexIdType_ = 5;
         onChanged();
         return this;
       }
@@ -1825,15 +1825,15 @@ public final class MetaDataProtos {
      */
     long getViewIndexId();
 
-    // optional int32 viewIndexType = 13 [default = 5];
+    // optional int32 viewIndexIdType = 13 [default = 5];
     /**
-     * <code>optional int32 viewIndexType = 13 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 13 [default = 5];</code>
      */
-    boolean hasViewIndexType();
+    boolean hasViewIndexIdType();
     /**
-     * <code>optional int32 viewIndexType = 13 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 13 [default = 5];</code>
      */
-    int getViewIndexType();
+    int getViewIndexIdType();
   }
   /**
    * Protobuf type {@code MetaDataResponse}
@@ -1979,7 +1979,7 @@ public final class MetaDataProtos {
             }
             case 104: {
               bitField0_ |= 0x00000200;
-              viewIndexType_ = input.readInt32();
+              viewIndexIdType_ = input.readInt32();
               break;
             }
           }
@@ -2282,20 +2282,20 @@ public final class MetaDataProtos {
       return viewIndexId_;
     }
 
-    // optional int32 viewIndexType = 13 [default = 5];
-    public static final int VIEWINDEXTYPE_FIELD_NUMBER = 13;
-    private int viewIndexType_;
+    // optional int32 viewIndexIdType = 13 [default = 5];
+    public static final int VIEWINDEXIDTYPE_FIELD_NUMBER = 13;
+    private int viewIndexIdType_;
     /**
-     * <code>optional int32 viewIndexType = 13 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 13 [default = 5];</code>
      */
-    public boolean hasViewIndexType() {
+    public boolean hasViewIndexIdType() {
       return ((bitField0_ & 0x00000200) == 0x00000200);
     }
     /**
-     * <code>optional int32 viewIndexType = 13 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 13 [default = 5];</code>
      */
-    public int getViewIndexType() {
-      return viewIndexType_;
+    public int getViewIndexIdType() {
+      return viewIndexIdType_;
     }
 
     private void initFields() {
@@ -2311,7 +2311,7 @@ public final class MetaDataProtos {
       schema_ = org.apache.phoenix.coprocessor.generated.PSchemaProtos.PSchema.getDefaultInstance();
       autoPartitionNum_ = 0L;
       viewIndexId_ = 0L;
-      viewIndexType_ = 5;
+      viewIndexIdType_ = 5;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -2386,7 +2386,7 @@ public final class MetaDataProtos {
         output.writeInt64(12, viewIndexId_);
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
-        output.writeInt32(13, viewIndexType_);
+        output.writeInt32(13, viewIndexIdType_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -2452,7 +2452,7 @@ public final class MetaDataProtos {
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(13, viewIndexType_);
+          .computeInt32Size(13, viewIndexIdType_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2528,10 +2528,10 @@ public final class MetaDataProtos {
         result = result && (getViewIndexId()
             == other.getViewIndexId());
       }
-      result = result && (hasViewIndexType() == other.hasViewIndexType());
-      if (hasViewIndexType()) {
-        result = result && (getViewIndexType()
-            == other.getViewIndexType());
+      result = result && (hasViewIndexIdType() == other.hasViewIndexIdType());
+      if (hasViewIndexIdType()) {
+        result = result && (getViewIndexIdType()
+            == other.getViewIndexIdType());
       }
       result = result &&
           getUnknownFields().equals(other.getUnknownFields());
@@ -2594,9 +2594,9 @@ public final class MetaDataProtos {
         hash = (37 * hash) + VIEWINDEXID_FIELD_NUMBER;
         hash = (53 * hash) + hashLong(getViewIndexId());
       }
-      if (hasViewIndexType()) {
-        hash = (37 * hash) + VIEWINDEXTYPE_FIELD_NUMBER;
-        hash = (53 * hash) + getViewIndexType();
+      if (hasViewIndexIdType()) {
+        hash = (37 * hash) + VIEWINDEXIDTYPE_FIELD_NUMBER;
+        hash = (53 * hash) + getViewIndexIdType();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -2751,7 +2751,7 @@ public final class MetaDataProtos {
         bitField0_ = (bitField0_ & ~0x00000400);
         viewIndexId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000800);
-        viewIndexType_ = 5;
+        viewIndexIdType_ = 5;
         bitField0_ = (bitField0_ & ~0x00001000);
         return this;
       }
@@ -2851,7 +2851,7 @@ public final class MetaDataProtos {
         if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
           to_bitField0_ |= 0x00000200;
         }
-        result.viewIndexType_ = viewIndexType_;
+        result.viewIndexIdType_ = viewIndexIdType_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2957,8 +2957,8 @@ public final class MetaDataProtos {
         if (other.hasViewIndexId()) {
           setViewIndexId(other.getViewIndexId());
         }
-        if (other.hasViewIndexType()) {
-          setViewIndexType(other.getViewIndexType());
+        if (other.hasViewIndexIdType()) {
+          setViewIndexIdType(other.getViewIndexIdType());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4040,35 +4040,35 @@ public final class MetaDataProtos {
         return this;
       }
 
-      // optional int32 viewIndexType = 13 [default = 5];
-      private int viewIndexType_ = 5;
+      // optional int32 viewIndexIdType = 13 [default = 5];
+      private int viewIndexIdType_ = 5;
       /**
-       * <code>optional int32 viewIndexType = 13 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 13 [default = 5];</code>
        */
-      public boolean hasViewIndexType() {
+      public boolean hasViewIndexIdType() {
         return ((bitField0_ & 0x00001000) == 0x00001000);
       }
       /**
-       * <code>optional int32 viewIndexType = 13 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 13 [default = 5];</code>
        */
-      public int getViewIndexType() {
-        return viewIndexType_;
+      public int getViewIndexIdType() {
+        return viewIndexIdType_;
       }
       /**
-       * <code>optional int32 viewIndexType = 13 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 13 [default = 5];</code>
        */
-      public Builder setViewIndexType(int value) {
+      public Builder setViewIndexIdType(int value) {
         bitField0_ |= 0x00001000;
-        viewIndexType_ = value;
+        viewIndexIdType_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int32 viewIndexType = 13 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 13 [default = 5];</code>
        */
-      public Builder clearViewIndexType() {
+      public Builder clearViewIndexIdType() {
         bitField0_ = (bitField0_ & ~0x00001000);
-        viewIndexType_ = 5;
+        viewIndexIdType_ = 5;
         onChanged();
         return this;
       }
@@ -17827,105 +17827,105 @@ public final class MetaDataProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n\025MetaDataService.proto\032\014PTable.proto\032\017P" +
-      "Function.proto\032\rPSchema.proto\"\254\001\n\020Shared" +
+      "Function.proto\032\rPSchema.proto\"\256\001\n\020Shared" +
       "TableState\022\020\n\010tenantId\030\001 \001(\014\022\022\n\nschemaNa" +
       "me\030\002 \002(\014\022\021\n\ttableName\030\003 \002(\014\022\031\n\007columns\030\004" +
       " \003(\0132\010.PColumn\022\025\n\rphysicalNames\030\005 \003(\014\022\023\n" +
-      "\013viewIndexId\030\006 \002(\003\022\030\n\rviewIndexType\030\007 \001(" +
-      "\005:\0015\"\353\002\n\020MetaDataResponse\022!\n\nreturnCode\030" +
-      "\001 \001(\0162\r.MutationCode\022\024\n\014mutationTime\030\002 \001" +
-      "(\003\022\026\n\005table\030\003 \001(\0132\007.PTable\022\026\n\016tablesToDe" +
-      "lete\030\004 \003(\014\022\022\n\ncolumnName\030\005 \001(\014\022\022\n\nfamily",
-      "Name\030\006 \001(\014\022\024\n\014functionName\030\007 \001(\014\022\034\n\010func" +
-      "tion\030\010 \003(\0132\n.PFunction\022/\n\024sharedTablesTo" +
-      "Delete\030\t \003(\0132\021.SharedTableState\022\030\n\006schem" +
-      "a\030\n \001(\0132\010.PSchema\022\030\n\020autoPartitionNum\030\013 " +
-      "\001(\003\022\023\n\013viewIndexId\030\014 \001(\003\022\030\n\rviewIndexTyp" +
-      "e\030\r \001(\005:\0015\"\364\001\n\017GetTableRequest\022\020\n\010tenant" +
-      "Id\030\001 \002(\014\022\022\n\nschemaName\030\002 \002(\014\022\021\n\ttableNam" +
-      "e\030\003 \002(\014\022\026\n\016tableTimestamp\030\004 \002(\003\022\027\n\017clien" +
-      "tTimestamp\030\005 \002(\003\022\025\n\rclientVersion\030\006 \001(\005\022" +
-      "\037\n\027skipAddingParentColumns\030\007 \001(\010\022\031\n\021skip",
-      "AddingIndexes\030\010 \001(\010\022$\n\023lockedAncestorTab" +
-      "le\030\t \001(\0132\007.PTable\"\212\001\n\023GetFunctionsReques" +
-      "t\022\020\n\010tenantId\030\001 \002(\014\022\025\n\rfunctionNames\030\002 \003" +
-      "(\014\022\032\n\022functionTimestamps\030\003 \003(\003\022\027\n\017client" +
-      "Timestamp\030\004 \002(\003\022\025\n\rclientVersion\030\005 \001(\005\"V" +
-      "\n\020GetSchemaRequest\022\022\n\nschemaName\030\001 \002(\t\022\027" +
-      "\n\017clientTimestamp\030\002 \002(\003\022\025\n\rclientVersion" +
-      "\030\003 \002(\005\"d\n\022CreateTableRequest\022\036\n\026tableMet" +
+      "\013viewIndexId\030\006 \002(\003\022\032\n\017viewIndexIdType\030\007 " +
+      "\001(\005:\0015\"\355\002\n\020MetaDataResponse\022!\n\nreturnCod" +
+      "e\030\001 \001(\0162\r.MutationCode\022\024\n\014mutationTime\030\002" +
+      " \001(\003\022\026\n\005table\030\003 \001(\0132\007.PTable\022\026\n\016tablesTo" +
+      "Delete\030\004 \003(\014\022\022\n\ncolumnName\030\005 \001(\014\022\022\n\nfami",
+      "lyName\030\006 \001(\014\022\024\n\014functionName\030\007 \001(\014\022\034\n\010fu" +
+      "nction\030\010 \003(\0132\n.PFunction\022/\n\024sharedTables" +
+      "ToDelete\030\t \003(\0132\021.SharedTableState\022\030\n\006sch" +
+      "ema\030\n \001(\0132\010.PSchema\022\030\n\020autoPartitionNum\030" +
+      "\013 \001(\003\022\023\n\013viewIndexId\030\014 \001(\003\022\032\n\017viewIndexI" +
+      "dType\030\r \001(\005:\0015\"\364\001\n\017GetTableRequest\022\020\n\010te" +
+      "nantId\030\001 \002(\014\022\022\n\nschemaName\030\002 \002(\014\022\021\n\ttabl" +
+      "eName\030\003 \002(\014\022\026\n\016tableTimestamp\030\004 \002(\003\022\027\n\017c" +
+      "lientTimestamp\030\005 \002(\003\022\025\n\rclientVersion\030\006 " +
+      "\001(\005\022\037\n\027skipAddingParentColumns\030\007 \001(\010\022\031\n\021",
+      "skipAddingIndexes\030\010 \001(\010\022$\n\023lockedAncesto" +
+      "rTable\030\t \001(\0132\007.PTable\"\212\001\n\023GetFunctionsRe" +
+      "quest\022\020\n\010tenantId\030\001 \002(\014\022\025\n\rfunctionNames" +
+      "\030\002 \003(\014\022\032\n\022functionTimestamps\030\003 \003(\003\022\027\n\017cl" +
+      "ientTimestamp\030\004 \002(\003\022\025\n\rclientVersion\030\005 \001" +
+      "(\005\"V\n\020GetSchemaRequest\022\022\n\nschemaName\030\001 \002" +
+      "(\t\022\027\n\017clientTimestamp\030\002 \002(\003\022\025\n\rclientVer" +
+      "sion\030\003 \002(\005\"d\n\022CreateTableRequest\022\036\n\026tabl" +
+      "eMetadataMutations\030\001 \003(\014\022\025\n\rclientVersio" +
+      "n\030\002 \001(\005\022\027\n\017allocateIndexId\030\003 \001(\010\"r\n\025Crea",
+      "teFunctionRequest\022\036\n\026tableMetadataMutati" +
+      "ons\030\001 \003(\014\022\021\n\ttemporary\030\002 \002(\010\022\017\n\007replace\030" +
+      "\003 \001(\010\022\025\n\rclientVersion\030\004 \001(\005\"`\n\023CreateSc" +
+      "hemaRequest\022\036\n\026tableMetadataMutations\030\001 " +
+      "\003(\014\022\022\n\nschemaName\030\002 \002(\t\022\025\n\rclientVersion" +
+      "\030\003 \002(\005\"\216\001\n\020DropTableRequest\022\036\n\026tableMeta" +
+      "dataMutations\030\001 \003(\014\022\021\n\ttableType\030\002 \002(\t\022\017" +
+      "\n\007cascade\030\003 \001(\010\022\025\n\rclientVersion\030\004 \001(\005\022\037" +
+      "\n\027skipAddingParentColumns\030\005 \001(\010\"_\n\021DropS" +
+      "chemaRequest\022\037\n\027schemaMetadataMutations\030",
+      "\001 \003(\014\022\022\n\nschemaName\030\002 \002(\t\022\025\n\rclientVersi" +
+      "on\030\003 \002(\005\"I\n\020AddColumnRequest\022\036\n\026tableMet" +
       "adataMutations\030\001 \003(\014\022\025\n\rclientVersion\030\002 " +
-      "\001(\005\022\027\n\017allocateIndexId\030\003 \001(\010\"r\n\025CreateFu",
-      "nctionRequest\022\036\n\026tableMetadataMutations\030" +
-      "\001 \003(\014\022\021\n\ttemporary\030\002 \002(\010\022\017\n\007replace\030\003 \001(" +
-      "\010\022\025\n\rclientVersion\030\004 \001(\005\"`\n\023CreateSchema" +
-      "Request\022\036\n\026tableMetadataMutations\030\001 \003(\014\022" +
-      "\022\n\nschemaName\030\002 \002(\t\022\025\n\rclientVersion\030\003 \002" +
-      "(\005\"\216\001\n\020DropTableRequest\022\036\n\026tableMetadata" +
-      "Mutations\030\001 \003(\014\022\021\n\ttableType\030\002 \002(\t\022\017\n\007ca" +
-      "scade\030\003 \001(\010\022\025\n\rclientVersion\030\004 \001(\005\022\037\n\027sk" +
-      "ipAddingParentColumns\030\005 \001(\010\"_\n\021DropSchem" +
-      "aRequest\022\037\n\027schemaMetadataMutations\030\001 \003(",
-      "\014\022\022\n\nschemaName\030\002 \002(\t\022\025\n\rclientVersion\030\003" +
-      " \002(\005\"I\n\020AddColumnRequest\022\036\n\026tableMetadat" +
+      "\001(\005\"J\n\021DropColumnRequest\022\036\n\026tableMetadat" +
       "aMutations\030\001 \003(\014\022\025\n\rclientVersion\030\002 \001(\005\"" +
-      "J\n\021DropColumnRequest\022\036\n\026tableMetadataMut" +
-      "ations\030\001 \003(\014\022\025\n\rclientVersion\030\002 \001(\005\"^\n\023D" +
-      "ropFunctionRequest\022\036\n\026tableMetadataMutat" +
-      "ions\030\001 \003(\014\022\020\n\010ifExists\030\002 \001(\010\022\025\n\rclientVe" +
-      "rsion\030\003 \001(\005\"P\n\027UpdateIndexStateRequest\022\036" +
-      "\n\026tableMetadataMutations\030\001 \003(\014\022\025\n\rclient" +
-      "Version\030\002 \001(\005\"*\n\021ClearCacheRequest\022\025\n\rcl",
-      "ientVersion\030\001 \001(\005\"*\n\022ClearCacheResponse\022" +
-      "\024\n\014unfreedBytes\030\001 \001(\003\"*\n\021GetVersionReque" +
-      "st\022\025\n\rclientVersion\030\001 \001(\005\"E\n\022GetVersionR" +
-      "esponse\022\017\n\007version\030\001 \002(\003\022\036\n\026systemCatalo" +
-      "gTimestamp\030\002 \001(\003\"\205\001\n\032ClearTableFromCache" +
-      "Request\022\020\n\010tenantId\030\001 \002(\014\022\022\n\nschemaName\030" +
-      "\002 \002(\014\022\021\n\ttableName\030\003 \002(\014\022\027\n\017clientTimest" +
-      "amp\030\004 \002(\003\022\025\n\rclientVersion\030\005 \001(\005\"\035\n\033Clea" +
-      "rTableFromCacheResponse*\271\005\n\014MutationCode" +
-      "\022\030\n\024TABLE_ALREADY_EXISTS\020\000\022\023\n\017TABLE_NOT_",
-      "FOUND\020\001\022\024\n\020COLUMN_NOT_FOUND\020\002\022\031\n\025COLUMN_" +
-      "ALREADY_EXISTS\020\003\022\035\n\031CONCURRENT_TABLE_MUT" +
-      "ATION\020\004\022\027\n\023TABLE_NOT_IN_REGION\020\005\022\025\n\021NEWE" +
-      "R_TABLE_FOUND\020\006\022\034\n\030UNALLOWED_TABLE_MUTAT" +
-      "ION\020\007\022\021\n\rNO_PK_COLUMNS\020\010\022\032\n\026PARENT_TABLE" +
-      "_NOT_FOUND\020\t\022\033\n\027FUNCTION_ALREADY_EXISTS\020" +
-      "\n\022\026\n\022FUNCTION_NOT_FOUND\020\013\022\030\n\024NEWER_FUNCT" +
-      "ION_FOUND\020\014\022\032\n\026FUNCTION_NOT_IN_REGION\020\r\022" +
-      "\031\n\025SCHEMA_ALREADY_EXISTS\020\016\022\026\n\022NEWER_SCHE" +
-      "MA_FOUND\020\017\022\024\n\020SCHEMA_NOT_FOUND\020\020\022\030\n\024SCHE",
-      "MA_NOT_IN_REGION\020\021\022\032\n\026TABLES_EXIST_ON_SC" +
-      "HEMA\020\022\022\035\n\031UNALLOWED_SCHEMA_MUTATION\020\023\022%\n" +
-      "!AUTO_PARTITION_SEQUENCE_NOT_FOUND\020\024\022#\n\037" +
-      "CANNOT_COERCE_AUTO_PARTITION_ID\020\025\022\024\n\020TOO" +
-      "_MANY_INDEXES\020\026\022\037\n\033UNABLE_TO_CREATE_CHIL" +
-      "D_LINK\020\027\022!\n\035UNABLE_TO_UPDATE_PARENT_TABL" +
-      "E\020\0302\345\006\n\017MetaDataService\022/\n\010getTable\022\020.Ge" +
-      "tTableRequest\032\021.MetaDataResponse\0227\n\014getF" +
-      "unctions\022\024.GetFunctionsRequest\032\021.MetaDat" +
-      "aResponse\0221\n\tgetSchema\022\021.GetSchemaReques",
-      "t\032\021.MetaDataResponse\0225\n\013createTable\022\023.Cr" +
-      "eateTableRequest\032\021.MetaDataResponse\022;\n\016c" +
-      "reateFunction\022\026.CreateFunctionRequest\032\021." +
-      "MetaDataResponse\0227\n\014createSchema\022\024.Creat" +
-      "eSchemaRequest\032\021.MetaDataResponse\0221\n\tdro" +
-      "pTable\022\021.DropTableRequest\032\021.MetaDataResp" +
-      "onse\0223\n\ndropSchema\022\022.DropSchemaRequest\032\021" +
-      ".MetaDataResponse\0227\n\014dropFunction\022\024.Drop" +
-      "FunctionRequest\032\021.MetaDataResponse\0221\n\tad" +
-      "dColumn\022\021.AddColumnRequest\032\021.MetaDataRes",
-      "ponse\0223\n\ndropColumn\022\022.DropColumnRequest\032" +
-      "\021.MetaDataResponse\022?\n\020updateIndexState\022\030" +
-      ".UpdateIndexStateRequest\032\021.MetaDataRespo" +
-      "nse\0225\n\nclearCache\022\022.ClearCacheRequest\032\023." +
-      "ClearCacheResponse\0225\n\ngetVersion\022\022.GetVe" +
-      "rsionRequest\032\023.GetVersionResponse\022P\n\023cle" +
-      "arTableFromCache\022\033.ClearTableFromCacheRe" +
-      "quest\032\034.ClearTableFromCacheResponseBB\n(o" +
-      "rg.apache.phoenix.coprocessor.generatedB" +
-      "\016MetaDataProtosH\001\210\001\001\240\001\001"
+      "^\n\023DropFunctionRequest\022\036\n\026tableMetadataM" +
+      "utations\030\001 \003(\014\022\020\n\010ifExists\030\002 \001(\010\022\025\n\rclie" +
+      "ntVersion\030\003 \001(\005\"P\n\027UpdateIndexStateReque" +
+      "st\022\036\n\026tableMetadataMutations\030\001 \003(\014\022\025\n\rcl" +
+      "ientVersion\030\002 \001(\005\"*\n\021ClearCacheRequest\022\025",
+      "\n\rclientVersion\030\001 \001(\005\"*\n\022ClearCacheRespo" +
+      "nse\022\024\n\014unfreedBytes\030\001 \001(\003\"*\n\021GetVersionR" +
+      "equest\022\025\n\rclientVersion\030\001 \001(\005\"E\n\022GetVers" +
+      "ionResponse\022\017\n\007version\030\001 \002(\003\022\036\n\026systemCa" +
+      "talogTimestamp\030\002 \001(\003\"\205\001\n\032ClearTableFromC" +
+      "acheRequest\022\020\n\010tenantId\030\001 \002(\014\022\022\n\nschemaN" +
+      "ame\030\002 \002(\014\022\021\n\ttableName\030\003 \002(\014\022\027\n\017clientTi" +
+      "mestamp\030\004 \002(\003\022\025\n\rclientVersion\030\005 \001(\005\"\035\n\033" +
+      "ClearTableFromCacheResponse*\271\005\n\014Mutation" +
+      "Code\022\030\n\024TABLE_ALREADY_EXISTS\020\000\022\023\n\017TABLE_",
+      "NOT_FOUND\020\001\022\024\n\020COLUMN_NOT_FOUND\020\002\022\031\n\025COL" +
+      "UMN_ALREADY_EXISTS\020\003\022\035\n\031CONCURRENT_TABLE" +
+      "_MUTATION\020\004\022\027\n\023TABLE_NOT_IN_REGION\020\005\022\025\n\021" +
+      "NEWER_TABLE_FOUND\020\006\022\034\n\030UNALLOWED_TABLE_M" +
+      "UTATION\020\007\022\021\n\rNO_PK_COLUMNS\020\010\022\032\n\026PARENT_T" +
+      "ABLE_NOT_FOUND\020\t\022\033\n\027FUNCTION_ALREADY_EXI" +
+      "STS\020\n\022\026\n\022FUNCTION_NOT_FOUND\020\013\022\030\n\024NEWER_F" +
+      "UNCTION_FOUND\020\014\022\032\n\026FUNCTION_NOT_IN_REGIO" +
+      "N\020\r\022\031\n\025SCHEMA_ALREADY_EXISTS\020\016\022\026\n\022NEWER_" +
+      "SCHEMA_FOUND\020\017\022\024\n\020SCHEMA_NOT_FOUND\020\020\022\030\n\024",
+      "SCHEMA_NOT_IN_REGION\020\021\022\032\n\026TABLES_EXIST_O" +
+      "N_SCHEMA\020\022\022\035\n\031UNALLOWED_SCHEMA_MUTATION\020" +
+      "\023\022%\n!AUTO_PARTITION_SEQUENCE_NOT_FOUND\020\024" +
+      "\022#\n\037CANNOT_COERCE_AUTO_PARTITION_ID\020\025\022\024\n" +
+      "\020TOO_MANY_INDEXES\020\026\022\037\n\033UNABLE_TO_CREATE_" +
+      "CHILD_LINK\020\027\022!\n\035UNABLE_TO_UPDATE_PARENT_" +
+      "TABLE\020\0302\345\006\n\017MetaDataService\022/\n\010getTable\022" +
+      "\020.GetTableRequest\032\021.MetaDataResponse\0227\n\014" +
+      "getFunctions\022\024.GetFunctionsRequest\032\021.Met" +
+      "aDataResponse\0221\n\tgetSchema\022\021.GetSchemaRe",
+      "quest\032\021.MetaDataResponse\0225\n\013createTable\022" +
+      "\023.CreateTableRequest\032\021.MetaDataResponse\022" +
+      ";\n\016createFunction\022\026.CreateFunctionReques" +
+      "t\032\021.MetaDataResponse\0227\n\014createSchema\022\024.C" +
+      "reateSchemaRequest\032\021.MetaDataResponse\0221\n" +
+      "\tdropTable\022\021.DropTableRequest\032\021.MetaData" +
+      "Response\0223\n\ndropSchema\022\022.DropSchemaReque" +
+      "st\032\021.MetaDataResponse\0227\n\014dropFunction\022\024." +
+      "DropFunctionRequest\032\021.MetaDataResponse\0221" +
+      "\n\taddColumn\022\021.AddColumnRequest\032\021.MetaDat",
+      "aResponse\0223\n\ndropColumn\022\022.DropColumnRequ" +
+      "est\032\021.MetaDataResponse\022?\n\020updateIndexSta" +
+      "te\022\030.UpdateIndexStateRequest\032\021.MetaDataR" +
+      "esponse\0225\n\nclearCache\022\022.ClearCacheReques" +
+      "t\032\023.ClearCacheResponse\0225\n\ngetVersion\022\022.G" +
+      "etVersionRequest\032\023.GetVersionResponse\022P\n" +
+      "\023clearTableFromCache\022\033.ClearTableFromCac" +
+      "heRequest\032\034.ClearTableFromCacheResponseB" +
+      "B\n(org.apache.phoenix.coprocessor.genera" +
+      "tedB\016MetaDataProtosH\001\210\001\001\240\001\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -17937,13 +17937,13 @@ public final class MetaDataProtos {
           internal_static_SharedTableState_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_SharedTableState_descriptor,
-              new java.lang.String[] { "TenantId", "SchemaName", "TableName", "Columns", "PhysicalNames", "ViewIndexId", "ViewIndexType", });
+              new java.lang.String[] { "TenantId", "SchemaName", "TableName", "Columns", "PhysicalNames", "ViewIndexId", "ViewIndexIdType", });
           internal_static_MetaDataResponse_descriptor =
             getDescriptor().getMessageTypes().get(1);
           internal_static_MetaDataResponse_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_MetaDataResponse_descriptor,
-              new java.lang.String[] { "ReturnCode", "MutationTime", "Table", "TablesToDelete", "ColumnName", "FamilyName", "FunctionName", "Function", "SharedTablesToDelete", "Schema", "AutoPartitionNum", "ViewIndexId", "ViewIndexType", });
+              new java.lang.String[] { "ReturnCode", "MutationTime", "Table", "TablesToDelete", "ColumnName", "FamilyName", "FunctionName", "Function", "SharedTablesToDelete", "Schema", "AutoPartitionNum", "ViewIndexId", "ViewIndexIdType", });
           internal_static_GetTableRequest_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_GetTableRequest_fieldAccessorTable = new

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/PTableProtos.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/PTableProtos.java
@@ -3695,15 +3695,15 @@ public final class PTableProtos {
      */
     int getTransactionProvider();
 
-    // optional int32 viewIndexType = 39 [default = 5];
+    // optional int32 viewIndexIdType = 39 [default = 5];
     /**
-     * <code>optional int32 viewIndexType = 39 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 39 [default = 5];</code>
      */
-    boolean hasViewIndexType();
+    boolean hasViewIndexIdType();
     /**
-     * <code>optional int32 viewIndexType = 39 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 39 [default = 5];</code>
      */
-    int getViewIndexType();
+    int getViewIndexIdType();
   }
   /**
    * Protobuf type {@code PTable}
@@ -3962,7 +3962,7 @@ public final class PTableProtos {
             }
             case 312: {
               bitField1_ |= 0x00000002;
-              viewIndexType_ = input.readInt32();
+              viewIndexIdType_ = input.readInt32();
               break;
             }
           }
@@ -4745,20 +4745,20 @@ public final class PTableProtos {
       return transactionProvider_;
     }
 
-    // optional int32 viewIndexType = 39 [default = 5];
-    public static final int VIEWINDEXTYPE_FIELD_NUMBER = 39;
-    private int viewIndexType_;
+    // optional int32 viewIndexIdType = 39 [default = 5];
+    public static final int VIEWINDEXIDTYPE_FIELD_NUMBER = 39;
+    private int viewIndexIdType_;
     /**
-     * <code>optional int32 viewIndexType = 39 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 39 [default = 5];</code>
      */
-    public boolean hasViewIndexType() {
+    public boolean hasViewIndexIdType() {
       return ((bitField1_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional int32 viewIndexType = 39 [default = 5];</code>
+     * <code>optional int32 viewIndexIdType = 39 [default = 5];</code>
      */
-    public int getViewIndexType() {
-      return viewIndexType_;
+    public int getViewIndexIdType() {
+      return viewIndexIdType_;
     }
 
     private void initFields() {
@@ -4799,7 +4799,7 @@ public final class PTableProtos {
       encodedCQCounters_ = java.util.Collections.emptyList();
       useStatsForParallelization_ = false;
       transactionProvider_ = 0;
-      viewIndexType_ = 5;
+      viewIndexIdType_ = 5;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4979,7 +4979,7 @@ public final class PTableProtos {
         output.writeInt32(38, transactionProvider_);
       }
       if (((bitField1_ & 0x00000002) == 0x00000002)) {
-        output.writeInt32(39, viewIndexType_);
+        output.writeInt32(39, viewIndexIdType_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -5145,7 +5145,7 @@ public final class PTableProtos {
       }
       if (((bitField1_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(39, viewIndexType_);
+          .computeInt32Size(39, viewIndexIdType_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -5343,10 +5343,10 @@ public final class PTableProtos {
         result = result && (getTransactionProvider()
             == other.getTransactionProvider());
       }
-      result = result && (hasViewIndexType() == other.hasViewIndexType());
-      if (hasViewIndexType()) {
-        result = result && (getViewIndexType()
-            == other.getViewIndexType());
+      result = result && (hasViewIndexIdType() == other.hasViewIndexIdType());
+      if (hasViewIndexIdType()) {
+        result = result && (getViewIndexIdType()
+            == other.getViewIndexIdType());
       }
       result = result &&
           getUnknownFields().equals(other.getUnknownFields());
@@ -5509,9 +5509,9 @@ public final class PTableProtos {
         hash = (37 * hash) + TRANSACTIONPROVIDER_FIELD_NUMBER;
         hash = (53 * hash) + getTransactionProvider();
       }
-      if (hasViewIndexType()) {
-        hash = (37 * hash) + VIEWINDEXTYPE_FIELD_NUMBER;
-        hash = (53 * hash) + getViewIndexType();
+      if (hasViewIndexIdType()) {
+        hash = (37 * hash) + VIEWINDEXIDTYPE_FIELD_NUMBER;
+        hash = (53 * hash) + getViewIndexIdType();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -5711,7 +5711,7 @@ public final class PTableProtos {
         bitField1_ = (bitField1_ & ~0x00000008);
         transactionProvider_ = 0;
         bitField1_ = (bitField1_ & ~0x00000010);
-        viewIndexType_ = 5;
+        viewIndexIdType_ = 5;
         bitField1_ = (bitField1_ & ~0x00000020);
         return this;
       }
@@ -5910,7 +5910,7 @@ public final class PTableProtos {
         if (((from_bitField1_ & 0x00000020) == 0x00000020)) {
           to_bitField1_ |= 0x00000002;
         }
-        result.viewIndexType_ = viewIndexType_;
+        result.viewIndexIdType_ = viewIndexIdType_;
         result.bitField0_ = to_bitField0_;
         result.bitField1_ = to_bitField1_;
         onBuilt();
@@ -6119,8 +6119,8 @@ public final class PTableProtos {
         if (other.hasTransactionProvider()) {
           setTransactionProvider(other.getTransactionProvider());
         }
-        if (other.hasViewIndexType()) {
-          setViewIndexType(other.getViewIndexType());
+        if (other.hasViewIndexIdType()) {
+          setViewIndexIdType(other.getViewIndexIdType());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -8234,35 +8234,35 @@ public final class PTableProtos {
         return this;
       }
 
-      // optional int32 viewIndexType = 39 [default = 5];
-      private int viewIndexType_ = 5;
+      // optional int32 viewIndexIdType = 39 [default = 5];
+      private int viewIndexIdType_ = 5;
       /**
-       * <code>optional int32 viewIndexType = 39 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 39 [default = 5];</code>
        */
-      public boolean hasViewIndexType() {
+      public boolean hasViewIndexIdType() {
         return ((bitField1_ & 0x00000020) == 0x00000020);
       }
       /**
-       * <code>optional int32 viewIndexType = 39 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 39 [default = 5];</code>
        */
-      public int getViewIndexType() {
-        return viewIndexType_;
+      public int getViewIndexIdType() {
+        return viewIndexIdType_;
       }
       /**
-       * <code>optional int32 viewIndexType = 39 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 39 [default = 5];</code>
        */
-      public Builder setViewIndexType(int value) {
+      public Builder setViewIndexIdType(int value) {
         bitField1_ |= 0x00000020;
-        viewIndexType_ = value;
+        viewIndexIdType_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int32 viewIndexType = 39 [default = 5];</code>
+       * <code>optional int32 viewIndexIdType = 39 [default = 5];</code>
        */
-      public Builder clearViewIndexType() {
+      public Builder clearViewIndexIdType() {
         bitField1_ = (bitField1_ & ~0x00000020);
-        viewIndexType_ = 5;
+        viewIndexIdType_ = 5;
         onChanged();
         return this;
       }
@@ -8936,7 +8936,7 @@ public final class PTableProtos {
       "es\030\002 \003(\014\022\033\n\023guidePostsByteCount\030\003 \001(\003\022\025\n" +
       "\rkeyBytesCount\030\004 \001(\003\022\027\n\017guidePostsCount\030" +
       "\005 \001(\005\022!\n\013pGuidePosts\030\006 \001(\0132\014.PGuidePosts" +
-      "\"\307\007\n\006PTable\022\027\n\017schemaNameBytes\030\001 \002(\014\022\026\n\016" +
+      "\"\311\007\n\006PTable\022\027\n\017schemaNameBytes\030\001 \002(\014\022\026\n\016" +
       "tableNameBytes\030\002 \002(\014\022\036\n\ttableType\030\003 \002(\0162" +
       "\013.PTableType\022\022\n\nindexState\030\004 \001(\t\022\026\n\016sequ" +
       "enceNumber\030\005 \002(\003\022\021\n\ttimeStamp\030\006 \002(\003\022\023\n\013p" +
@@ -8959,12 +8959,13 @@ public final class PTableProtos {
       "eme\030\" \001(\014\022\026\n\016encodingScheme\030# \001(\014\022,\n\021enc" +
       "odedCQCounters\030$ \003(\0132\021.EncodedCQCounter\022" +
       "\"\n\032useStatsForParallelization\030% \001(\010\022\033\n\023t" +
-      "ransactionProvider\030& \001(\005\022\030\n\rviewIndexTyp" +
-      "e\030\' \001(\005:\0015\"6\n\020EncodedCQCounter\022\021\n\tcolFam" +
-      "ily\030\001 \002(\t\022\017\n\007counter\030\002 \002(\005*A\n\nPTableType",
-      "\022\n\n\006SYSTEM\020\000\022\010\n\004USER\020\001\022\010\n\004VIEW\020\002\022\t\n\005INDE" +
-      "X\020\003\022\010\n\004JOIN\020\004B@\n(org.apache.phoenix.copr" +
-      "ocessor.generatedB\014PTableProtosH\001\210\001\001\240\001\001"
+      "ransactionProvider\030& \001(\005\022\032\n\017viewIndexIdT" +
+      "ype\030\' \001(\005:\0015\"6\n\020EncodedCQCounter\022\021\n\tcolF" +
+      "amily\030\001 \002(\t\022\017\n\007counter\030\002 \002(\005*A\n\nPTableTy",
+      "pe\022\n\n\006SYSTEM\020\000\022\010\n\004USER\020\001\022\010\n\004VIEW\020\002\022\t\n\005IN" +
+      "DEX\020\003\022\010\n\004JOIN\020\004B@\n(org.apache.phoenix.co" +
+      "processor.generatedB\014PTableProtosH\001\210\001\001\240\001" +
+      "\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -8988,7 +8989,7 @@ public final class PTableProtos {
           internal_static_PTable_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_PTable_descriptor,
-              new java.lang.String[] { "SchemaNameBytes", "TableNameBytes", "TableType", "IndexState", "SequenceNumber", "TimeStamp", "PkNameBytes", "BucketNum", "Columns", "Indexes", "IsImmutableRows", "DataTableNameBytes", "DefaultFamilyName", "DisableWAL", "MultiTenant", "ViewType", "ViewStatement", "PhysicalNames", "TenantId", "ViewIndexId", "IndexType", "StatsTimeStamp", "StoreNulls", "BaseColumnCount", "RowKeyOrderOptimizable", "Transactional", "UpdateCacheFrequency", "IndexDisableTimestamp", "IsNamespaceMapped", "AutoParititonSeqName", "IsAppendOnlySchema", "ParentNameBytes", "StorageScheme", "EncodingScheme", "EncodedCQCounters", "UseStatsForParallelization", "TransactionProvider", "ViewIndexType", });
+              new java.lang.String[] { "SchemaNameBytes", "TableNameBytes", "TableType", "IndexState", "SequenceNumber", "TimeStamp", "PkNameBytes", "BucketNum", "Columns", "Indexes", "IsImmutableRows", "DataTableNameBytes", "DefaultFamilyName", "DisableWAL", "MultiTenant", "ViewType", "ViewStatement", "PhysicalNames", "TenantId", "ViewIndexId", "IndexType", "StatsTimeStamp", "StoreNulls", "BaseColumnCount", "RowKeyOrderOptimizable", "Transactional", "UpdateCacheFrequency", "IndexDisableTimestamp", "IsNamespaceMapped", "AutoParititonSeqName", "IsAppendOnlySchema", "ParentNameBytes", "StorageScheme", "EncodingScheme", "EncodedCQCounters", "UseStatsForParallelization", "TransactionProvider", "ViewIndexIdType", });
           internal_static_EncodedCQCounter_descriptor =
             getDescriptor().getMessageTypes().get(3);
           internal_static_EncodedCQCounter_fieldAccessorTable = new

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/ServerCachingProtos.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/generated/ServerCachingProtos.java
@@ -2158,15 +2158,15 @@ public final class ServerCachingProtos {
      */
     int getImmutableStorageScheme();
 
-    // optional int32 viewIndexType = 22;
+    // optional int32 viewIndexIdType = 22;
     /**
-     * <code>optional int32 viewIndexType = 22;</code>
+     * <code>optional int32 viewIndexIdType = 22;</code>
      */
-    boolean hasViewIndexType();
+    boolean hasViewIndexIdType();
     /**
-     * <code>optional int32 viewIndexType = 22;</code>
+     * <code>optional int32 viewIndexIdType = 22;</code>
      */
-    int getViewIndexType();
+    int getViewIndexIdType();
   }
   /**
    * Protobuf type {@code IndexMaintainer}
@@ -2362,7 +2362,7 @@ public final class ServerCachingProtos {
             }
             case 176: {
               bitField0_ |= 0x00010000;
-              viewIndexType_ = input.readInt32();
+              viewIndexIdType_ = input.readInt32();
               break;
             }
           }
@@ -2849,20 +2849,20 @@ public final class ServerCachingProtos {
       return immutableStorageScheme_;
     }
 
-    // optional int32 viewIndexType = 22;
-    public static final int VIEWINDEXTYPE_FIELD_NUMBER = 22;
-    private int viewIndexType_;
+    // optional int32 viewIndexIdType = 22;
+    public static final int VIEWINDEXIDTYPE_FIELD_NUMBER = 22;
+    private int viewIndexIdType_;
     /**
-     * <code>optional int32 viewIndexType = 22;</code>
+     * <code>optional int32 viewIndexIdType = 22;</code>
      */
-    public boolean hasViewIndexType() {
+    public boolean hasViewIndexIdType() {
       return ((bitField0_ & 0x00010000) == 0x00010000);
     }
     /**
-     * <code>optional int32 viewIndexType = 22;</code>
+     * <code>optional int32 viewIndexIdType = 22;</code>
      */
-    public int getViewIndexType() {
-      return viewIndexType_;
+    public int getViewIndexIdType() {
+      return viewIndexIdType_;
     }
 
     private void initFields() {
@@ -2887,7 +2887,7 @@ public final class ServerCachingProtos {
       indexedColumnInfo_ = java.util.Collections.emptyList();
       encodingScheme_ = 0;
       immutableStorageScheme_ = 0;
-      viewIndexType_ = 0;
+      viewIndexIdType_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3049,7 +3049,7 @@ public final class ServerCachingProtos {
         output.writeInt32(21, immutableStorageScheme_);
       }
       if (((bitField0_ & 0x00010000) == 0x00010000)) {
-        output.writeInt32(22, viewIndexType_);
+        output.writeInt32(22, viewIndexIdType_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -3151,7 +3151,7 @@ public final class ServerCachingProtos {
       }
       if (((bitField0_ & 0x00010000) == 0x00010000)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(22, viewIndexType_);
+          .computeInt32Size(22, viewIndexIdType_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -3266,10 +3266,10 @@ public final class ServerCachingProtos {
         result = result && (getImmutableStorageScheme()
             == other.getImmutableStorageScheme());
       }
-      result = result && (hasViewIndexType() == other.hasViewIndexType());
-      if (hasViewIndexType()) {
-        result = result && (getViewIndexType()
-            == other.getViewIndexType());
+      result = result && (hasViewIndexIdType() == other.hasViewIndexIdType());
+      if (hasViewIndexIdType()) {
+        result = result && (getViewIndexIdType()
+            == other.getViewIndexIdType());
       }
       result = result &&
           getUnknownFields().equals(other.getUnknownFields());
@@ -3368,9 +3368,9 @@ public final class ServerCachingProtos {
         hash = (37 * hash) + IMMUTABLESTORAGESCHEME_FIELD_NUMBER;
         hash = (53 * hash) + getImmutableStorageScheme();
       }
-      if (hasViewIndexType()) {
-        hash = (37 * hash) + VIEWINDEXTYPE_FIELD_NUMBER;
-        hash = (53 * hash) + getViewIndexType();
+      if (hasViewIndexIdType()) {
+        hash = (37 * hash) + VIEWINDEXIDTYPE_FIELD_NUMBER;
+        hash = (53 * hash) + getViewIndexIdType();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -3548,7 +3548,7 @@ public final class ServerCachingProtos {
         bitField0_ = (bitField0_ & ~0x00080000);
         immutableStorageScheme_ = 0;
         bitField0_ = (bitField0_ & ~0x00100000);
-        viewIndexType_ = 0;
+        viewIndexIdType_ = 0;
         bitField0_ = (bitField0_ & ~0x00200000);
         return this;
       }
@@ -3690,7 +3690,7 @@ public final class ServerCachingProtos {
         if (((from_bitField0_ & 0x00200000) == 0x00200000)) {
           to_bitField0_ |= 0x00010000;
         }
-        result.viewIndexType_ = viewIndexType_;
+        result.viewIndexIdType_ = viewIndexIdType_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3869,8 +3869,8 @@ public final class ServerCachingProtos {
         if (other.hasImmutableStorageScheme()) {
           setImmutableStorageScheme(other.getImmutableStorageScheme());
         }
-        if (other.hasViewIndexType()) {
-          setViewIndexType(other.getViewIndexType());
+        if (other.hasViewIndexIdType()) {
+          setViewIndexIdType(other.getViewIndexIdType());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -5636,35 +5636,35 @@ public final class ServerCachingProtos {
         return this;
       }
 
-      // optional int32 viewIndexType = 22;
-      private int viewIndexType_ ;
+      // optional int32 viewIndexIdType = 22;
+      private int viewIndexIdType_ ;
       /**
-       * <code>optional int32 viewIndexType = 22;</code>
+       * <code>optional int32 viewIndexIdType = 22;</code>
        */
-      public boolean hasViewIndexType() {
+      public boolean hasViewIndexIdType() {
         return ((bitField0_ & 0x00200000) == 0x00200000);
       }
       /**
-       * <code>optional int32 viewIndexType = 22;</code>
+       * <code>optional int32 viewIndexIdType = 22;</code>
        */
-      public int getViewIndexType() {
-        return viewIndexType_;
+      public int getViewIndexIdType() {
+        return viewIndexIdType_;
       }
       /**
-       * <code>optional int32 viewIndexType = 22;</code>
+       * <code>optional int32 viewIndexIdType = 22;</code>
        */
-      public Builder setViewIndexType(int value) {
+      public Builder setViewIndexIdType(int value) {
         bitField0_ |= 0x00200000;
-        viewIndexType_ = value;
+        viewIndexIdType_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int32 viewIndexType = 22;</code>
+       * <code>optional int32 viewIndexIdType = 22;</code>
        */
-      public Builder clearViewIndexType() {
+      public Builder clearViewIndexIdType() {
         bitField0_ = (bitField0_ & ~0x00200000);
-        viewIndexType_ = 0;
+        viewIndexIdType_ = 0;
         onChanged();
         return this;
       }
@@ -8795,7 +8795,7 @@ public final class ServerCachingProtos {
       "ength\030\003 \002(\005\"4\n\017ColumnReference\022\016\n\006family" +
       "\030\001 \002(\014\022\021\n\tqualifier\030\002 \002(\014\"4\n\nColumnInfo\022" +
       "\022\n\nfamilyName\030\001 \001(\t\022\022\n\ncolumnName\030\002 \002(\t\"" +
-      "\335\005\n\017IndexMaintainer\022\023\n\013saltBuckets\030\001 \002(\005" +
+      "\337\005\n\017IndexMaintainer\022\023\n\013saltBuckets\030\001 \002(\005" +
       "\022\025\n\risMultiTenant\030\002 \002(\010\022\023\n\013viewIndexId\030\003" +
       " \001(\014\022(\n\016indexedColumns\030\004 \003(\0132\020.ColumnRef" +
       "erence\022 \n\030indexedColumnTypeOrdinal\030\005 \003(\005",
@@ -8812,24 +8812,24 @@ public final class ServerCachingProtos {
       "ed\030\020 \002(\010\022\033\n\023indexRowKeyByteSize\030\021 \002(\005\022\021\n" +
       "\timmutable\030\022 \002(\010\022&\n\021indexedColumnInfo\030\023 " +
       "\003(\0132\013.ColumnInfo\022\026\n\016encodingScheme\030\024 \002(\005" +
-      "\022\036\n\026immutableStorageScheme\030\025 \002(\005\022\025\n\rview" +
-      "IndexType\030\026 \001(\005\"\370\001\n\025AddServerCacheReques" +
-      "t\022\020\n\010tenantId\030\001 \001(\014\022\017\n\007cacheId\030\002 \002(\014\022)\n\010" +
-      "cachePtr\030\003 \002(\0132\027.ImmutableBytesWritable\022" +
-      ")\n\014cacheFactory\030\004 \002(\0132\023.ServerCacheFacto" +
-      "ry\022\017\n\007txState\030\005 \001(\014\022\"\n\032hasProtoBufIndexM" +
-      "aintainer\030\006 \001(\010\022\025\n\rclientVersion\030\007 \001(\005\022\032",
-      "\n\022usePersistentCache\030\010 \001(\010\"(\n\026AddServerC" +
-      "acheResponse\022\016\n\006return\030\001 \002(\010\"=\n\030RemoveSe" +
-      "rverCacheRequest\022\020\n\010tenantId\030\001 \001(\014\022\017\n\007ca" +
-      "cheId\030\002 \002(\014\"+\n\031RemoveServerCacheResponse" +
-      "\022\016\n\006return\030\001 \002(\0102\245\001\n\024ServerCachingServic" +
-      "e\022A\n\016addServerCache\022\026.AddServerCacheRequ" +
-      "est\032\027.AddServerCacheResponse\022J\n\021removeSe" +
-      "rverCache\022\031.RemoveServerCacheRequest\032\032.R" +
-      "emoveServerCacheResponseBG\n(org.apache.p" +
-      "hoenix.coprocessor.generatedB\023ServerCach",
-      "ingProtosH\001\210\001\001\240\001\001"
+      "\022\036\n\026immutableStorageScheme\030\025 \002(\005\022\027\n\017view" +
+      "IndexIdType\030\026 \001(\005\"\370\001\n\025AddServerCacheRequ" +
+      "est\022\020\n\010tenantId\030\001 \001(\014\022\017\n\007cacheId\030\002 \002(\014\022)" +
+      "\n\010cachePtr\030\003 \002(\0132\027.ImmutableBytesWritabl" +
+      "e\022)\n\014cacheFactory\030\004 \002(\0132\023.ServerCacheFac" +
+      "tory\022\017\n\007txState\030\005 \001(\014\022\"\n\032hasProtoBufInde" +
+      "xMaintainer\030\006 \001(\010\022\025\n\rclientVersion\030\007 \001(\005",
+      "\022\032\n\022usePersistentCache\030\010 \001(\010\"(\n\026AddServe" +
+      "rCacheResponse\022\016\n\006return\030\001 \002(\010\"=\n\030Remove" +
+      "ServerCacheRequest\022\020\n\010tenantId\030\001 \001(\014\022\017\n\007" +
+      "cacheId\030\002 \002(\014\"+\n\031RemoveServerCacheRespon" +
+      "se\022\016\n\006return\030\001 \002(\0102\245\001\n\024ServerCachingServ" +
+      "ice\022A\n\016addServerCache\022\026.AddServerCacheRe" +
+      "quest\032\027.AddServerCacheResponse\022J\n\021remove" +
+      "ServerCache\022\031.RemoveServerCacheRequest\032\032" +
+      ".RemoveServerCacheResponseBG\n(org.apache" +
+      ".phoenix.coprocessor.generatedB\023ServerCa",
+      "chingProtosH\001\210\001\001\240\001\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -8859,7 +8859,7 @@ public final class ServerCachingProtos {
           internal_static_IndexMaintainer_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_IndexMaintainer_descriptor,
-              new java.lang.String[] { "SaltBuckets", "IsMultiTenant", "ViewIndexId", "IndexedColumns", "IndexedColumnTypeOrdinal", "DataTableColRefForCoveredColumns", "IndexTableColRefForCoveredColumns", "IsLocalIndex", "IndexTableName", "RowKeyOrderOptimizable", "DataTableEmptyKeyValueColFamily", "EmptyKeyValueColFamily", "IndexedExpressions", "RowKeyMetadata", "NumDataTableColFamilies", "IndexWalDisabled", "IndexRowKeyByteSize", "Immutable", "IndexedColumnInfo", "EncodingScheme", "ImmutableStorageScheme", "ViewIndexType", });
+              new java.lang.String[] { "SaltBuckets", "IsMultiTenant", "ViewIndexId", "IndexedColumns", "IndexedColumnTypeOrdinal", "DataTableColRefForCoveredColumns", "IndexTableColRefForCoveredColumns", "IsLocalIndex", "IndexTableName", "RowKeyOrderOptimizable", "DataTableEmptyKeyValueColFamily", "EmptyKeyValueColFamily", "IndexedExpressions", "RowKeyMetadata", "NumDataTableColFamilies", "IndexWalDisabled", "IndexRowKeyByteSize", "Immutable", "IndexedColumnInfo", "EncodingScheme", "ImmutableStorageScheme", "ViewIndexIdType", });
           internal_static_AddServerCacheRequest_descriptor =
             getDescriptor().getMessageTypes().get(4);
           internal_static_AddServerCacheRequest_fieldAccessorTable = new

--- a/phoenix-core/src/main/java/org/apache/phoenix/index/IndexMaintainer.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/index/IndexMaintainer.java
@@ -318,7 +318,7 @@ public class IndexMaintainer implements Writable, Iterable<ColumnReference> {
     }
     
     private byte[] viewIndexId;
-    private PDataType viewIndexType;
+    private PDataType viewIndexIdType;
     private boolean isMultiTenant;
     // indexed expressions that are not present in the row key of the data table, the expression can also refer to a regular column
     private List<Expression> indexedExpressions;
@@ -376,8 +376,8 @@ public class IndexMaintainer implements Writable, Iterable<ColumnReference> {
         this(dataTable.getRowKeySchema(), dataTable.getBucketNum() != null);
         this.rowKeyOrderOptimizable = index.rowKeyOrderOptimizable();
         this.isMultiTenant = dataTable.isMultiTenant();
-        this.viewIndexId = index.getViewIndexId() == null ? null : index.getViewIndexType().toBytes(index.getViewIndexId());
-        this.viewIndexType = index.getViewIndexType();
+        this.viewIndexId = index.getViewIndexId() == null ? null : index.getviewIndexIdType().toBytes(index.getViewIndexId());
+        this.viewIndexIdType = index.getviewIndexIdType();
         this.isLocalIndex = index.getIndexType() == IndexType.LOCAL;
         this.encodingScheme = index.getEncodingScheme();
         
@@ -829,7 +829,7 @@ public class IndexMaintainer implements Writable, Iterable<ColumnReference> {
 
                 @Override
                 public PDataType getDataType() {
-                    return viewIndexType;
+                    return viewIndexIdType;
                 }
 
                 @Override
@@ -1231,7 +1231,7 @@ public class IndexMaintainer implements Writable, Iterable<ColumnReference> {
             // Fixed length
             //Use legacy viewIndexIdType for clients older than 4.10 release
             viewIndexId = new byte[MetaDataUtil.getLegacyViewIndexIdDataType().getByteSize()];
-            viewIndexType = MetaDataUtil.getLegacyViewIndexIdDataType();
+            viewIndexIdType = MetaDataUtil.getLegacyViewIndexIdDataType();
             input.readFully(viewIndexId);
         }
         int nIndexedColumns = Math.abs(encodedIndexedColumnsAndViewId) - 1;
@@ -1348,8 +1348,8 @@ public class IndexMaintainer implements Writable, Iterable<ColumnReference> {
         maintainer.nIndexSaltBuckets = proto.getSaltBuckets();
         maintainer.isMultiTenant = proto.getIsMultiTenant();
         maintainer.viewIndexId = proto.hasViewIndexId() ? proto.getViewIndexId().toByteArray() : null;
-        maintainer.viewIndexType = proto.hasViewIndexType()
-                ? PDataType.fromTypeId(proto.getViewIndexType())
+        maintainer.viewIndexIdType = proto.hasViewIndexIdType()
+                ? PDataType.fromTypeId(proto.getViewIndexIdType())
                 : MetaDataUtil.getLegacyViewIndexIdDataType();
         List<ServerCachingProtos.ColumnReference> indexedColumnsList = proto.getIndexedColumnsList();
         maintainer.indexedColumns = new HashSet<ColumnReference>(indexedColumnsList.size());
@@ -1470,7 +1470,7 @@ public class IndexMaintainer implements Writable, Iterable<ColumnReference> {
         builder.setIsMultiTenant(maintainer.isMultiTenant);
         if (maintainer.viewIndexId != null) {
             builder.setViewIndexId(ByteStringer.wrap(maintainer.viewIndexId));
-            builder.setViewIndexType(maintainer.viewIndexType.getSqlType());
+            builder.setViewIndexIdType(maintainer.viewIndexIdType.getSqlType());
         }
         for (ColumnReference colRef : maintainer.indexedColumns) {
             ServerCachingProtos.ColumnReference.Builder cRefBuilder =  ServerCachingProtos.ColumnReference.newBuilder();

--- a/phoenix-core/src/main/java/org/apache/phoenix/index/PhoenixIndexFailurePolicy.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/index/PhoenixIndexFailurePolicy.java
@@ -318,7 +318,7 @@ public class PhoenixIndexFailurePolicy extends DelegateIndexFailurePolicy {
                     new HashMap<ImmutableBytesWritable, String>();
             for (PTable index : indexes) {
                 if (localIndex == null) localIndex = index;
-                localIndexNames.put(new ImmutableBytesWritable(index.getViewIndexType().toBytes(
+                localIndexNames.put(new ImmutableBytesWritable(index.getviewIndexIdType().toBytes(
                         index.getViewIndexId())), index.getName().getString());
             }
             if (localIndex == null) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/DelegateTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/DelegateTable.java
@@ -218,8 +218,8 @@ public class DelegateTable implements PTable {
     }
 
     @Override
-    public PDataType getViewIndexType() {
-        return delegate.getViewIndexType();
+    public PDataType getviewIndexIdType() {
+        return delegate.getviewIndexIdType();
     }
 
     @Override
@@ -331,5 +331,13 @@ public class DelegateTable implements PTable {
     @Override
     public Boolean useStatsForParallelization() {
         return delegate.useStatsForParallelization();
+    }
+
+    @Override public boolean hasViewModifiedUpdateCacheFrequency() {
+        return delegate.hasViewModifiedUpdateCacheFrequency();
+    }
+
+    @Override public boolean hasViewModifiedUseStatsForParallelization() {
+        return delegate.hasViewModifiedUseStatsForParallelization();
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/PTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/PTable.java
@@ -736,7 +736,7 @@ public interface PTable extends PMetaDataEntity {
     ViewType getViewType();
     String getViewStatement();
     Long getViewIndexId();
-    PDataType getViewIndexType();
+    PDataType getviewIndexIdType();
     PTableKey getKey();
 
     IndexType getIndexType();
@@ -774,7 +774,9 @@ public interface PTable extends PMetaDataEntity {
     QualifierEncodingScheme getEncodingScheme();
     EncodedCQCounter getEncodedCQCounter();
     Boolean useStatsForParallelization();
-    
+    boolean hasViewModifiedUpdateCacheFrequency();
+    boolean hasViewModifiedUseStatsForParallelization();
+
     /**
      * Class to help track encoded column qualifier counters per column family.
      */

--- a/phoenix-protocol/src/main/MetaDataService.proto
+++ b/phoenix-protocol/src/main/MetaDataService.proto
@@ -61,7 +61,7 @@ message SharedTableState {
   repeated PColumn columns = 4;  
   repeated bytes physicalNames = 5;
   required int64 viewIndexId = 6;
-  optional int32 viewIndexType = 7 [default = 5];
+  optional int32 viewIndexIdType = 7 [default = 5];
 }
 
 message MetaDataResponse {
@@ -77,7 +77,7 @@ message MetaDataResponse {
   optional PSchema schema = 10;
   optional int64 autoPartitionNum = 11;
   optional int64 viewIndexId = 12;
-  optional int32 viewIndexType = 13 [default = 5];
+  optional int32 viewIndexIdType = 13 [default = 5];
 }
 
 message GetTableRequest {

--- a/phoenix-protocol/src/main/PTable.proto
+++ b/phoenix-protocol/src/main/PTable.proto
@@ -103,7 +103,7 @@ message PTable {
   repeated EncodedCQCounter encodedCQCounters = 36;
   optional bool useStatsForParallelization = 37;
   optional int32 transactionProvider = 38;
-  optional int32 viewIndexType = 39 [default = 5];
+  optional int32 viewIndexIdType = 39 [default = 5];
 }
 
 message EncodedCQCounter {

--- a/phoenix-protocol/src/main/ServerCachingService.proto
+++ b/phoenix-protocol/src/main/ServerCachingService.proto
@@ -62,7 +62,7 @@ message IndexMaintainer {
   repeated ColumnInfo indexedColumnInfo = 19;
   required int32 encodingScheme = 20;
   required int32 immutableStorageScheme = 21;
-  optional int32 viewIndexType = 22 ;
+  optional int32 viewIndexIdType = 22 ;
 }
 
 message AddServerCacheRequest {


### PR DESCRIPTION
[WIP]
- When a view alters a property, add a tag for the corresponding cell in SYSCAT
- Introduce a bitset to keep track of these properties in PTable
- Add tests
- TODO:
1. Handle the case where we "CREATE VIEW <>" with properties specified
2. Add unit tests for tagging changes
3. Refactoring change for PHOENIX-4951 as part of this patch itself.