### PR TITLE
PHOENIX-5562 Simplify detection of concurrent updates on data tables with indexes

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -108,19 +108,12 @@ public class IndexRegionObserver implements RegionObserver, RegionCoprocessor {
    * Class to represent pending data table rows
    */
   private static class PendingRow {
-      private long latestTimestamp;
-      private long count;
+      private boolean concurrent = false;
+      private long count = 1;
 
-      PendingRow(long latestTimestamp) {
-          count = 1;
-          this.latestTimestamp = latestTimestamp;
-      }
-
-      public void add(long timestamp) {
+      public void add() {
           count++;
-          if (latestTimestamp < timestamp) {
-              latestTimestamp = timestamp;
-          }
+          concurrent = true;
       }
 
       public void remove() {
@@ -131,8 +124,8 @@ public class IndexRegionObserver implements RegionObserver, RegionCoprocessor {
           return count;
       }
 
-      public long getLatestTimestamp() {
-          return latestTimestamp;
+      public boolean isConcurrent() {
+          return concurrent;
       }
   }
 
@@ -163,10 +156,6 @@ public class IndexRegionObserver implements RegionObserver, RegionCoprocessor {
       // The collection of candidate index mutations that will be applied after the data table mutations
       private Collection<Pair<Pair<Mutation, byte[]>, byte[]>> intermediatePostIndexUpdates;
       private List<RowLock> rowLocks = Lists.newArrayListWithExpectedSize(QueryServicesOptions.DEFAULT_MUTATE_BATCH_SIZE);
-      // The set of row keys for the data table rows of this batch such that for each of these rows there exists another
-      // batch with a timestamp earlier than the timestamp of this batch and the earlier batch has a mutation on the
-      // row (i.e., concurrent updates).
-      private HashSet<ImmutableBytesPtr> pendingRows = new HashSet<>();
       private HashSet<ImmutableBytesPtr> rowsToLock = new HashSet<>();
       long dataWriteStartTime;
 
@@ -407,16 +396,15 @@ public class IndexRegionObserver implements RegionObserver, RegionCoprocessor {
       }
   }
 
-  private void populatePendingRows(BatchMutateContext context, long now) {
+  private void populatePendingRows(BatchMutateContext context) {
       for (RowLock rowLock : context.rowLocks) {
           ImmutableBytesPtr rowKey = rowLock.getRowKey();
           PendingRow pendingRow = pendingRows.get(rowKey);
           if (pendingRow == null) {
-              pendingRows.put(rowKey, new PendingRow(now));
+              pendingRows.put(rowKey, new PendingRow());
           } else {
               // m is a mutation on a row that has already a pending mutation in progress from another batch
-              pendingRow.add(now);
-              context.pendingRows.add(rowKey);
+              pendingRow.add();
           }
       }
   }
@@ -585,17 +573,12 @@ public class IndexRegionObserver implements RegionObserver, RegionCoprocessor {
                       Put unverifiedPut = new Put(m.getRow());
                       unverifiedPut.addColumn(emptyCF, emptyCQ, now - 1, UNVERIFIED_BYTES);
                       context.preIndexUpdates.add(new Pair <>(unverifiedPut, next.getFirst().getSecond()));
-                      // Ignore post index updates (i.e., the third write phase updates) for this row if it is
-                      // going through concurrent updates
-                      ImmutableBytesPtr rowKey = new ImmutableBytesPtr(next.getSecond());
-                      if (!context.pendingRows.contains(rowKey)) {
-                          if (m instanceof Put) {
-                              // Remove the empty column prepared by Index codec as we need to change its value
-                              removeEmptyColumn(m, emptyCF, emptyCQ);
-                              ((Put) m).addColumn(emptyCF, emptyCQ, now, VERIFIED_BYTES);
-                          }
-                          context.intermediatePostIndexUpdates.add(next);
+                      if (m instanceof Put) {
+                          // Remove the empty column prepared by Index codec as we need to change its value
+                          removeEmptyColumn(m, emptyCF, emptyCQ);
+                          ((Put) m).addColumn(emptyCF, emptyCQ, now, VERIFIED_BYTES);
                       }
+                      context.intermediatePostIndexUpdates.add(next);
                   }
               }
           }
@@ -645,7 +628,7 @@ public class IndexRegionObserver implements RegionObserver, RegionCoprocessor {
       // Add the table rows in the mini batch to the collection of pending rows. This will be used to detect
       // concurrent updates
       if (replayWrite == null) {
-          populatePendingRows(context, now);
+          populatePendingRows(context);
       }
       // First group all the updates for a single row into a single update to be processed
       Collection<? extends Mutation> mutations = groupMutations(miniBatchOp, now, replayWrite);
@@ -688,9 +671,9 @@ public class IndexRegionObserver implements RegionObserver, RegionCoprocessor {
               Pair<Pair<Mutation, byte[]>, byte[]> update = iterator.next();
               ImmutableBytesPtr rowKey = new ImmutableBytesPtr(update.getSecond());
               PendingRow pendingRow = pendingRows.get(rowKey);
-              // Has any concurrent mutation arrived for the same row? if so, skip post index updates
+              // Are there concurrent updates on the data table row? if so, skip post index updates
               // and let read repair resolve conflicts
-              if (pendingRow.getLatestTimestamp() > now) {
+              if (pendingRow.isConcurrent()) {
                   iterator.remove();
               }
           }


### PR DESCRIPTION
In the current implementation, we have two pending-rows sets. The first one is at the table region level and the second one is at the batch level. The table region level set is a set of structures, one for each active row. This per row structure includes the row key, the timestamp of the last update on the row, and the number of concurrent updates on the row (i.e., the reference count). The second set is a simply set of row keys such that the corresponding rows for these row keys have at least one pending update at the time this batch is in the first phase. It turns out that we do not actually need the batch level set. All we need is that after acquiring the lock for the second time for a given update, we need to check if there are concurrent updates on the row using the region level set. if so, the last phase is skipped.