### PR TITLE
PHOENIX-5379 : Avoid possible NPE while closing CSVParser

### DIFF
--- a/phoenix-pherf/src/main/java/org/apache/phoenix/pherf/result/impl/CSVFileResultHandler.java
+++ b/phoenix-pherf/src/main/java/org/apache/phoenix/pherf/result/impl/CSVFileResultHandler.java
@@ -47,11 +47,10 @@ public class CSVFileResultHandler extends CSVResultHandler {
     }
 
     public synchronized List<Result> read() throws IOException {
-        CSVParser parser = null;
         util.ensureBaseResultDirExists();
-        try {
-            File file = new File(resultFileName);
-            parser = CSVParser.parse(file, Charset.defaultCharset(), CSVFormat.DEFAULT);
+        File file = new File(resultFileName);
+        try (CSVParser parser = CSVParser
+                .parse(file, Charset.defaultCharset(), CSVFormat.DEFAULT)) {
             List<CSVRecord> records = parser.getRecords();
             List<Result> results = new ArrayList<>();
             String header = null;
@@ -70,8 +69,6 @@ public class CSVFileResultHandler extends CSVResultHandler {
                 results.add(result);
             }
             return results;
-        } finally {
-            parser.close();
         }
     }
 


### PR DESCRIPTION
CSVFileResultHandler closes CSVParser which could cause NPE if creating CSVParser causes IOException and original IOException can be lost