### PR TITLE
PHOENIX-5572 httpclient NoClassDefFoundError due to old httpcore version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -803,6 +803,10 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
exclude httpcore from the tephra dependency, so that we get httpcore via hadoop3->httpclient