### PR TITLE
PHOENIX-5416: Fix Array2IT testArrayRefToLiteral

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/Array2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/Array2IT.java
@@ -18,6 +18,7 @@
 package org.apache.phoenix.end2end;
 
 import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -37,10 +38,12 @@ import org.apache.phoenix.schema.types.PhoenixArray;
 import org.apache.phoenix.util.PropertiesUtil;
 import org.apache.phoenix.util.SchemaUtil;
 import org.apache.phoenix.util.StringUtil;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class Array2IT extends ArrayIT {
+
+    private static final String TEST_QUERY = "select ?[2] from \"SYSTEM\".\"CATALOG\" limit 1";
+
     @Test
     public void testFixedWidthCharArray() throws Exception {
         Connection conn;
@@ -670,17 +673,50 @@ public class Array2IT extends ArrayIT {
 
     }
 
-    @Test // see PHOENIX-5416
-    @Ignore
-    public void testArrayRefToLiteral() throws Exception {
+    @Test
+    public void testArrayRefToLiteralCharArraySameLengths() throws Exception {
         Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
         try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
-            PreparedStatement stmt = conn.prepareStatement("select ?[2] from \"SYSTEM\".\"CATALOG\" limit 1");
+            PreparedStatement stmt = conn.prepareStatement(TEST_QUERY);
+            // Test with each element of the char array having same lengths
             Array array = conn.createArrayOf("CHAR", new String[] {"a","b","c"});
             stmt.setArray(1, array);
             ResultSet rs = stmt.executeQuery();
             assertTrue(rs.next());
             assertEquals("b", rs.getString(1));
+            assertFalse(rs.next());
+        }
+    }
+
+    @Test
+    public void testArrayRefToLiteralCharArrayDiffLengths() throws Exception {
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+            PreparedStatement stmt = conn.prepareStatement(TEST_QUERY);
+            // Test with each element of the char array having different lengths
+            Array array = conn.createArrayOf("CHAR", new String[] {"a","bb","ccc"});
+            stmt.setArray(1, array);
+            ResultSet rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            assertEquals("bb", rs.getString(1));
+            assertFalse(rs.next());
+        }
+    }
+
+    @Test
+    public void testArrayRefToLiteralBinaryArray() throws Exception {
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+            PreparedStatement stmt = conn.prepareStatement(TEST_QUERY);
+            // Test with each element of the binary array having different lengths
+            byte[][] bytes = {{0,0,1}, {0,0,2,0}, {0,0,0,3,4}};
+            Array array = conn.createArrayOf("BINARY", bytes);
+            stmt.setArray(1, array);
+            ResultSet rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            // Note that all elements are padded to be of the same length
+            // as the longest element of the byte array
+            assertArrayEquals(new byte[] {0,0,2,0,0}, rs.getBytes(1));
             assertFalse(rs.next());
         }
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/LiteralExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/LiteralExpression.java
@@ -338,6 +338,17 @@ public class LiteralExpression extends BaseTerminalExpression {
 
     @Override
     public Integer getMaxLength() {
+        // For literals representing arrays of CHAR or BINARY, the byte size is null and the max
+        // length of the expression is also null, so we must get the max length of the
+        // actual underlying array
+        if (maxLength == null && getDataType() != null && getDataType().isArrayType() &&
+                PDataType.arrayBaseType(getDataType()).getByteSize() == null) {
+            Object value = getValue();
+            if (value instanceof PhoenixArray) {
+                // Return the max length of the underlying PhoenixArray data
+                return ((PhoenixArray) value).getMaxLength();
+            }
+        }
         return maxLength;
     }
 


### PR DESCRIPTION
For Arrays of `CHAR` and `BINARY` which are both fixed width and both have getByteSize() null, we run into an NPE.

With this change, inside ArrayIndexFunction#getMaxLength, instead of returning this.children.get(0).getMaxLength(), we inspect the children.get(0) `LiteralExpression` and return the maxLength of the underlying `PCharArray`/`PBinaryArray` data.