### PR TITLE
PHOENIX-5104: breaks client backwards compatibility

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -352,6 +352,8 @@ public interface QueryServices extends SQLCloseable {
     public static final String GLOBAL_INDEX_ROW_REPAIR_COUNT_ATTRIB = "phoenix.global.index.row.repair.count.ms";
     // Enable the IndexRegionObserver Coprocessor
     public static final String INDEX_REGION_OBSERVER_ENABLED_ATTRIB = "phoenix.index.region.observer.enabled";
+    // Enable support for long view index(default is false for clients below version 4)
+    public static final String LONG_VIEW_INDEX_ENABLED_ATTRIB = "phoenix.index.longViewIndex.enabled";
 
 
     // Before 4.15 when we created a view we included the parent table column metadata in the view

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -395,6 +395,7 @@ public class QueryServicesOptions {
 
     public static final String DEFAULT_GUIDE_POSTS_CACHE_FACTORY_CLASS = "org.apache.phoenix.query.DefaultGuidePostsCacheFactory";
 
+    public static final boolean DEFAULT_LONG_VIEW_INDEX_ENABLED = false;
     private final Configuration config;
 
     private QueryServicesOptions(Configuration config) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -97,6 +97,7 @@ import static org.apache.phoenix.query.QueryConstants.BASE_TABLE_BASE_COLUMN_COU
 import static org.apache.phoenix.query.QueryConstants.DEFAULT_COLUMN_FAMILY;
 import static org.apache.phoenix.query.QueryConstants.ENCODED_CQ_COUNTER_INITIAL_VALUE;
 import static org.apache.phoenix.query.QueryServices.DROP_METADATA_ATTRIB;
+import static org.apache.phoenix.query.QueryServices.LONG_VIEW_INDEX_ENABLED_ATTRIB;
 import static org.apache.phoenix.query.QueryServicesOptions.DEFAULT_DROP_METADATA;
 import static org.apache.phoenix.query.QueryServicesOptions.DEFAULT_RUN_UPDATE_STATS_ASYNC;
 import static org.apache.phoenix.schema.PTable.EncodedCQCounter.NULL_COUNTER;
@@ -1426,6 +1427,18 @@ public class MetaDataClient {
     }
 
     /**
+     * Supprort long viewIndexId only if client has explicitly set
+     * the QueryServices.LONG_VIEW_INDEX_ENABLED_ATTRIB connection property to 'true'.
+     * @return
+     */
+    private PDataType getViewIndexDataType() throws SQLException {
+        boolean supportsLongViewIndexId = connection.getQueryServices().getProps().getBoolean(
+                                QueryServices.LONG_VIEW_INDEX_ENABLED_ATTRIB,
+                                QueryServicesOptions.DEFAULT_LONG_VIEW_INDEX_ENABLED);
+        return supportsLongViewIndexId ? MetaDataUtil.getViewIndexIdDataType() : MetaDataUtil.getLegacyViewIndexIdDataType();
+    }
+
+    /**
      * Create an index table by morphing the CreateIndexStatement into a CreateTableStatement and calling
      * MetaDataClient.createTable. In doing so, we perform the following translations:
      * 1) Change the type of any columns being indexed to types that support null if the column is nullable.
@@ -1523,7 +1536,7 @@ public class MetaDataClient {
              */
             if (isLocalIndex || (dataTable.getType() == PTableType.VIEW && dataTable.getViewType() != ViewType.MAPPED)) {
                 allocateIndexId = true;
-                PDataType dataType = MetaDataUtil.getViewIndexIdDataType();
+                PDataType dataType = getViewIndexDataType();
                 ColumnName colName = ColumnName.caseSensitiveColumnName(MetaDataUtil.getViewIndexIdColumnName());
                 allPkColumns.add(new ColumnDefInPkConstraint(colName, SortOrder.getDefault(), false));
                 columnDefs.add(FACTORY.columnDef(colName, dataType.getSqlTypeName(), false, null, null, false, SortOrder.getDefault(), null, false));


### PR DESCRIPTION
Fixing by adding a new connection property "phoenix.index.longViewIndex.enabled" which is by default false.
Clients can set this property to true to be able to use longViewIndexes on phoenix 4.x version. This feature is by default avaiable to phoenix version 5 and above.