### PR TITLE
PHOENIX-4900 Modify MAX_MUTATION_SIZE_EXCEEDED and MAX_MUTATION_SIZE_…

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MutationStateIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MutationStateIT.java
@@ -59,7 +59,51 @@ public class MutationStateIT extends ParallelStatsDisabledIT {
     }
 
     @Test
-    public void testMaxMutationSize() throws Exception {
+    public void testDeleteMaxMutationSize() throws SQLException {
+        String tableName = generateUniqueName();
+        int NUMBER_OF_ROWS = 20;
+        String ddl = "CREATE TABLE " + tableName + " (V BIGINT PRIMARY KEY, K BIGINT)";
+        PhoenixConnection conn = (PhoenixConnection) DriverManager.getConnection(getUrl());
+        conn.createStatement().execute(ddl);
+
+        for(int i = 0; i < NUMBER_OF_ROWS; i++) {
+            conn.createStatement().execute(
+                    "UPSERT INTO " + tableName + " VALUES (" + i + ", "+ i + ")");
+            conn.commit();
+        }
+
+        Properties props = new Properties();
+        props.setProperty(QueryServices.MAX_MUTATION_SIZE_ATTRIB,
+                String.valueOf(NUMBER_OF_ROWS / 2));
+        PhoenixConnection connection =
+                (PhoenixConnection) DriverManager.getConnection(getUrl(), props);
+        connection.setAutoCommit(false);
+
+        try {
+            for(int i = 0; i < NUMBER_OF_ROWS; i++) {
+                connection.createStatement().execute(
+                        "DELETE FROM " + tableName + " WHERE K = " + i );
+            }
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains(
+                    SQLExceptionCode.MAX_MUTATION_SIZE_EXCEEDED.getMessage()));
+        }
+
+        props.setProperty(QueryServices.MAX_MUTATION_SIZE_BYTES_ATTRIB, "10");
+        props.setProperty(QueryServices.MAX_MUTATION_SIZE_ATTRIB, "10000");
+        connection = (PhoenixConnection) DriverManager.getConnection(getUrl(), props);
+        connection.setAutoCommit(false);
+
+        try {
+            connection.createStatement().execute("DELETE FROM " + tableName );
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains(
+                    SQLExceptionCode.MAX_MUTATION_SIZE_BYTES_EXCEEDED.getMessage()));
+        }
+    }
+
+    @Test
+    public void testUpsertMaxMutationSize() throws Exception {
         Properties connectionProperties = new Properties();
         connectionProperties.setProperty(QueryServices.MAX_MUTATION_SIZE_ATTRIB, "3");
         connectionProperties.setProperty(QueryServices.MAX_MUTATION_SIZE_BYTES_ATTRIB, "1000000");
@@ -76,6 +120,8 @@ public class MutationStateIT extends ParallelStatsDisabledIT {
         } catch (SQLException e) {
             assertEquals(SQLExceptionCode.MAX_MUTATION_SIZE_EXCEEDED.getErrorCode(),
                 e.getErrorCode());
+            assertTrue(e.getMessage().contains(
+                    SQLExceptionCode.MAX_MUTATION_SIZE_EXCEEDED.getMessage()));
         }
 
         // set the max mutation size (bytes) to a low value
@@ -89,6 +135,8 @@ public class MutationStateIT extends ParallelStatsDisabledIT {
         } catch (SQLException e) {
             assertEquals(SQLExceptionCode.MAX_MUTATION_SIZE_BYTES_EXCEEDED.getErrorCode(),
                 e.getErrorCode());
+            assertTrue(e.getMessage().contains(
+                    SQLExceptionCode.MAX_MUTATION_SIZE_BYTES_EXCEEDED.getMessage()));
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
@@ -466,8 +466,12 @@ public enum SQLExceptionCode {
         "because this client already has the maximum number" +
         " of connections to the target cluster."),
     
-    MAX_MUTATION_SIZE_EXCEEDED(729, "LIM01", "MutationState size is bigger than maximum allowed number of rows"),
-    MAX_MUTATION_SIZE_BYTES_EXCEEDED(730, "LIM02", "MutationState size is bigger than maximum allowed number of bytes"), 
+    MAX_MUTATION_SIZE_EXCEEDED(729, "LIM01", "MutationState size is bigger" +
+            " than maximum allowed number of rows, try upserting rows in smaller batches or " +
+            "using autocommit on for deletes."),
+    MAX_MUTATION_SIZE_BYTES_EXCEEDED(730, "LIM02", "MutationState size is " +
+            "bigger than maximum allowed number of bytes, try upserting rows in smaller batches " +
+            "or using autocommit on for deletes."),
     INSUFFICIENT_MEMORY(999, "50M01", "Unable to allocate enough memory."),
     HASH_JOIN_CACHE_NOT_FOUND(900, "HJ01", "Hash Join cache not found"),
 


### PR DESCRIPTION
…BYTES_EXCEEDED exception message to recommend turning autocommit off for deletes