### PR TITLE
use PreparedStatement

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DeleteIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DeleteIT.java
@@ -791,9 +791,12 @@ public class DeleteIT extends ParallelStatsDisabledIT {
         props.setProperty(QueryServices.ENABLE_SERVER_SIDE_MUTATIONS, allowServerSideMutations);
         try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
             conn.createStatement().execute(ddl);
-            Statement stmt = conn.createStatement();
+            //Statement stmt = conn.createStatement();
+			PreparedStatement preStmt = conn.prepareStatement("UPSERT INTO " + tableName + " (pk1, v1) VALUES (" + ? + ",'value')");  
             for (int i = 0; i < numRecords ; i++) {
-                stmt.executeUpdate("UPSERT INTO " + tableName + " (pk1, v1) VALUES (" + i + ",'value')");
+                //stmt.executeUpdate("UPSERT INTO " + tableName + " (pk1, v1) VALUES (" + i + ",'value')");
+				preStmt.setBigDecimal(1, new BigDecimal(i));
+				preStmt.executeUpdate();
             }
             conn.commit();
             conn.setAutoCommit(autoCommit);


### PR DESCRIPTION
Hello,
Is it a good way to use "PreparedStatement" instead of "createStatement" in order to improve performance?  "PreparedStatement" is used to execute dynamic or parameterized SQL queries. It is helpful if we are executing a particular SQL query multiple times ( such as in a loop in this case) since "PreparedStatement" can be precompiled and the query is created only once.