### PR TITLE
PHOENIX-5369: BasePermissionsIT.testReadPermsOnTableIndexAndView test uses an incorrect user for permission based operations

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/BasePermissionsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/BasePermissionsIT.java
@@ -968,7 +968,7 @@ public abstract class BasePermissionsIT extends BaseTest {
 
         // Revoke READ permissions to RegularUser2 on the table
         // Permissions should propagate automatically to relevant physical tables such as global index and view index.
-        verifyAllowed(revokePermissions(regularUser2, fullTableName, false), regularUser1);
+        verifyAllowed(revokePermissions(regularUser2, fullTableName, false), superUser1);
         // READ query should fail now
         verifyDenied(readTable(fullTableName), AccessDeniedException.class, regularUser2);
         verifyDenied(readTableWithoutVerification(schemaName + "." + idx1TableName), AccessDeniedException.class, regularUser2);


### PR DESCRIPTION
BasePermissionsIT.testReadPermsOnTableIndexAndView test uses an incorrect user for permission based operations