### PR TITLE
PHOENIX-5246: PhoenixAccessControllers.getAccessControllers() method …

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/PhoenixAccessController.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/PhoenixAccessController.java
@@ -71,7 +71,7 @@ import com.google.protobuf.RpcCallback;
 public class PhoenixAccessController extends BaseMetaDataEndpointObserver {
 
     private PhoenixMetaDataControllerEnvironment env;
-    private ArrayList<BaseMasterAndRegionObserver> accessControllers;
+    private volatile ArrayList<BaseMasterAndRegionObserver> accessControllers;
     private boolean accessCheckEnabled;
     private UserProvider userProvider;
     public static final Log LOG = LogFactory.getLog(PhoenixAccessController.class);


### PR DESCRIPTION
…is not correctly implementing the double-checked locking