### PR TITLE
PHOENIX-5428 Upgrade maven-checkstyle-plugin version

### DIFF
--- a/phoenix-tracing-webapp/src/main/config/checkstyle/checker.xml
+++ b/phoenix-tracing-webapp/src/main/config/checkstyle/checker.xml
@@ -57,7 +57,6 @@ limitations under the License.
   <module name="FileTabCharacter"/>
 
   <module name="TreeWalker">
-    <property name="cacheFile" value="target/checkstyle-cachefile"/>
 
     <!-- Checks for blocks. You know, those {}'s         -->
     <!-- See http://checkstyle.sf.net/config_blocks.html -->
@@ -90,10 +89,6 @@ limitations under the License.
     </module>
       <!-- Switch statements should be complete and with independent cases -->
     <module name="FallThrough"/>
-    <!-- For hadoop_yarn profile, some YARN exceptions aren't loading in checkstyle -->
-    <module name="RedundantThrows">
-        <property name="suppressLoadErrors" value="true" />
-    </module>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
       <!-- Only one statement per line allowed -->
@@ -256,26 +251,24 @@ limitations under the License.
       <!-- No extra whitespace around types -->
     <module name="GenericWhitespace"/>
 
-    <!-- Required for SuppressionCommentFilter below -->
-    <module name="FileContentsHolder"/>
+    <!-- Setup special comments to suppress specific checks from source files -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE\: stop ([\w\|]+)"/>
+      <property name="onCommentFormat"  value="CHECKSTYLE\: resume ([\w\|]+)"/>
+      <property name="checkFormat"      value="$1"/>
+    </module>
+
+    <!-- Turn off all checks between OFF and ON -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE\: OFF"/>
+      <property name="onCommentFormat"  value="CHECKSTYLE\: ON"/>
+    </module>
+
+    <!-- Turn off checks for the next N lines. -->
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE: +IGNORE (\d+)"/>
+      <property name="influenceFormat" value="$1"/>
+    </module>
   </module>
 
-  <!-- Setup special comments to suppress specific checks from source files -->
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CHECKSTYLE\: stop ([\w\|]+)"/>
-    <property name="onCommentFormat"  value="CHECKSTYLE\: resume ([\w\|]+)"/>
-    <property name="checkFormat"      value="$1"/>
-  </module>
-
-  <!-- Turn off all checks between OFF and ON -->
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CHECKSTYLE\: OFF"/>
-    <property name="onCommentFormat"  value="CHECKSTYLE\: ON"/>
-  </module>
-
-  <!-- Turn off checks for the next N lines. -->
-  <module name="SuppressWithNearbyCommentFilter">
-    <property name="commentFormat" value="CHECKSTYLE: +IGNORE (\d+)"/>
-    <property name="influenceFormat" value="$1"/>
-  </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.13</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>validate</id>

--- a/src/main/config/checkstyle/checker.xml
+++ b/src/main/config/checkstyle/checker.xml
@@ -57,7 +57,6 @@ limitations under the License.
   <module name="FileTabCharacter"/>
 
   <module name="TreeWalker">
-    <property name="cacheFile" value="target/checkstyle-cachefile"/>
 
     <!-- Checks for blocks. You know, those {}'s         -->
     <!-- See http://checkstyle.sf.net/config_blocks.html -->
@@ -90,10 +89,6 @@ limitations under the License.
     </module>
       <!-- Switch statements should be complete and with independent cases -->
     <module name="FallThrough"/>
-    <!-- For hadoop_yarn profile, some YARN exceptions aren't loading in checkstyle -->
-    <module name="RedundantThrows">
-        <property name="suppressLoadErrors" value="true" />
-    </module>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
       <!-- Only one statement per line allowed -->
@@ -256,26 +251,24 @@ limitations under the License.
       <!-- No extra whitespace around types -->
     <module name="GenericWhitespace"/>
 
-    <!-- Required for SuppressionCommentFilter below -->
-    <module name="FileContentsHolder"/>
+    <!-- Setup special comments to suppress specific checks from source files -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE\: stop ([\w\|]+)"/>
+      <property name="onCommentFormat"  value="CHECKSTYLE\: resume ([\w\|]+)"/>
+      <property name="checkFormat"      value="$1"/>
+    </module>
+
+    <!-- Turn off all checks between OFF and ON -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE\: OFF"/>
+      <property name="onCommentFormat"  value="CHECKSTYLE\: ON"/>
+    </module>
+
+    <!-- Turn off checks for the next N lines. -->
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE: +IGNORE (\d+)"/>
+      <property name="influenceFormat" value="$1"/>
+    </module>
   </module>
 
-  <!-- Setup special comments to suppress specific checks from source files -->
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CHECKSTYLE\: stop ([\w\|]+)"/>
-    <property name="onCommentFormat"  value="CHECKSTYLE\: resume ([\w\|]+)"/>
-    <property name="checkFormat"      value="$1"/>
-  </module>
-
-  <!-- Turn off all checks between OFF and ON -->
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CHECKSTYLE\: OFF"/>
-    <property name="onCommentFormat"  value="CHECKSTYLE\: ON"/>
-  </module>
-
-  <!-- Turn off checks for the next N lines. -->
-  <module name="SuppressWithNearbyCommentFilter">
-    <property name="commentFormat" value="CHECKSTYLE: +IGNORE (\d+)"/>
-    <property name="influenceFormat" value="$1"/>
-  </module>
 </module>


### PR DESCRIPTION
This upgrades maven-checkstyle-plugin to 3.1.0 and
updates the checker.xml config files to work with recent
checkstyle versions