### PR TITLE
PHOENIX-5408: Typo in ConnectionQueryServicesImpl Warning Logging

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -440,7 +440,7 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
             try {
                 this.queryDisruptor = new QueryLoggerDisruptor(this.config);
             } catch (SQLException e) {
-                LOGGER.warn("Unable to initiate qeuery logging service !!");
+                LOGGER.warn("Unable to initiate query logging service !!");
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
"query" was misspelled to "qeuery" in ConnectionQueryServicesImpl warning logging:
https://github.com/apache/phoenix/blob/62387ee3c55f8be1947161bc9d501b1867cc24f1/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java#L443