### PR TITLE
PHOENIX-5224 Change 'Statement' to 'PreparedStatement' for better performance

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DeleteIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DeleteIT.java
@@ -791,9 +791,11 @@ public class DeleteIT extends ParallelStatsDisabledIT {
         props.setProperty(QueryServices.ENABLE_SERVER_SIDE_MUTATIONS, allowServerSideMutations);
         try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
             conn.createStatement().execute(ddl);
-            Statement stmt = conn.createStatement();
+            String sqlStr = "UPSERT INTO " + tableName + " (pk1, v1) VALUES (?,'value')";
+            PreparedStatement stmt = conn.prepareStatement(sqlStr);
             for (int i = 0; i < numRecords ; i++) {
-                stmt.executeUpdate("UPSERT INTO " + tableName + " (pk1, v1) VALUES (" + i + ",'value')");
+                stmt.setInt(1, i);
+                stmt.executeUpdate();
             }
             conn.commit();
             conn.setAutoCommit(autoCommit);
@@ -856,8 +858,11 @@ public class DeleteIT extends ParallelStatsDisabledIT {
             conn.createStatement().execute(ddl);
             conn.createStatement().execute(idx1);
             Statement stmt = conn.createStatement();
+            PreparedStatement stmt = conn.papareStatement("UPSERT INTO " + tableName + " VALUES (?, ?, 'value2')");
             for(int i = 0; i < 20; i++) {
-                stmt.executeUpdate("UPSERT INTO " + tableName + " VALUES ("+i+",'value"+i+"', 'value2')");
+                stmt.setInt(1, i);
+                stmt.setString(2, "value"+i);
+                stmt.executeUpdate();
                 if (i % 10 == 0) {
                     conn.commit();
                 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DropTableIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DropTableIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.sql.PreparedStatement;
 
 import org.junit.Test;
 
@@ -35,8 +36,9 @@ public class DropTableIT extends ParallelStatsDisabledIT {
           final Statement stmt = conn.createStatement()) {
         assertFalse(stmt.execute(String.format("CREATE TABLE %s(pk varchar not null primary key)", tableName)));
         String dropTable = String.format("DROP TABLE IF EXISTS %s", tableName);
+        PreparedStatement pstmt = conn.prepareStatement(dropTable);
         for (int i = 0; i < 5; i++) {
-          assertFalse(stmt.execute(dropTable));
+          assertFalse(stmt.execute());
         }
       }
     }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/UpsertSelectAutoCommitIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/UpsertSelectAutoCommitIT.java
@@ -236,11 +236,9 @@ public class UpsertSelectAutoCommitIT extends ParallelStatsDisabledIT {
         conn.createStatement().execute(
                 "UPSERT INTO " + tableName + " VALUES (NEXT VALUE FOR "+ tableName + "_seq, 1)");
         conn.commit();
+        PreparedStatement stmt = conn.parareStatement("UPSERT INTO " + tableName + " SELECT NEXT VALUE FOR "+ tableName + "_seq, val FROM " + tableName);
         for (int i=0; i<6; i++) {
-            Statement stmt = conn.createStatement();
-            int upsertCount = stmt.executeUpdate(
-                    "UPSERT INTO " + tableName + " SELECT NEXT VALUE FOR "+ tableName + "_seq, val FROM "
-                            + tableName);
+            int upsertCount = stmt.executeUpdate();
             conn.commit();
             assertEquals((int)Math.pow(2, i), upsertCount);
         }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/IndexRebuildIncrementDisableCountIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/IndexRebuildIncrementDisableCountIT.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -168,10 +169,14 @@ public class IndexRebuildIncrementDisableCountIT extends BaseUniqueNamesOwnClust
         try {
 
             Statement stmt = conn.createStatement();
+            String sqlStr = "UPSERT INTO " + tableName + " VALUES(?, ?, ?, ?)"; 
+            PreparedStatement stmt = conn.prepareStatement(sqlStr);
             for (int i = 0; i < 10000; i++) {
-                stmt.executeUpdate(
-                    "UPSERT INTO " + tableName + " VALUES('" + getRandomOrgId(maxOrgId) + "'," + i
-                            + "," + (i + 1) + "," + (i + 2) + ")");
+                stmt.setString(1, getRandomOrgId(maxOrgId);
+                stmt.setInt(2, i);
+                stmt.setInt(3, i + 1);
+                stmt.setInt(4, i + 2);
+                stmt.executeUpdate();
             }
             conn.commit();
         } catch (Exception e) {

--- a/phoenix-core/src/it/java/org/apache/phoenix/tx/TxCheckpointIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/tx/TxCheckpointIT.java
@@ -28,6 +28,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
@@ -104,9 +105,9 @@ public class TxCheckpointIT extends ParallelStatsDisabledIT {
         conn.createStatement().execute("CREATE "+(localIndex? "LOCAL " : "")+"INDEX " + indexName + " ON " + fullTableName + "(val)");
 
         conn.createStatement().execute("UPSERT INTO " + fullTableName + " VALUES (NEXT VALUE FOR " + seqName + ",1)");
+        PreparedStatement stmt = comm.prepareStatement("UPSERT INTO " + fullTableName + " SELECT NEXT VALUE FOR " + seqName + ", val FROM " + fullTableName);
         for (int i=0; i<6; i++) {
-            Statement stmt = conn.createStatement();
-            int upsertCount = stmt.executeUpdate("UPSERT INTO " + fullTableName + " SELECT NEXT VALUE FOR " + seqName + ", val FROM " + fullTableName);
+            int upsertCount = stmt.executeUpdate();
             assertEquals((int)Math.pow(2, i), upsertCount);
         }
         conn.close();

--- a/phoenix-queryserver/src/it/java/org/apache/phoenix/end2end/HttpParamImpersonationQueryServerIT.java
+++ b/phoenix-queryserver/src/it/java/org/apache/phoenix/end2end/HttpParamImpersonationQueryServerIT.java
@@ -32,6 +32,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -380,11 +381,13 @@ public class HttpParamImpersonationQueryServerIT {
 
     void createTable(String tableName, int numRows) throws Exception {
         try (Connection conn = DriverManager.getConnection(PQS_URL);
-            Statement stmt = conn.createStatement()) {
+            Statement stmt = conn.createStatement();
+            PreparedStatement pstmt = conn.prepareStatement("UPSERT INTO " + tableName + " values(?)")) {
             conn.setAutoCommit(true);
             assertFalse(stmt.execute("CREATE TABLE " + tableName + "(pk integer not null primary key)"));
             for (int i = 0; i < numRows; i++) {
-                assertEquals(1, stmt.executeUpdate("UPSERT INTO " + tableName + " values(" + i + ")"));
+                pstmt.setInt(1, i);
+                assertEquals(1, stmt.executeUpdate());
             }
             readRows(stmt, tableName, numRows);
         }

--- a/phoenix-queryserver/src/it/java/org/apache/phoenix/end2end/SecureQueryServerIT.java
+++ b/phoenix-queryserver/src/it/java/org/apache/phoenix/end2end/SecureQueryServerIT.java
@@ -29,6 +29,7 @@ import java.security.PrivilegedExceptionAction;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -294,12 +295,14 @@ public class SecureQueryServerIT {
                 // Phoenix
                 final String tableName = "phx_table1";
                 try (java.sql.Connection conn = DriverManager.getConnection(PQS_URL);
-                        Statement stmt = conn.createStatement()) {
+                        Statement stmt = conn.createStatement(); 
+                        PreparedStatement pstmt = conn.prepareStatement("UPSERT INTO " + tableName + " values(?)"))) {
                     conn.setAutoCommit(true);
                     assertFalse(stmt.execute("CREATE TABLE " + tableName + "(pk integer not null primary key)"));
                     final int numRows = 5;
                     for (int i = 0; i < numRows; i++) {
-                      assertEquals(1, stmt.executeUpdate("UPSERT INTO " + tableName + " values(" + i + ")"));
+                      pstmt.setInt(1, i);
+                      assertEquals(1, stmt.executeUpdate());
                     }
 
                     try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName)) {


### PR DESCRIPTION
Fix: [#PHOENIX-5224](https://issues.apache.org/jira/browse/PHOENIX-5224). When the same SQL query is intensively used in a loop, it should be replaced with PreparedStatement, which is a big gain on performance.