### PR TITLE
PHOENIX-5363: Phoenix parcel artifacts for CDH releases don't pass Cloudera verification tools test

### DIFF
--- a/dev/make_rc.sh
+++ b/dev/make_rc.sh
@@ -103,8 +103,8 @@ rm -rf $DIR_REL_BIN_PATH;
 echo "DONE generating binary and source tars in release directory."
 
 # Generate parcels folder
-FILE_PARCEL_TAR=$(find $DIR_PARCEL_TAR -name '*.parcel.tar' -printf '%f\n')
-PARCEL_BASENAME=$(echo $FILE_PARCEL_TAR | sed 's/\.parcel\.tar//')
+FILE_PARCEL_TAR=$(find $DIR_PARCEL_TAR -name '*.parcel.tar.gz' -printf '%f\n')
+PARCEL_BASENAME=$(echo $FILE_PARCEL_TAR | sed 's/\.parcel\.tar.gz//')
 
 PARCEL_DISTROS=( "el6" "el7" "sles12" "xenial")
 for distro in "${PARCEL_DISTROS[@]}"

--- a/phoenix-parcel/pom.xml
+++ b/phoenix-parcel/pom.xml
@@ -111,6 +111,7 @@
             </goals>
             <configuration>
               <finalName>${parcel.file}</finalName>
+              <formats>tar.gz</formats>
               <attach>false</attach>
               <tarLongFileMode>gnu</tarLongFileMode>
               <appendAssemblyId>false</appendAssemblyId>


### PR DESCRIPTION
Parcel artifacts are created as `tar` files but they should be `tar.gz` files instead 