### PR TITLE
PHOENIX-5261: Implement ALTER TABLE/VIEW ADD COLUMN CASCADE

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/AlterAddCascadeIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/AlterAddCascadeIndexIT.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.end2end;
+
+import org.apache.phoenix.schema.PTableImpl;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+
+@RunWith(Parameterized.class)
+public class AlterAddCascadeIndexIT extends ParallelStatsDisabledIT {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    private static Connection conn;
+    private Properties prop;
+    private boolean isViewIndex;
+    private boolean isLocalIndex;
+    private String databaseObjectName;
+    private String indexesName;
+    private String planOutput;
+    private final String tableDDLOptions;
+
+
+    public AlterAddCascadeIndexIT(boolean isViewIndex, boolean isLocalIndex, boolean mutable, boolean columnEncoded) {
+        this.isViewIndex = isViewIndex;
+        this.isLocalIndex = isLocalIndex;
+        StringBuilder optionBuilder = new StringBuilder();
+        if (!columnEncoded) {
+            optionBuilder.append("COLUMN_ENCODED_BYTES=0");
+        }
+        if (!mutable && !columnEncoded) {
+            optionBuilder.append(",IMMUTABLE_ROWS=true");
+        } else if (!mutable && columnEncoded) {
+            optionBuilder.append("IMMUTABLE_ROWS=true");
+        }
+        if (!columnEncoded && !mutable) {
+            optionBuilder.append(",IMMUTABLE_STORAGE_SCHEME="+ PTableImpl.ImmutableStorageScheme.ONE_CELL_PER_COLUMN);
+        }
+        this.tableDDLOptions = optionBuilder.toString();
+    }
+
+    @Parameters(name="AlterAddCascadeIndexIT_isViewIndex={0},isLocalIndex={1},mutable={2},columnEncoded={3}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { true, true, true, true},
+            { true, true, true, false},
+            { true, true, false, true},
+            { true, true, false, false},
+            { true, false, true, true},
+            { true, false, true, false},
+            { true, false, false, true},
+            { true, false, false, false},
+            { false, true, true, true},
+            { false, true, true, false},
+            { false, true, false, true},
+            { false, true, false, false},
+            { false, false, true, true},
+            { false, false, true, false},
+            { false, false, false, true},
+            { false, false, false, false}
+        });
+    }
+
+    @Before
+    public void setup() throws SQLException {
+        prop = new Properties();
+        conn = DriverManager.getConnection(getUrl(), prop);
+        conn.setAutoCommit(true);
+        conn.createStatement().execute("CREATE TABLE IF NOT EXISTS us_population (\n" +
+                "      state CHAR(2) NOT NULL,\n" +
+                "      city VARCHAR NOT NULL,\n" +
+                "      population BIGINT,\n" +
+                "      CONSTRAINT my_pk PRIMARY KEY (state, city)) " + tableDDLOptions);
+
+        loadData();
+
+        if(isViewIndex) {
+            conn.createStatement().execute("CREATE VIEW IF NOT EXISTS us_population_gv" +
+                    "(city_area INTEGER, avg_fam_size INTEGER) AS " +
+                    "SELECT * FROM us_population WHERE state = 'CA'");
+
+            conn.createStatement().execute("CREATE "+(isLocalIndex ? "LOCAL " : "") +"INDEX IF NOT EXISTS us_population_gv_gi ON " +
+                    "us_population_gv (city_area) INCLUDE (population)");
+            conn.createStatement().execute("CREATE "+(isLocalIndex ? "LOCAL " : "")+"INDEX IF NOT EXISTS us_population_gv_gi_2 ON " +
+                    "us_population_gv (avg_fam_size) INCLUDE (population)");
+            databaseObjectName = "us_population_gv";
+            indexesName = "us_population_gv_gi, us_population_gv_gi_2";
+            planOutput = isLocalIndex? "US_POPULATION" : "_IDX_US_POPULATION";
+
+        } else {
+            conn.createStatement().execute("CREATE "+ (isLocalIndex ? "LOCAL " : "") + "INDEX IF NOT EXISTS us_population_gi ON " +
+                    "us_population (population)");
+            conn.createStatement().execute("CREATE "+ (isLocalIndex ? "LOCAL " : "") + "INDEX IF NOT EXISTS us_population_gi_2 ON " +
+                    "us_population (state, population)");
+            databaseObjectName = "us_population";
+            indexesName = "us_population_gi, us_population_gi_2";
+            planOutput = isLocalIndex? "US_POPULATION" : "us_population_gi";
+        }
+    }
+
+    private void loadData() throws SQLException {
+        PreparedStatement ps = conn.prepareStatement("UPSERT INTO us_population VALUES('NY','New York',8143197)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('CA','Los Angeles',3844829)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('IL','Chicago',2842518)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('TX','Houston',2016582)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('PA','Philadelphia',1463281)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('AZ','Phoenix',1461575)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('TX','San Antonio',1256509)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('CA','San Diego',1255540)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('TX','Dallas',1213825)");
+        ps.executeUpdate();
+        ps = conn.prepareStatement("UPSERT INTO us_population VALUES('CA','San Jose',912332)");
+        ps.executeUpdate();
+    }
+
+    // Test with ALTER TABLE CASCADE INDEX ALL
+    @Test
+    public void testAlterDBOAddCascadeIndexAll() throws SQLException {
+        String query = "ALTER " +(isViewIndex? "VIEW " : "TABLE ") + databaseObjectName +" ADD new_column VARCHAR CASCADE INDEX ALL";
+        conn.createStatement().execute(query);
+        query = "EXPLAIN SELECT new_column FROM "+databaseObjectName;
+        ResultSet rs = conn.prepareStatement(query).executeQuery();
+        rs.next();
+        //confirm it is using global index to access the column
+        Assert.assertTrue(rs.getString(1).contains(planOutput.toUpperCase()));
+    }
+
+    // Test with ALTER VIEW CASCADE INDEX ALL
+    @Test
+    public void testAlterDBOAddCascadeIndexAllUpsert() throws SQLException {
+        String query = "ALTER " +(isViewIndex? "VIEW " : "TABLE ") + databaseObjectName +" ADD new_column_3 VARCHAR CASCADE INDEX ALL";
+        conn.createStatement().execute(query);
+        PreparedStatement ps;
+        if(isViewIndex) {
+            ps = conn.prepareStatement("UPSERT INTO us_population_gv(state,city,population,city_area,avg_fam_size,new_column_3) " +
+                    "VALUES('CA','Santa Barbara',912332,1300,4,'test_column')");
+        } else {
+            ps = conn.prepareStatement("UPSERT INTO us_population(state,city,population,new_column_3) " +
+                    "VALUES('CA','Santa Barbara',912332,'test_column')");
+        }
+        ps.executeUpdate();
+        query = "EXPLAIN SELECT new_column_3 FROM "+databaseObjectName+" where new_column_3 = 'test_column'";
+        ResultSet rs = conn.prepareStatement(query).executeQuery();
+        rs.next();
+        //confirm it is using global index to access the column
+        Assert.assertTrue(rs.getString(1).contains(planOutput.toUpperCase()));
+        query = "SELECT new_column_3 FROM "+databaseObjectName+" where new_column_3 = 'test_column'";
+        rs = conn.prepareStatement(query).executeQuery();
+        rs.next();
+        Assert.assertEquals(rs.getString(1),"test_column");
+    }
+
+    // Test with CASCADE INDEX <index_name>
+    @Test
+    public void testAlterDBOAddCascadeIndex() throws SQLException {
+        String query = "ALTER " + (isViewIndex? "VIEW " : "TABLE ")
+                + databaseObjectName + " ADD new_column_1 FLOAT CASCADE INDEX " + indexesName.split(",")[0];
+        conn.createStatement().execute(query);
+        query = "EXPLAIN SELECT new_column_1 FROM " + databaseObjectName;
+        ResultSet rs = conn.prepareStatement(query).executeQuery();
+        rs.next();
+        //confirm it is using global index to access the column
+        System.out.println(rs.getString(1));
+        Assert.assertTrue(rs.getString(1).contains(planOutput.toUpperCase()));
+    }
+
+    // Test with CASCADE INDEX <index_name>
+    @Test
+    public void testAlterDBOAddCascadeIndexTwoCols() throws SQLException {
+        String query = "ALTER " + (isViewIndex ? "VIEW " : "TABLE ") + databaseObjectName
+                + " ADD new_column_1 FLOAT, new_column_2 BIGINT CASCADE INDEX " + indexesName.split(",")[0];
+        conn.createStatement().execute(query);
+        query = "EXPLAIN SELECT new_column_1, new_column_2 FROM " + databaseObjectName;
+        ResultSet rs = conn.prepareStatement(query).executeQuery();
+        rs.next();
+        //confirm it is using global index to access the column
+        Assert.assertTrue(rs.getString(1).contains(planOutput.toUpperCase()));
+    }
+
+    // Test with CASCADE INDEX <index_name>, <index_name>
+    @Test
+    public void testAlterDBOAddCascadeIndexes() throws SQLException {
+        String query = "ALTER " + (isViewIndex ? "VIEW " : "TABLE ")
+                + databaseObjectName + " ADD new_column_1 DOUBLE CASCADE INDEX " + indexesName;
+        conn.createStatement().execute(query);
+        query = "EXPLAIN SELECT new_column_1 FROM " + databaseObjectName;
+        ResultSet rs = conn.prepareStatement(query).executeQuery();
+        rs.next();
+        //confirm it is using global index to access the column
+        Assert.assertTrue(rs.getString(1).contains(planOutput.toUpperCase()));
+    }
+
+    // Exception for invalid grammar
+    @Test
+    public void testAlterDBOInvalidGrammarI() throws SQLException {
+        String query = "ALTER " + (isViewIndex ? "VIEW " : "TABLE ") + databaseObjectName + " ADD new_column VARCHAR ALL";
+        exception.expectMessage("Syntax error");
+        conn.createStatement().execute(query);
+    }
+
+    // Exception for invalid grammar
+    @Test
+    public void testAlterDBOInvalidGrammarII() throws SQLException {
+        String query = "ALTER " + (isViewIndex ? "VIEW " : "TABLE ") + databaseObjectName
+                + " ADD new_column VARCHAR CASCADE " + indexesName.split(",")[0];
+        exception.expectMessage("Syntax error");
+        conn.createStatement().execute(query);
+    }
+
+    // Exception for invalid grammar
+    @Test
+    public void testAlterDBOInvalidGrammarIII() throws SQLException {
+        String query = "ALTER " + (isViewIndex ? "VIEW " : "TABLE ") + databaseObjectName
+                + " ADD new_column VARCHAR INDEX " + indexesName.split(",")[0];
+        exception.expectMessage("Syntax error");
+        conn.createStatement().execute(query);
+    }
+
+    @After
+    public void teardown() throws SQLException {
+        if (isViewIndex) {
+            conn.createStatement().execute("DROP INDEX IF EXISTS us_population_gv_gi ON us_population_gv");
+            conn.createStatement().execute("DROP INDEX IF EXISTS us_population_gv_gi_2 ON us_population_gv");
+        } else {
+            conn.createStatement().execute("DROP INDEX IF EXISTS us_population_gi ON us_population");
+            conn.createStatement().execute("DROP INDEX IF EXISTS us_population_gi_2 ON us_population");
+        }
+        conn.createStatement().execute("DROP VIEW IF EXISTS us_population_gv");
+        conn.createStatement().execute("DROP TABLE IF EXISTS us_population");
+    }
+}

