### PR TITLE
PHOENIX-5470 Tool to find view corruption

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/FindViewCorruptionToolIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/FindViewCorruptionToolIT.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.end2end;
+
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.phoenix.tool.FindViewCorruptionTool;
+import org.apache.phoenix.util.PhoenixRuntime;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Category(NeedsOwnMiniClusterTest.class)
+public class FindViewCorruptionToolIT extends ParallelStatsEnabledIT {
+
+    private static final String filePath = "/tmp/";
+    String CREATE_TABLE_QUERY = "CREATE TABLE %s (A BIGINT PRIMARY KEY, B VARCHAR)";
+    String CREATE_VIEW_QUERY = "CREATE VIEW %s AS SELECT * FROM %s";
+    String CREATE_MULTI_TENANT_TABLE_QUERY = "CREATE TABLE %s (TENANT_ID VARCHAR NOT NULL, " +
+            "A VARCHAR NOT NULL, B BIGINT, CONSTRAINT pk PRIMARY KEY(TENANT_ID, A)) MULTI_TENANT=true";
+
+    @Test
+    public void testMultiLevelCorruptedView() throws Exception {
+        String tableName1 = generateUniqueName();
+        String viewName1 = generateUniqueName();
+        String viewName2 = generateUniqueName();
+        String viewName3 = generateUniqueName();
+        Connection conn = DriverManager.getConnection(getUrl());
+        conn.createStatement().execute(String.format(CREATE_TABLE_QUERY, tableName1));
+        conn.createStatement().execute(String.format(CREATE_VIEW_QUERY, viewName1, tableName1));
+        conn.createStatement().execute(String.format(CREATE_VIEW_QUERY, viewName2, tableName1));
+        conn.createStatement().execute(String.format(CREATE_VIEW_QUERY, viewName3, viewName2));
+        //Testing no corrupted view case
+        assertEquals(0,runFindCorruptedViewTool(true, false, null));
+
+        conn.createStatement().execute("UPSERT INTO SYSTEM.CATALOG " +
+                "(TABLE_NAME, TABLE_TYPE, COLUMN_COUNT) VALUES('" + viewName1 + "','v',1) ");
+        conn.commit();
+        //Testing corrupted view on a base table
+        assertEquals(1, runFindCorruptedViewTool(true, false, null));
+
+        conn.createStatement().execute("UPSERT INTO SYSTEM.CATALOG " +
+                "(TABLE_NAME, TABLE_TYPE, COLUMN_COUNT) VALUES('" + viewName2 + "','v',1) ");
+        conn.commit();
+
+        //Testing multi layer corrupted view
+        assertEquals(2, runFindCorruptedViewTool(true, false, null));
+
+        String schema1 = generateUniqueName();
+        String tableName2 = generateUniqueName();
+        String fullTableName1 = schema1 + '.' +  tableName2;
+        String viewName4 = generateUniqueName();
+        String fullViewName1 = schema1 + '.' +  viewName4;
+        conn.createStatement().execute(String.format(CREATE_TABLE_QUERY, fullTableName1));
+        conn.createStatement().execute(String.format(CREATE_VIEW_QUERY, fullViewName1, fullTableName1));
+        conn.createStatement().execute("UPSERT INTO SYSTEM.CATALOG " +
+                "(TABLE_SCHEM,TABLE_NAME, TABLE_TYPE, COLUMN_COUNT) VALUES('" +
+                schema1 + "', '"+ viewName4 + "','v',10) ");
+        conn.commit();
+        //Testing corrupted view with schema enabled
+        assertEquals(3, runFindCorruptedViewTool(true, true, null));
+        //Testing output logging file
+        verifyLineCount(filePath + FindViewCorruptionTool.fileName,3);
+        //Testing corrupted view for a namespace
+        assertEquals(1, runFindCorruptedViewTool(true, false, schema1));
+
+        String schema2 = generateUniqueName();
+        String tableName3 = generateUniqueName();
+        String fullTableName2 = schema2 + '.' +  tableName3;
+        String viewName5 = generateUniqueName();
+        String tenantId = generateUniqueName();
+        String fullViewName2 = schema2 + '.' +  viewName5;
+
+        conn.createStatement().execute(
+                String.format(CREATE_MULTI_TENANT_TABLE_QUERY, fullTableName2));
+        Connection tenantConnection = tenantConnection(getUrl(), tenantId);
+        tenantConnection.createStatement().execute(
+                String.format(CREATE_VIEW_QUERY, fullViewName2, fullTableName2));
+
+        //Testing corrupted view for a specific tenant
+        conn.createStatement().execute("UPSERT INTO SYSTEM.CATALOG " +
+                "(TENANT_ID, TABLE_SCHEM,TABLE_NAME, TABLE_TYPE, COLUMN_COUNT) VALUES('" +
+                tenantId + "', '"+ schema2 + "', '"+ viewName5 + "','v', 0) ");
+        conn.commit();
+        assertEquals(4, runFindCorruptedViewTool(true, false, null));
+
+        //Testing get all corrupted view string list and write to a customized path/filename APIs
+        FindViewCorruptionTool tool = getFindCorruptionTool();
+        assertEquals(4, tool.run(getArgValues(true,false,null)));
+        assertEquals(4, tool.getCorruptedViews().size());
+        String randomFilename = generateUniqueName();
+        tool.writeCorruptedViews(filePath, randomFilename);
+        verifyLineCount(filePath + randomFilename, 4);
+    }
+
+    private Connection tenantConnection(String url, String tenantId) throws SQLException {
+        Properties props = new Properties();
+        props.setProperty(PhoenixRuntime.TENANT_ID_ATTRIB, tenantId);
+        return DriverManager.getConnection(url, props);
+    }
+
+    private void verifyLineCount(String fileName, long lineCount) throws IOException {
+        LineNumberReader reader = new LineNumberReader(new FileReader(fileName));
+        while (reader.readLine() != null) {
+        }
+        int count = reader.getLineNumber();
+        if (count != lineCount) {
+            System.out.println((count + " != " + lineCount));
+        }
+        assertTrue(count == lineCount);
+    }
+
+    public static String[] getArgValues(boolean getCorruptedViewCount, boolean outputPath,
+                                        String schemaName) {
+        final List<String> args = Lists.newArrayList();
+        if (outputPath) {
+            args.add("-op");
+            args.add(filePath);
+        }
+        if (getCorruptedViewCount) {
+            args.add("-c");
+        }
+        if (schemaName != null) {
+            args.add("-s");
+            args.add(schemaName);
+        }
+        return args.toArray(new String[0]);
+    }
+
+    public static int runFindCorruptedViewTool(boolean getCorruptedViewCount, boolean outputPath,
+                                               String schemaName)
+            throws Exception {
+        FindViewCorruptionTool tool = getFindCorruptionTool();
+        final String[] cmdArgs =
+                getArgValues(getCorruptedViewCount, outputPath, schemaName);
+        return tool.run(cmdArgs);
+    }
+
+    public static FindViewCorruptionTool getFindCorruptionTool() {
+        FindViewCorruptionTool tool = new FindViewCorruptionTool();
+        Configuration conf = new Configuration(getUtility().getConfiguration());
+        tool.setConf(conf);
+        return tool;
+    }
+
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/tool/FindViewCorruptionTool.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/tool/FindViewCorruptionTool.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.tool;
+
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.PosixParser;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.mapreduce.util.ConnectionUtil;
+import org.apache.phoenix.schema.PTableType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.*;
+
+/**
+ * A tool to identify corrupted views.
+ */
+public class FindViewCorruptionTool extends Configured implements Tool {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FindViewCorruptionTool.class);
+
+    private static final String TABLE_QUERY = "SELECT " +
+            TENANT_ID + ", " +
+            TABLE_SCHEM + "," +
+            TABLE_NAME + "," +
+            COLUMN_COUNT +
+            " FROM " + SYSTEM_CATALOG_NAME +
+            " WHERE "+ TABLE_TYPE + " = '" + PTableType.TABLE.getSerializedValue() + "'";
+
+    private static final String GET_ALL_CHILDREN_QUERY = "SELECT " +
+            COLUMN_FAMILY +
+            " FROM " + SYSTEM_CHILD_LINK_NAME + " WHERE " +
+            TABLE_NAME + " = '%s' AND LINK_TYPE=4";
+
+    private static final String GET_CHILD_INFO_QUERY = "SELECT " +
+            TENANT_ID + ", " +
+            TABLE_SCHEM + "," +
+            TABLE_NAME + "," +
+            COLUMN_COUNT +
+            " FROM " + SYSTEM_CATALOG_NAME + " WHERE " +
+            TABLE_NAME + " = '%s' AND " +
+            TABLE_TYPE + " = '" + PTableType.VIEW.getSerializedValue() + "'";
+
+    private static final String COLUMN_COUNT_QUERY = "SELECT COUNT(*) FROM " +
+            SYSTEM_CATALOG_NAME + " WHERE " +
+            TABLE_NAME + " = '%s' AND " +
+            COLUMN_NAME + " IS NOT NULL AND LINK_TYPE IS NULL";
+
+    // The set of tables or views
+    List<MetaNode> set = new ArrayList<>();
+    List<MetaNode> corruptedViewSet = new ArrayList<>();
+    String outputPath;
+    boolean getCorruptedViewCount = false;
+    String schemaName;
+
+    public static final String fileName = "FindViewCorruptionTool.txt";
+
+    private static final Option HELP_OPTION = new Option("h", "help", false, "Help");
+    private static final Option SCHEMA_OPTION = new Option("s", "schema name", true,
+            "Running tool for a specific schema");
+    private static final Option OUTPUT_PATH_OPTION = new Option("op", "output-path", true,
+            "Output path where the files listing corrupted views are written");
+    private static final Option GET_CORRUPTED_VIEWS_COUNT_OPTION = new Option("c",
+            "get corrupted view count", false,
+            "If specified, cleans orphan views and links");
+
+    /**
+     * Go through all the views in the system catalog table and add them
+     * @param phoenixConnection
+     * @throws Exception
+     */
+    private void populateTableSetMetadata(PhoenixConnection phoenixConnection) throws Exception {
+        ResultSet viewRS = phoenixConnection.createStatement().executeQuery(getAddingSchemaQuery(
+                String.format(TABLE_QUERY), this.schemaName == null ? "" : this.schemaName));
+        while (viewRS.next()) {
+            MetaNode node = constructMetaNode(viewRS);
+            set.add(node);
+        }
+    }
+
+    private MetaNode constructMetaNode(ResultSet rs) throws SQLException {
+        String tenantId = rs.getString(1);
+        String schemaName = rs.getString(2);
+        String tableName = rs.getString(3);
+        int columnCount = rs.getInt(4);
+        return new MetaNode(tenantId, schemaName, tableName, columnCount);
+    }
+
+    public void findCorruptedViews(PhoenixConnection phoenixConnection) throws Exception {
+        populateTableSetMetadata(phoenixConnection);
+        List<MetaNode> nextLevel = new ArrayList<>();
+        while (set.size() > 0) {
+            for (MetaNode parent : set) {
+                ResultSet childLinkInfoRS = phoenixConnection.createStatement().executeQuery(
+                        getQuery(String.format(GET_ALL_CHILDREN_QUERY, parent.getTableName()),
+                                parent.getSchemaName(), parent.getTenantId()));
+                // get all children
+                while (childLinkInfoRS.next()) {
+                    String schemaName;
+                    String tableName;
+                    String fullName = childLinkInfoRS.getString(1);
+                    String[] columns = fullName.split("\\.");
+                    if (columns.length == 1) {
+                        schemaName = "";
+                        tableName = fullName;
+                    } else {
+                        schemaName = columns[0];
+                        tableName = columns[1];
+                    }
+                    ResultSet childRS = phoenixConnection.createStatement().executeQuery(
+                            getAddingSchemaQuery(
+                                    String.format(GET_CHILD_INFO_QUERY, tableName), schemaName));
+                    if (!childRS.next()) {
+                        continue;
+                    }
+                    MetaNode child = constructMetaNode(childRS);
+                    ResultSet selectColumnCountRS = phoenixConnection.createStatement().executeQuery(
+                            getQuery(String.format(COLUMN_COUNT_QUERY, child.getTableName()),
+                                    child.getSchemaName(), child.getTenantId()));
+                    selectColumnCountRS.next();
+                    int selectColumnCount = selectColumnCountRS.getInt(1);
+                    if (selectColumnCount + parent.getColumnCount() != child.getColumnCount()) {
+                        child.setSelectColumnCount(selectColumnCount);
+                        corruptedViewSet.add(child);
+                    } else {
+                        nextLevel.add(child);
+                    }
+                }
+            }
+            set = nextLevel;
+            nextLevel = new ArrayList<>();
+        }
+    }
+
+    private String getAddingSchemaQuery(String query, String schemaName) {
+        if (schemaName.length() > 0) {
+            query += " AND " + TABLE_SCHEM + "='" + schemaName + "'";
+        }
+
+        return query;
+    }
+
+    private String getQuery(String query, String schemaName, String tenantId) {
+        if (schemaName.length() > 0) {
+            query += " AND " + TABLE_SCHEM + "='" + schemaName + "'";
+        } else {
+            query += " AND " + TABLE_SCHEM + " IS NULL";
+        }
+
+        if (tenantId.length() > 0) {
+            query += " AND " + TENANT_ID + "='" + tenantId + "'";
+        } else {
+            query += " AND " + TENANT_ID + " IS NULL";
+        }
+        return query;
+    }
+
+    private void parseOptions(String[] args) {
+        final Options options = getOptions();
+        CommandLineParser parser = new PosixParser();
+        CommandLine cmdLine = null;
+
+        try {
+            cmdLine = parser.parse(options, args);
+        } catch (ParseException e) {
+            printHelpAndExit("Error parsing command line options: " + e.getMessage(), options);
+        }
+        if (cmdLine.hasOption(HELP_OPTION.getOpt())) {
+            printHelpAndExit(options, 0);
+        }
+        if (cmdLine.hasOption(SCHEMA_OPTION.getOpt())) {
+            if (SCHEMA_OPTION.getArgName() == null) {
+                throw new IllegalStateException(SCHEMA_OPTION.getLongOpt() +
+                        " requires an argument.");
+            } else {
+                this.schemaName = cmdLine.getOptionValue(SCHEMA_OPTION.getOpt());
+            }
+        }
+        if (cmdLine.hasOption(GET_CORRUPTED_VIEWS_COUNT_OPTION.getOpt())) {
+            getCorruptedViewCount = true;
+        }
+        outputPath = cmdLine.getOptionValue(OUTPUT_PATH_OPTION.getOpt());
+    }
+
+    private Options getOptions() {
+        final Options options = new Options();
+        options.addOption(OUTPUT_PATH_OPTION);
+        options.addOption(SCHEMA_OPTION);
+        options.addOption(GET_CORRUPTED_VIEWS_COUNT_OPTION);
+        options.addOption(HELP_OPTION);
+        return options;
+    }
+
+    private void printHelpAndExit(String errorMessage, Options options) {
+        System.err.println(errorMessage);
+        printHelpAndExit(options, 1);
+    }
+
+    private void printHelpAndExit(Options options, int exitCode) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("help", options);
+        System.exit(exitCode);
+    }
+
+    private class MetaNode {
+        private String tenantId;
+        private String schemaName;
+        private String tableName;
+        private int selectColumnCount;
+        private int columnCount;
+
+        public MetaNode (String tenantId, String schemaName, String tableName, int columnCount) {
+            this.schemaName = schemaName == null ? "" : schemaName;
+            this.tableName = tableName  == null ? "" : tableName;
+            this.tenantId = tenantId  == null ? "" : tenantId;
+            this.columnCount = columnCount;
+            this.selectColumnCount = 0;
+        }
+
+        public String getTenantId() {
+            return this.tenantId;
+        }
+
+        public String getSchemaName() {
+            return this.schemaName;
+        }
+
+        public String getTableName() {
+            return this.tableName;
+        }
+
+        public int getColumnCount() {
+            return this.columnCount;
+        }
+
+        public int getSelectColumnCount() {
+            return this.selectColumnCount;
+        }
+
+        public void setColumnCount(int columnCount) {
+            this.selectColumnCount = columnCount;
+        }
+
+        public void setSelectColumnCount(int selectColumnCount) {
+            this.selectColumnCount = selectColumnCount;
+        }
+    }
+
+    private void closeConnection(Connection connection) {
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Failed to close connection: ", e);
+            throw new RuntimeException("Failed to close connection with exception: ", e);
+        }
+    }
+
+    /*
+     * @return return all corrupted view info in a string format as following:
+     * "TenantId,SchemaName,TableName,ColumnCountFromHeadRow,SelectCountColumnNumber"
+     */
+    public List<String> getCorruptedViews() {
+        List<String> corruptedView = new ArrayList<>();
+        for (MetaNode view : this.corruptedViewSet) {
+            corruptedView.add(view.getTenantId() + "," + view.getSchemaName() + "," +
+                    view.getTableName() + "," + view.getColumnCount() + "," +
+                    view.getSelectColumnCount());
+        }
+        return corruptedView;
+    }
+
+    public void writeCorruptedViews(String outputPath, String fileName) throws IOException {
+        FileWriter fw = null;
+        Path path = Paths.get(outputPath);
+        Path filePath = Paths.get(path.toString(), fileName);
+
+        try {
+            fw = new FileWriter(new File(filePath.toString()));
+            for (String viewInfo : getCorruptedViews()) {
+                fw.write(viewInfo);
+                fw.write(System.lineSeparator());
+            }
+        } finally {
+            if (fw != null) {
+                fw.close();
+            }
+        }
+    }
+
+    @Override
+    public int run(String[] args) throws Exception {
+        Connection connection = null;
+        try {
+            Configuration configuration = HBaseConfiguration.addHbaseResources(getConf());
+            Properties props = new Properties();
+            try {
+                parseOptions(args);
+            } catch (IllegalStateException e) {
+                printHelpAndExit(e.getMessage(), getOptions());
+            }
+            connection = ConnectionUtil.getInputConnection(configuration, props);
+            PhoenixConnection phoenixConnection = connection.unwrap(PhoenixConnection.class);
+            findCorruptedViews(phoenixConnection);
+            if (outputPath != null) {
+                writeCorruptedViews(outputPath, fileName);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Find View Corruption Tool : An exception occurred "
+                    + ExceptionUtils.getMessage(e) + " at:\n" +
+                    ExceptionUtils.getStackTrace(e));
+            return -1;
+        } finally {
+            closeConnection(connection);
+        }
+        if (getCorruptedViewCount) {
+            return corruptedViewSet.size();
+        }
+        return 0;
+    }
+
+    public static void main(final String[] args) throws Exception {
+        int result = ToolRunner.run(new FindViewCorruptionTool(), args);
+        System.exit(result);
+    }
+}


### PR DESCRIPTION
After 4.14, we enabled CHILD_LINK and changed the behavior of SYSCAT, so 4.15 branches have a different implementation. The logic as following:
1. get all tables to a list.
2. iterate all tables and find direct child/children from CHILD_LINK table.
3. for each child view, we compare SELECT COUNT column from SYSCAT + parent.COLUMN_COUNT with child view COLUMN_COUNT.

This groud buildup logic can help us find a view of corruption with pruning. If we have a corrupted global view with 1000 view on top of it, this algorithm will not waste of time to iterate 1000 views. Instead, it stops immediately and adds a corrupted view to the result list.
