### PR TITLE
PHOENIX-5176 KeyRange.compareUpperRange(KeyRang 1, KeyRang 2) returns wrong result when two key ranges have the same upper bound values but one is inclusive and another is exclusive

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/query/KeyRange.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/KeyRange.java
@@ -519,7 +519,7 @@ public class KeyRange implements Writable {
         return Lists.transform(keys, POINT);
     }
 
-    private static int compareUpperRange(KeyRange rowKeyRange1,KeyRange rowKeyRange2) {
+    public static int compareUpperRange(KeyRange rowKeyRange1,KeyRange rowKeyRange2) {
         int result = Boolean.compare(rowKeyRange1.upperUnbound(), rowKeyRange2.upperUnbound());
         if (result != 0) {
             return result;
@@ -528,7 +528,7 @@ public class KeyRange implements Writable {
         if (result != 0) {
             return result;
         }
-        return Boolean.compare(rowKeyRange2.isUpperInclusive(), rowKeyRange1.isUpperInclusive());
+        return Boolean.compare(rowKeyRange1.isUpperInclusive(), rowKeyRange2.isUpperInclusive());
     }
 
     public static List<KeyRange> intersect(List<KeyRange> rowKeyRanges1, List<KeyRange> rowKeyRanges2) {


### PR DESCRIPTION
#### What does this PR do?
Which problem(s) does it fix and how? What does this PR add?

#### Where should the reviewer start?
Explain what should be set-up first in order to get the review started. Which page has to be viewed etc.

#### How should this be manually tested?
- [ ] Write down all
- [ ] the steps a person
- [ ] needs to take to test it.

#### Documents
##### Screenshots (if appropriate)
If this PR changes something that concerns UI changes, please post before and after screenshots here.

##### Other documents
If you have any documents that have anything to do with this PR.

#### Who should be notified?
- [ ] Write down the name/department this branch needs
- [ ] to be communicated to
- [ ] Check the box(es) to indicate that it has been
- [ ] communicated (add the label)

#### What should happen on deployment? (check all that apply)
- [x] The usual steps.
- [ ] There are database changes, which should be run.
- [ ] There are files that should be manually uploaded.

#### Questions:
- Does this require a blog post?
- Does this require a knowledge base update?
- Does support need training for this?
- Does this has to be communicated to partners?