--- a/phoenix-core/src/main/antlr3/PhoenixSQL.g
+++ b/phoenix-core/src/main/antlr3/PhoenixSQL.g
@@ -656,8 +656,8 @@ alter_session_node returns [AlterSessionStatement ret]
 // Parse an alter table statement.
 alter_table_node returns [AlterTableStatement ret]
     :   ALTER (TABLE | v=VIEW) t=from_table_name
-        ( (DROP COLUMN (IF ex=EXISTS)? c=column_names) | (ADD (IF NOT ex=EXISTS)? (d=column_defs) (p=fam_properties)?) | (SET (p=fam_properties)) )
-        { PTableType tt = v==null ? (QueryConstants.SYSTEM_SCHEMA_NAME.equals(t.getSchemaName()) ? PTableType.SYSTEM : PTableType.TABLE) : PTableType.VIEW; ret = ( c == null ? factory.addColumn(factory.namedTable(null,t), tt, d, ex!=null, p) : factory.dropColumn(factory.namedTable(null,t), tt, c, ex!=null) ); }
+        ( (DROP COLUMN (IF ex=EXISTS)? c=column_names) | (ADD (IF NOT ex=EXISTS)? (d=column_defs) (p=fam_properties)?) (cas=CASCADE INDEX (list=indexes | all=ALL))? | (SET (p=fam_properties)) )
+        { PTableType tt = v==null ? (QueryConstants.SYSTEM_SCHEMA_NAME.equals(t.getSchemaName()) ? PTableType.SYSTEM : PTableType.TABLE) : PTableType.VIEW; ret = ( c == null ? factory.addColumn(factory.namedTable(null,t), tt, d, ex!=null, p, cas!=null, (all == null ? list : null)) : factory.dropColumn(factory.namedTable(null,t), tt, c, ex!=null) ); }
     ;
 
 update_statistics_node returns [UpdateStatisticsStatement ret]
