### PR TITLE
PHOENIX-5136

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKeyIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKeyIT.java
@@ -580,6 +580,40 @@ public class OnDuplicateKeyIT extends ParallelStatsDisabledIT {
         }
     }
 
+    @Test
+    public void testRowsCreatedViaUpsertOnDuplicateKeyShouldNotBeReturnedInQueryIfNotMatched() throws Exception {
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        Connection conn = DriverManager.getConnection(getUrl(), props);
+        String tableName = generateUniqueName();
+        String ddl = " create table " + tableName + "(pk varchar primary key, counter1 bigint, counter2 smallint)";
+        conn.createStatement().execute(ddl);
+        createIndex(conn, tableName);
+        // The data has to be specifically starting with null for the first counter to fail the test. If you reverse the values, the test passes.
+        String dml1 = "UPSERT INTO " + tableName + " VALUES('a',NULL,2) ON DUPLICATE KEY UPDATE " +
+                "counter1 = CASE WHEN (counter1 IS NULL) THEN NULL ELSE counter1 END, " +
+                "counter2 = CASE WHEN (counter1 IS NULL) THEN 2 ELSE counter2 END";
+        conn.createStatement().execute(dml1);
+        conn.commit();
+
+        String dml2 = "UPSERT INTO " + tableName + " VALUES('b',1,2) ON DUPLICATE KEY UPDATE " +
+                "counter1 = CASE WHEN (counter1 IS NULL) THEN 1 ELSE counter1 END, " +
+                "counter2 = CASE WHEN (counter1 IS NULL) THEN 2 ELSE counter2 END";
+        conn.createStatement().execute(dml2);
+        conn.commit();
+
+        // Using this statement causes the test to pass
+        //ResultSet rs = conn.createStatement().executeQuery("SELECT * FROM " + tableName + " WHERE counter2 = 2 AND counter1 = 1");
+        // This statement should be equivalent to the one above, but it selects both rows.
+        ResultSet rs = conn.createStatement().executeQuery("SELECT * FROM " + tableName + " WHERE counter2 = 2 AND (counter1 = 1 OR counter1 = 1)");
+        assertTrue(rs.next());
+        assertEquals("b",rs.getString(1));
+        assertEquals(1,rs.getLong(2));
+        assertEquals(2,rs.getLong(3));
+        assertFalse(rs.next());
+
+        conn.close();
+    }
+
 
 }
     


### PR DESCRIPTION
`NULL` values for rows that are inserted using `UPSERT ON DUPLICATE KEY UPDATE` will be stored in HBase as empty byte arrays.  `NULL` values represented by empty byte arrays are not handled well in the `AndOrOperator.evaluate()`.  Any child expression of the `AndOrOperator` that evaluates to `NULL` represented by empty byte array will get marked in `partialEvalState`, thus having no effect when the `AndOrOperator` is re-evaluated against a different cell from the same row.  This causes problems because the child expression *should* be re-evaluated since it can still affect the final result.

The fix ensures that `partialEvalState` is not marked if the child expression evaluates to a NULL value represented by empty array.

Let me know if this fix is acceptable or if there is a better approach to this problem!