@@ -682,6 +682,11 @@ properties returns [Map<String,Object> ret]
 column_defs returns [List<ColumnDef> ret]
 @init{ret = new ArrayList<ColumnDef>(); }
     :  v = column_def {$ret.add(v);}  (COMMA v = column_def {$ret.add(v);} )*
+;
+
+indexes returns [List<NamedNode> ret]
+@init{ret = new ArrayList<NamedNode>(); }
+    :  v = index_name {$ret.add(v);}  (COMMA v = index_name {$ret.add(v);} )*
 ;
 
 column_def returns [ColumnDef ret]

--- a/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
@@ -475,12 +475,16 @@ public enum SQLExceptionCode {
     INSUFFICIENT_MEMORY(999, "50M01", "Unable to allocate enough memory."),
     HASH_JOIN_CACHE_NOT_FOUND(900, "HJ01", "Hash Join cache not found"),
 
-    CANNOT_UPSERT_WITH_SCN_FOR_ROW_TIMSTAMP_COLUMN(901,"43M12",
+    CANNOT_UPSERT_WITH_SCN_FOR_ROW_TIMSTAMP_COLUMN(901, "43M12",
             "Cannot use a connection with SCN set to upsert data for " +
                     "table with ROW_TIMESTAMP column."),
-    CANNOT_UPSERT_WITH_SCN_FOR_MUTABLE_TABLE_WITH_INDEXES(903,"43M14",
+    CANNOT_UPSERT_WITH_SCN_FOR_MUTABLE_TABLE_WITH_INDEXES(903, "43M14",
             "Cannot use a connection with SCN set to " +
-                    "upsert data for a mutable table with indexes.");
+                    "upsert data for a mutable table with indexes."),
+
+    NOT_SUPPORTED_CASCADE_FEATURE_PK(904, "43M15",
+            "CASCADE feature is not supported to add PK column");
+
 
 
     private final int errorCode;

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -1420,8 +1420,8 @@ public class PhoenixStatement implements Statement, SQLCloseable {
 
     private static class ExecutableAddColumnStatement extends AddColumnStatement implements CompilableStatement {
 
-        ExecutableAddColumnStatement(NamedTableNode table, PTableType tableType, List<ColumnDef> columnDefs, boolean ifNotExists, ListMultimap<String,Pair<String,Object>> props) {
-            super(table, tableType, columnDefs, ifNotExists, props);
+        ExecutableAddColumnStatement(NamedTableNode table, PTableType tableType, List<ColumnDef> columnDefs, boolean ifNotExists, ListMultimap<String,Pair<String,Object>> props, boolean cascade, List<NamedNode> indexes) {
+            super(table, tableType, columnDefs, ifNotExists, props, cascade, indexes);
         }
 
         @SuppressWarnings("unchecked")
@@ -1562,8 +1562,8 @@ public class PhoenixStatement implements Statement, SQLCloseable {
         }
         
         @Override
-        public AddColumnStatement addColumn(NamedTableNode table,  PTableType tableType, List<ColumnDef> columnDefs, boolean ifNotExists, ListMultimap<String,Pair<String,Object>> props) {
-            return new ExecutableAddColumnStatement(table, tableType, columnDefs, ifNotExists, props);
+        public AddColumnStatement addColumn(NamedTableNode table,  PTableType tableType, List<ColumnDef> columnDefs, boolean ifNotExists, ListMultimap<String,Pair<String,Object>> props, boolean cascade, List<NamedNode> indexes) {
+            return new ExecutableAddColumnStatement(table, tableType, columnDefs, ifNotExists, props, cascade, indexes);
         }
         
         @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/AddColumnStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/AddColumnStatement.java
@@ -29,12 +29,16 @@ public class AddColumnStatement extends AlterTableStatement {
     private final List<ColumnDef> columnDefs;
     private final boolean ifNotExists;
     private final ListMultimap<String,Pair<String,Object>> props;
-    
-    protected AddColumnStatement(NamedTableNode table, PTableType tableType, List<ColumnDef> columnDefs, boolean ifNotExists, ListMultimap<String,Pair<String,Object>> props) {
+    private final boolean cascade;
+    private final List<NamedNode> indexes;
+
+    protected AddColumnStatement(NamedTableNode table, PTableType tableType, List<ColumnDef> columnDefs, boolean ifNotExists, ListMultimap<String,Pair<String,Object>> props, boolean cascade, List<NamedNode> indexes) {
         super(table, tableType);
         this.columnDefs = columnDefs;
         this.props = props == null ? ImmutableListMultimap.<String,Pair<String,Object>>of()  : props;
         this.ifNotExists = ifNotExists;
+        this.cascade = cascade;
+        this.indexes = indexes;
     }
 
     public List<ColumnDef> getColumnDefs() {
@@ -48,4 +52,8 @@ public class AddColumnStatement extends AlterTableStatement {
     public ListMultimap<String,Pair<String,Object>> getProps() {
         return props;
     }
+
+    public boolean isCascade() { return cascade; }
+
+    public List<NamedNode> getIndexes() { return indexes; }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
@@ -357,8 +357,8 @@ public class ParseNodeFactory {
         return new SequenceValueParseNode(tableName, SequenceValueParseNode.Op.NEXT_VALUE, numToAllocateNode);
     }
 
-    public AddColumnStatement addColumn(NamedTableNode table,  PTableType tableType, List<ColumnDef> columnDefs, boolean ifNotExists, ListMultimap<String,Pair<String,Object>> props) {
-        return new AddColumnStatement(table, tableType, columnDefs, ifNotExists, props);
+    public AddColumnStatement addColumn(NamedTableNode table,  PTableType tableType, List<ColumnDef> columnDefs, boolean ifNotExists, ListMultimap<String,Pair<String,Object>> props, boolean cascade, List<NamedNode>indexes) {
+        return new AddColumnStatement(table, tableType, columnDefs, ifNotExists, props, cascade, indexes);
     }
 
     public DropColumnStatement dropColumn(NamedTableNode table,  PTableType tableType, List<ColumnName> columnNodes, boolean ifExists) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/DelegateTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/DelegateTable.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.phoenix.hbase.index.util.KeyValueBuilder;
 import org.apache.phoenix.index.IndexMaintainer;
 import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.parse.NamedNode;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.transaction.TransactionFactory;
 
@@ -141,6 +142,12 @@ public class DelegateTable implements PTable {
     public List<PTable> getIndexes() {
         return delegate.getIndexes();
     }
+
+    @Override
+    public List<PTable> getIndexes(List<NamedNode> indexes) { return delegate.getIndexes(indexes); }
+
+    @Override
+    public List<PTable> getIndexes(boolean viewOnly) { return delegate.getIndexes(viewOnly); }
 
     @Override
     public PIndexState getIndexState() {

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/PTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/PTable.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.hbase.index.util.KeyValueBuilder;
 import org.apache.phoenix.index.IndexMaintainer;
 import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.parse.NamedNode;
 import org.apache.phoenix.schema.types.PArrayDataType;
 import org.apache.phoenix.schema.types.PArrayDataTypeDecoder;
 import org.apache.phoenix.schema.types.PArrayDataTypeEncoder;
@@ -56,7 +57,6 @@ public interface PTable extends PMetaDataEntity {
     public static final long INITIAL_SEQ_NUM = 0;
     public static final String IS_IMMUTABLE_ROWS_PROP_NAME = "IMMUTABLE_ROWS";
     public static final boolean DEFAULT_DISABLE_WAL = false;
-
     public enum ViewType {
         MAPPED((byte)1),
         READ_ONLY((byte)2),
@@ -707,6 +707,20 @@ public interface PTable extends PMetaDataEntity {
      * @return the list of indexes.
      */
     List<PTable> getIndexes();
+
+    /**
+     * Return the list of PTables for the indexes passed in as parameter
+     * @param indexes list of names of indexes
+     * @return the list of PTable indexes corresponding to input
+     */
+    List<PTable> getIndexes(List<NamedNode> indexes);
+
+    /**
+     * Return the list of index PTables for a view or otherwise
+     * @param viewOnly if PTable is a view
+     * @return the list of view indexes if viewOnly is true, otherwise all indexes
+     */
+    List<PTable> getIndexes(boolean viewOnly);
 
     /**
      * For a table of index type, return the state of the table.

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/PTableImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/PTableImpl.java
@@ -66,6 +66,7 @@ import org.apache.phoenix.hbase.index.util.KeyValueBuilder;
 import org.apache.phoenix.index.IndexMaintainer;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixStatement;
+import org.apache.phoenix.parse.NamedNode;
 import org.apache.phoenix.parse.ParseNode;
 import org.apache.phoenix.parse.SQLParser;
 import org.apache.phoenix.protobuf.ProtobufUtil;
@@ -1443,6 +1444,35 @@ public class PTableImpl implements PTable {
     @Override
     public List<PTable> getIndexes() {
         return indexes;
+    }
+
+    @Override
+    public List<PTable> getIndexes(boolean viewOnly) {
+        List<PTable> indexes = new ArrayList<>();
+        indexes.addAll(this.indexes);
+        if (viewOnly) {
+            for (PTable index: this.indexes) {
+                if(index.getTableName().toString().contains("#")) {
+                    indexes.remove(index);
+                }
+            }
+        }
+        return indexes;
+    }
+
+    @Override
+    public List<PTable> getIndexes(List<NamedNode> indexes) {
+        List<PTable> indexesPTable = Lists.newArrayListWithExpectedSize(indexes.size());
+        List<String> indexesParam = Lists.newArrayListWithExpectedSize(indexes.size());
+        for (NamedNode index : indexes) {
+            indexesParam.add(index.getName());
+        }
+        for (PTable index : this.indexes) {
+            if(indexesParam.contains(index.getTableName().getString())) {
+                indexesPTable.add(index);
+            }
+        }
+        return indexesPTable;
     }
 
     @Override


### PR DESCRIPTION
This PR will allow an option to cascade the column to the corresponding indexes if it is added to the view or base table. (Below example is applicable for the table also)

Let's suppose I have a base table A and a global view on it as A_GLOBAL_VIEW and 3 Global (currently, focusing on global indexes) indexes on the view A_GLOBAL_VIEW_INDEX_1, A_GLOBAL_VIEW_INDEX_2, and A_GLOBAL_VIEW_INDEX_3

The following syntax will add the new_column to the global view and also to all the 3 indexes on the view as an included column:
 
ALTER VIEW A_GLOBAL_VIEW ADD new_column VARCHAR CASCADE INDEX ALL

Let's say I want to add the column only to A_GLOBAL_VIEW_INDEX_2 and A_GLOBAL_VIEW_INDEX_3, the syntax will look like below:

ALTER VIEW A_GLOBAL_VIEW ADD new_column VARCHAR CASCADE INDEX A_GLOBAL_VIEW_INDEX_2, A_GLOBAL_VIEW_INDEX_3