### PR TITLE
Add a new Coprocessor - ViewTTLAware Coprocessor

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ViewTTLIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ViewTTLIT.java
@@ -18,6 +18,8 @@
 
 package org.apache.phoenix.end2end;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Result;
@@ -31,14 +33,29 @@ import org.apache.hadoop.hbase.filter.QualifierFilter;
 import org.apache.hadoop.hbase.filter.RowFilter;
 import org.apache.hadoop.hbase.filter.SubstringComparator;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compile.QueryPlan;
+import org.apache.phoenix.coprocessor.BaseScannerRegionObserver;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
-import org.apache.phoenix.query.PhoenixTestBuilder;
+import org.apache.phoenix.jdbc.PhoenixResultSet;
+import org.apache.phoenix.jdbc.PhoenixStatement;
+import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder;
+import org.apache.phoenix.query.PhoenixTestBuilder.BasicDataReader;
+import org.apache.phoenix.query.PhoenixTestBuilder.BasicDataWriter;
+import org.apache.phoenix.query.PhoenixTestBuilder.DataReader;
+import org.apache.phoenix.query.PhoenixTestBuilder.DataWriter;
+import org.apache.phoenix.query.PhoenixTestBuilder.DataSupplier;
+import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder.OtherOptions;
 import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder.TableOptions;
+import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder.GlobalViewOptions;
+import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder.GlobalViewIndexOptions;
 import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder.TenantViewOptions;
 import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder.TenantViewIndexOptions;
 import org.apache.phoenix.query.QueryConstants;
+import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTableType;
+import org.apache.phoenix.schema.types.PDataType;
+import org.apache.phoenix.util.PhoenixRuntime;
 import org.apache.phoenix.util.SchemaUtil;
 import org.apache.phoenix.util.TestUtil;
 import org.junit.Test;
@@ -51,9 +68,17 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
 
+import static java.util.Arrays.asList;
+import static org.apache.phoenix.query.PhoenixTestBuilder.DDLDefaults.MAX_ROWS;
 import static org.apache.phoenix.util.PhoenixRuntime.TENANT_ID_ATTRIB;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ViewTTLIT extends ParallelStatsDisabledIT {
@@ -65,6 +90,7 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
             + "WHERE %s AND TABLE_SCHEM = '%s' AND TABLE_NAME = '%s' AND TABLE_TYPE = '%s'";
 
     private static final String ALTER_VIEW_TTL_SQL = "ALTER VIEW %s.%s set VIEW_TTL=%d";
+    private static final int DEFAULT_NUM_ROWS = 5;
 
     // Scans the HBase rows directly for the view ttl related header rows column and asserts
     private void assertViewHeaderRowsHaveViewTTLRelatedCells(String schemaName, long minTimestamp,
@@ -134,7 +160,7 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
         // Define the test schema.
         // 1. Table with default columns => (ORG_ID, KP, COL1, COL2, COL3), PK => (ORG_ID, KP)
         // 2. GlobalView with default columns => (ID, COL4, COL5, COL6), PK => (ID)
-        final PhoenixTestBuilder.SchemaBuilder schemaBuilder = new PhoenixTestBuilder.SchemaBuilder(getUrl());
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
         schemaBuilder
                 .withTableDefaults()
                 .withGlobalViewDefaults()
@@ -153,7 +179,7 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
         // Define the test schema.
         // 1. Table with default columns => (ORG_ID, KP, COL1, COL2, COL3), PK => (ORG_ID, KP)
         // 2. Tenant with default columns => (ZID, COL7, COL8, COL9), PK => (ZID)
-        final PhoenixTestBuilder.SchemaBuilder schemaBuilder = new PhoenixTestBuilder.SchemaBuilder(getUrl());
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
 
         TableOptions tableOptions = TableOptions.withDefaults();
         tableOptions.setTableProps("COLUMN_ENCODED_BYTES=0,MULTI_TENANT=true,TTL=100");
@@ -177,7 +203,7 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
         // Define the test schema.
         // 1. Table with default columns => (ORG_ID, KP, COL1, COL2, COL3), PK => (ORG_ID, KP)
         // 2. Tenant with default columns => (ZID, COL7, COL8, COL9), PK => (ZID)
-        final PhoenixTestBuilder.SchemaBuilder schemaBuilder = new PhoenixTestBuilder.SchemaBuilder(getUrl());
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
 
         TableOptions tableOptions = TableOptions.withDefaults();
         tableOptions.setTableProps("COLUMN_ENCODED_BYTES=0,MULTI_TENANT=true");
@@ -203,7 +229,7 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
         // Define the test schema.
         // 1. Table with default columns => (ORG_ID, KP, COL1, COL2, COL3), PK => (ORG_ID, KP)
         // 2. Tenant with default columns => (ZID, COL7, COL8, COL9), PK => (ZID)
-        final PhoenixTestBuilder.SchemaBuilder schemaBuilder = new PhoenixTestBuilder.SchemaBuilder(getUrl());
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
 
         TableOptions tableOptions = TableOptions.withDefaults();
         tableOptions.setTableProps("COLUMN_ENCODED_BYTES=0,MULTI_TENANT=true");
@@ -238,18 +264,18 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
         // 1. Table with default columns => (ORG_ID, KP, COL1, COL2, COL3), PK => (ORG_ID, KP)
         // 2. GlobalView with default columns => (ID, COL4, COL5, COL6), PK => (ID)
         // 3. Tenant with default columns => (ZID, COL7, COL8, COL9), PK => (ZID)
-        final PhoenixTestBuilder.SchemaBuilder schemaBuilder = new PhoenixTestBuilder.SchemaBuilder(getUrl());
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
 
         TableOptions tableOptions = TableOptions.withDefaults();
         tableOptions.setTableProps("COLUMN_ENCODED_BYTES=0,MULTI_TENANT=true");
 
-        PhoenixTestBuilder.SchemaBuilder.GlobalViewOptions
-                globalViewOptions = PhoenixTestBuilder.SchemaBuilder.GlobalViewOptions.withDefaults();
+        SchemaBuilder.GlobalViewOptions
+                globalViewOptions = SchemaBuilder.GlobalViewOptions.withDefaults();
         globalViewOptions.setTableProps("VIEW_TTL=300000");
 
-        PhoenixTestBuilder.SchemaBuilder.GlobalViewIndexOptions
+        SchemaBuilder.GlobalViewIndexOptions
                 globalViewIndexOptions =
-                PhoenixTestBuilder.SchemaBuilder.GlobalViewIndexOptions.withDefaults();
+                SchemaBuilder.GlobalViewIndexOptions.withDefaults();
         globalViewIndexOptions.setLocal(false);
 
         TenantViewOptions tenantViewWithOverrideOptions = TenantViewOptions.withDefaults();
@@ -315,7 +341,7 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
         // Define the test schema.
         // 1. Table with default columns => (ORG_ID, KP, COL1, COL2, COL3), PK => (ORG_ID, KP)
         // 2. Tenant with default columns => (ZID, COL7, COL8, COL9), PK => (ZID)
-        final PhoenixTestBuilder.SchemaBuilder schemaBuilder = new PhoenixTestBuilder.SchemaBuilder(getUrl());
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
 
         TableOptions tableOptions = TableOptions.withDefaults();
         tableOptions.setTableProps("COLUMN_ENCODED_BYTES=0,MULTI_TENANT=true");
@@ -351,7 +377,7 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
         // Define the test schema.
         // 1. Table with default columns => (ORG_ID, KP, COL1, COL2, COL3), PK => (ORG_ID, KP)
         // 2. Tenant with default columns => (ZID, COL7, COL8, COL9), PK => (ZID)
-        final PhoenixTestBuilder.SchemaBuilder schemaBuilder = new PhoenixTestBuilder.SchemaBuilder(getUrl());
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
 
         TableOptions tableOptions = TableOptions.withDefaults();
         tableOptions.setTableProps("COLUMN_ENCODED_BYTES=0,MULTI_TENANT=true");
@@ -394,4 +420,804 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
 
     }
 
+    @Test
+    public void testViewTTLForLevelTwoViewWithNoIndexes() throws Exception {
+        long startTime = System.currentTimeMillis();
+
+        // Define the test schema.
+        // 1. Table with default columns => (ORG_ID, KP, COL1, COL2, COL3), PK => (ORG_ID, KP)
+        // 2. GlobalView with default columns => (ID, COL4, COL5, COL6), PK => (ID)
+        // 3. Tenant with default columns => (ZID, COL7, COL8, COL9), PK => (ZID)
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
+
+        TableOptions tableOptions = TableOptions.withDefaults();
+        tableOptions.setTableProps("COLUMN_ENCODED_BYTES=0,MULTI_TENANT=true");
+
+        SchemaBuilder.GlobalViewOptions
+                globalViewOptions = SchemaBuilder.GlobalViewOptions.withDefaults();
+        globalViewOptions.setTableProps("VIEW_TTL=300000");
+
+        TenantViewOptions tenantViewWithOverrideOptions = TenantViewOptions.withDefaults();
+        tenantViewWithOverrideOptions.setTableProps("VIEW_TTL=10000");
+        schemaBuilder
+                .withTableOptions(tableOptions)
+                .withGlobalViewOptions(globalViewOptions)
+                .withTenantViewOptions(tenantViewWithOverrideOptions)
+                .buildWithNewTenant();
+
+        String tenantId = schemaBuilder.getDataOptions().getTenantId();
+        String schemaName = stripQuotes(SchemaUtil.getSchemaNameFromFullName(schemaBuilder.getEntityTenantViewName()));
+        String globalViewName = stripQuotes(SchemaUtil.getTableNameFromFullName(schemaBuilder.getEntityGlobalViewName()));
+        String tenantViewName = stripQuotes(SchemaUtil.getTableNameFromFullName(schemaBuilder.getEntityTenantViewName()));
+
+
+
+        // Expected 2 rows - one for GlobalView, one for TenantView  each.
+        // Since the VIEW_TTL property values are being set, we expect the view header columns to show up in regular scans too.
+        assertViewHeaderRowsHaveViewTTLRelatedCells(schemaBuilder.getTableOptions().getSchemaName(), startTime, false, 2);
+        assertSyscatHaveViewTTLRelatedColumns("", schemaName, globalViewName, PTableType.VIEW.getSerializedValue(), 300000);
+        // Since the VIEW_TTL property values are not being overriden, we expect the TTL value to be different from the global view.
+        assertSyscatHaveViewTTLRelatedColumns(tenantId, schemaName, tenantViewName, PTableType.VIEW.getSerializedValue(), 10000);
+
+        // Without override
+        startTime = System.currentTimeMillis();
+
+        TenantViewOptions tenantViewWithoutOverrideOptions = TenantViewOptions.withDefaults();
+        schemaBuilder
+                .withTableOptions(tableOptions)
+                .withGlobalViewOptions(globalViewOptions)
+                .withTenantViewOptions(tenantViewWithoutOverrideOptions)
+                .buildWithNewTenant();
+
+        tenantId = schemaBuilder.getDataOptions().getTenantId();
+        schemaName = stripQuotes(SchemaUtil.getSchemaNameFromFullName(schemaBuilder.getEntityTenantViewName()));
+        globalViewName = stripQuotes(SchemaUtil.getTableNameFromFullName(schemaBuilder.getEntityGlobalViewName()));
+        tenantViewName = stripQuotes(SchemaUtil.getTableNameFromFullName(schemaBuilder.getEntityTenantViewName()));
+
+
+        // Expected 1 rows - one for TenantView each.
+        // Since the VIEW_TTL property values are being set, we expect the view header columns to show up in regular scans too.
+        assertViewHeaderRowsHaveViewTTLRelatedCells(schemaBuilder.getTableOptions().getSchemaName(), startTime, false, 1);
+        assertSyscatHaveViewTTLRelatedColumns("", schemaName, globalViewName, PTableType.VIEW.getSerializedValue(), 300000);
+        // Since the VIEW_TTL property values are not being overriden, we expect the TTL value to be same as the global view.
+        assertSyscatHaveViewTTLRelatedColumns(tenantId, schemaName, tenantViewName, PTableType.VIEW.getSerializedValue(), 300000);
+    }
+
+    @Test
+    public void testWithTenantViewAndNoGlobalView() throws Exception {
+
+        long viewTTL = 10000;
+        TableOptions tableOptions = TableOptions.withDefaults();
+        tableOptions.getTableColumns().clear();
+        tableOptions.getTableColumnTypes().clear();
+
+        TenantViewOptions tenantViewOptions = TenantViewOptions.withDefaults();
+        tenantViewOptions.setTableProps(String.format("VIEW_TTL=%d", viewTTL));
+
+        // Define the test schema.
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
+        schemaBuilder
+                .withTableOptions(tableOptions)
+                .withTenantViewOptions(tenantViewOptions)
+                .build();
+
+
+        // Define the test data.
+        DataSupplier dataSupplier = new DataSupplier() {
+
+            final String
+                    orgId =
+                    String.format("00D0x000%s", schemaBuilder.getDataOptions().getUniqueName());
+            final String kp = SchemaUtil.normalizeIdentifier(schemaBuilder.getEntityKeyPrefix());
+
+            @Override public List<Object> getValues(int rowIndex) {
+                Random rnd = new Random();
+                String zid = String.format("00A0y000%07d", rowIndex);
+                String col7 = String.format("g%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String col8 = String.format("h%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String col9 = String.format("i%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                return Lists.newArrayList(new Object[] { zid, col7, col8, col9 });
+            }
+        };
+
+        // Create a test data reader/writer for the above schema.
+        DataWriter dataWriter = new BasicDataWriter();
+        DataReader dataReader = new BasicDataReader();
+
+        List<String> columns = Lists.newArrayList("ZID", "COL7", "COL8", "COL9");
+        List<String> rowKeyColumns = Lists.newArrayList("ZID");
+        String
+                tenantConnectUrl =
+                getUrl() + ';' + TENANT_ID_ATTRIB + '=' + schemaBuilder.getDataOptions()
+                        .getTenantId();
+        try (Connection writeConnection = DriverManager
+                .getConnection(tenantConnectUrl)) {
+            writeConnection.setAutoCommit(true);
+            dataWriter.setConnection(writeConnection);
+            dataWriter.setDataSupplier(dataSupplier);
+            dataWriter.setUpsertColumns(columns);
+            dataWriter.setRowKeyColumns(rowKeyColumns);
+            dataWriter.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+            dataReader.setValidationColumns(columns);
+            dataReader.setRowKeyColumns(rowKeyColumns);
+            dataReader.setDML(String.format("SELECT %s from %s",
+                    Joiner.on(",").join(columns),
+                    schemaBuilder.getEntityTenantViewName()));
+            dataReader.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+            // Validate data before and after ttl expiration.
+            upsertDataAndRunValidations(viewTTL, DEFAULT_NUM_ROWS, dataWriter,
+                    dataReader, schemaBuilder);
+
+        }
+    }
+
+    @Test public void testWithSQLUsingIndex() throws Exception {
+
+        long viewTTL = 10000;
+        TableOptions tableOptions = TableOptions.withDefaults();
+        tableOptions.getTableColumns().clear();
+        tableOptions.getTableColumnTypes().clear();
+
+        GlobalViewOptions
+                globalViewOptions =
+                SchemaBuilder.GlobalViewOptions.withDefaults();
+        globalViewOptions.setTableProps(String.format("VIEW_TTL=%d", viewTTL));
+
+        GlobalViewIndexOptions
+                globalViewIndexOptions =
+                SchemaBuilder.GlobalViewIndexOptions.withDefaults();
+        globalViewIndexOptions.setLocal(false);
+
+        TenantViewOptions tenantViewOptions = new TenantViewOptions();
+        tenantViewOptions
+                .setTenantViewColumns(asList("ZID", "COL7", "COL8", "COL9"));
+        tenantViewOptions
+                .setTenantViewColumnTypes(asList("CHAR(15)", "VARCHAR", "VARCHAR", "VARCHAR"));
+
+        tenantViewOptions.setTableProps(String.format("VIEW_TTL=%d", viewTTL));
+
+        OtherOptions testCaseWhenAllCFMatchAndAllDefault = new OtherOptions();
+        testCaseWhenAllCFMatchAndAllDefault.setTestName("testCaseWhenAllCFMatchAndAllDefault");
+        testCaseWhenAllCFMatchAndAllDefault
+                .setTableCFs(Lists.newArrayList((String) null, null, null));
+        testCaseWhenAllCFMatchAndAllDefault
+                .setGlobalViewCFs(Lists.newArrayList((String) null, null, null));
+        testCaseWhenAllCFMatchAndAllDefault.setTenantViewCFs(Lists.newArrayList((String)null, null, null, null));
+
+        // Define the test schema.
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
+        schemaBuilder
+                .withTableOptions(tableOptions)
+                .withGlobalViewOptions(globalViewOptions)
+                .withGlobalViewIndexOptions(globalViewIndexOptions)
+                .withTenantViewOptions(tenantViewOptions)
+                .withOtherOptions(testCaseWhenAllCFMatchAndAllDefault)
+                .build();
+
+
+        // Define the test data.
+        final List<String> outerCol4s = Lists.newArrayList();
+        DataSupplier dataSupplier = new DataSupplier() {
+            String col4ForWhereClause;
+
+            @Override public List<Object> getValues(int rowIndex) {
+                Random rnd = new Random();
+                String id = String.format("00A0y000%07d", rowIndex);
+                String zid = String.format("00B0y000%07d", rowIndex);
+                String
+                        col4 =
+                        String.format("d%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+
+                // Store the col4 data to be used later in a where clause
+                outerCol4s.add(col4);
+                String
+                        col5 =
+                        String.format("e%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col6 =
+                        String.format("f%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col7 =
+                        String.format("g%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col8 =
+                        String.format("h%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col9 =
+                        String.format("i%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+
+                return Lists.newArrayList(
+                        new Object[] { id, zid, col4, col5, col6, col7,
+                                col8, col9 });
+            }
+        };
+
+        // Create a test data reader/writer for the above schema.
+        DataWriter dataWriter = new BasicDataWriter();
+        DataReader dataReader = new BasicDataReader();
+
+        List<String> columns = Lists.newArrayList("ID", "ZID",
+                "COL4", "COL5", "COL6", "COL7", "COL8", "COL9");
+        List<String> rowKeyColumns = Lists.newArrayList("COL6");
+        String
+                tenantConnectUrl =
+                getUrl() + ';' + TENANT_ID_ATTRIB + '=' + schemaBuilder.getDataOptions()
+                        .getTenantId();
+        try (Connection writeConnection = DriverManager
+                .getConnection(tenantConnectUrl)) {
+            writeConnection.setAutoCommit(true);
+            dataWriter.setConnection(writeConnection);
+            dataWriter.setDataSupplier(dataSupplier);
+            dataWriter.setUpsertColumns(columns);
+            dataWriter.setRowKeyColumns(rowKeyColumns);
+            dataWriter.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+            // Upsert data for validation
+            upsertData(dataWriter, DEFAULT_NUM_ROWS);
+
+            dataReader.setValidationColumns(rowKeyColumns);
+            dataReader.setRowKeyColumns(rowKeyColumns);
+            dataReader.setDML(String.format("SELECT col6 from %s where col4 = '%s'",
+                    schemaBuilder.getEntityTenantViewName(), outerCol4s.get(1)));
+            dataReader.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+            // Validate data before and after ttl expiration.
+            validateExpiredRowsAreNotReturnedUsingCounts(viewTTL, dataReader, schemaBuilder);
+        }
+    }
+
+    @Test public void testWithVariousSQLs() throws Exception {
+
+        long viewTTL = 10000;
+        TableOptions tableOptions = TableOptions.withDefaults();
+        tableOptions.getTableColumns().clear();
+        tableOptions.getTableColumnTypes().clear();
+
+        GlobalViewOptions
+                globalViewOptions =
+                SchemaBuilder.GlobalViewOptions.withDefaults();
+        globalViewOptions.setTableProps(String.format("VIEW_TTL=%d", viewTTL));
+
+        GlobalViewIndexOptions
+                globalViewIndexOptions =
+                SchemaBuilder.GlobalViewIndexOptions.withDefaults();
+        globalViewIndexOptions.setLocal(false);
+
+        TenantViewOptions tenantViewOptions = new TenantViewOptions();
+        tenantViewOptions
+                .setTenantViewColumns(asList("ZID", "COL7", "COL8", "COL9"));
+        tenantViewOptions
+                .setTenantViewColumnTypes(asList("CHAR(15)", "VARCHAR", "VARCHAR", "VARCHAR"));
+
+        tenantViewOptions.setTableProps(String.format("VIEW_TTL=%d", viewTTL));
+
+        OtherOptions testCaseWhenAllCFMatchAndAllDefault = new OtherOptions();
+        testCaseWhenAllCFMatchAndAllDefault.setTestName("testCaseWhenAllCFMatchAndAllDefault");
+        testCaseWhenAllCFMatchAndAllDefault
+                .setTableCFs(Lists.newArrayList((String) null, null, null));
+        testCaseWhenAllCFMatchAndAllDefault
+                .setGlobalViewCFs(Lists.newArrayList((String) null, null, null));
+        testCaseWhenAllCFMatchAndAllDefault.setTenantViewCFs(Lists.newArrayList((String)null, null, null, null));
+
+        // Define the test schema.
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
+        schemaBuilder
+                .withTableOptions(tableOptions)
+                .withGlobalViewOptions(globalViewOptions)
+                .withGlobalViewIndexOptions(globalViewIndexOptions)
+                .withTenantViewOptions(tenantViewOptions)
+                .withOtherOptions(testCaseWhenAllCFMatchAndAllDefault)
+                .build();
+
+
+        // Define the test data.
+        final String groupById = String.format("00A0y000%07d", 0);
+        DataSupplier dataSupplier = new DataSupplier() {
+
+            @Override public List<Object> getValues(int rowIndex) {
+                Random rnd = new Random();
+                String zid = String.format("00B0y000%07d", rowIndex);
+                String
+                        col4 =
+                        String.format("d%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col5 =
+                        String.format("e%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col6 =
+                        String.format("f%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col7 =
+                        String.format("g%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col8 =
+                        String.format("h%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String
+                        col9 =
+                        String.format("i%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+
+                return Lists.newArrayList(
+                        new Object[] { groupById, zid, col4, col5, col6, col7,
+                                col8, col9 });
+            }
+        };
+
+        // Create a test data reader/writer for the above schema.
+        DataWriter dataWriter = new BasicDataWriter();
+        List<String> columns = Lists.newArrayList("ID", "ZID",
+                "COL4", "COL5", "COL6", "COL7", "COL8", "COL9");
+        List<String> rowKeyColumns = Lists.newArrayList("ID", "ZID");
+        String
+                tenantConnectUrl =
+                getUrl() + ';' + TENANT_ID_ATTRIB + '=' + schemaBuilder.getDataOptions()
+                        .getTenantId();
+        try (Connection writeConnection = DriverManager
+                .getConnection(tenantConnectUrl)) {
+            writeConnection.setAutoCommit(true);
+            dataWriter.setConnection(writeConnection);
+            dataWriter.setDataSupplier(dataSupplier);
+            dataWriter.setUpsertColumns(columns);
+            dataWriter.setRowKeyColumns(rowKeyColumns);
+            dataWriter.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+            upsertData(dataWriter, DEFAULT_NUM_ROWS);
+
+            // Case : count(1) sql
+            DataReader dataReader = new BasicDataReader();
+            dataReader.setValidationColumns(Arrays.asList("num_rows"));
+            dataReader.setRowKeyColumns(Arrays.asList("num_rows"));
+            dataReader.setDML(String.format("SELECT count(1) as num_rows from %s HAVING count(1) > 0",
+                    schemaBuilder.getEntityTenantViewName()));
+            dataReader.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+            // Validate data before and after ttl expiration.
+            validateExpiredRowsAreNotReturnedUsingCounts(viewTTL, dataReader, schemaBuilder);
+
+            // Case : group by sql
+            dataReader.setValidationColumns(Arrays.asList("num_rows"));
+            dataReader.setRowKeyColumns(Arrays.asList("num_rows"));
+            dataReader.setDML(String.format("SELECT count(1) as num_rows from %s GROUP BY ID HAVING count(1) > 0",
+                    schemaBuilder.getEntityTenantViewName(),
+                    groupById));
+
+            dataReader.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+            // Validate data before and after ttl expiration.
+            validateExpiredRowsAreNotReturnedUsingCounts(viewTTL, dataReader, schemaBuilder);
+        }
+    }
+
+    @Test
+    public void testWithTenantViewAndGlobalViewAndVariousOptions() throws Exception {
+        long viewTTL = 10000;
+
+        // Define the test schema
+        TableOptions tableOptions = TableOptions.withDefaults();
+
+        GlobalViewOptions
+                globalViewOptions =
+                SchemaBuilder.GlobalViewOptions.withDefaults();
+        globalViewOptions.setTableProps(String.format("VIEW_TTL=%d", viewTTL));
+
+        GlobalViewIndexOptions
+                globalViewIndexOptions =
+                GlobalViewIndexOptions.withDefaults();
+
+        TenantViewOptions tenantViewOptions = new TenantViewOptions();
+        tenantViewOptions
+                .setTenantViewColumns(asList("ZID", "COL7", "COL8", "COL9"));
+        tenantViewOptions
+                .setTenantViewColumnTypes(asList("CHAR(15)", "VARCHAR", "VARCHAR", "VARCHAR"));
+        tenantViewOptions.setTableProps(String.format("VIEW_TTL=%d", viewTTL));
+
+        TenantViewIndexOptions
+                tenantViewIndexOptions =
+                TenantViewIndexOptions.withDefaults();
+
+        OtherOptions testCaseWhenAllCFMatchAndAllDefault = new OtherOptions();
+        testCaseWhenAllCFMatchAndAllDefault.setTestName("testCaseWhenAllCFMatchAndAllDefault");
+        testCaseWhenAllCFMatchAndAllDefault
+                .setTableCFs(Lists.newArrayList((String) null, null, null));
+        testCaseWhenAllCFMatchAndAllDefault
+                .setGlobalViewCFs(Lists.newArrayList((String) null, null, null));
+        testCaseWhenAllCFMatchAndAllDefault.setTenantViewCFs(Lists.newArrayList((String)null, null, null, null));
+
+        for (String additionalProps : Lists
+                .newArrayList("COLUMN_ENCODED_BYTES=0", "DEFAULT_COLUMN_FAMILY='0'")) {
+
+            StringBuilder withTableProps = new StringBuilder();
+            withTableProps.append("MULTI_TENANT=true,").append(additionalProps);
+
+            for (boolean isGlobalViewLocal : Lists.newArrayList(true, false)) {
+                for (boolean isTenantViewLocal : Lists.newArrayList(true, false)) {
+
+                    tableOptions.setTableProps(withTableProps.toString());
+                    globalViewIndexOptions.setLocal(isGlobalViewLocal);
+                    tenantViewIndexOptions.setLocal(isTenantViewLocal);
+                    OtherOptions otherOptions = testCaseWhenAllCFMatchAndAllDefault;
+
+                    final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
+                    schemaBuilder
+                            .withTableOptions(tableOptions)
+                            .withGlobalViewOptions(globalViewOptions)
+                            .withGlobalViewIndexOptions(globalViewIndexOptions)
+                            .withTenantViewOptions(tenantViewOptions)
+                            .withTenantViewIndexOptions(tenantViewIndexOptions)
+                            .withOtherOptions(testCaseWhenAllCFMatchAndAllDefault)
+                            .buildWithNewTenant();
+
+                    // Define the test data.
+                    DataSupplier dataSupplier = new DataSupplier() {
+
+                        @Override public List<Object> getValues(int rowIndex) {
+                            Random rnd = new Random();
+                            String id = String.format("00A0y000%07d", rowIndex);
+                            String zid = String.format("00B0y000%07d", rowIndex);
+                            String
+                                    col1 =
+                                    String.format("a%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                            String
+                                    col2 =
+                                    String.format("b%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                            String
+                                    col3 =
+                                    String.format("c%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                            String
+                                    col4 =
+                                    String.format("d%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                            String
+                                    col5 =
+                                    String.format("e%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                            String
+                                    col6 =
+                                    String.format("f%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                            String
+                                    col7 =
+                                    String.format("g%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                            String
+                                    col8 =
+                                    String.format("h%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                            String
+                                    col9 =
+                                    String.format("i%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+
+                            return Lists.newArrayList(
+                                    new Object[] { id, zid, col1, col2, col3, col4, col5, col6, col7,
+                                            col8, col9 });
+                        }
+                    };
+
+                    // Create a test data reader/writer for the above schema.
+                    DataWriter dataWriter = new BasicDataWriter();
+                    DataReader dataReader = new BasicDataReader();
+
+                    List<String> columns = Lists.newArrayList("ID", "ZID", "COL1", "COL2",
+                            "COL3", "COL4", "COL5", "COL6", "COL7", "COL8", "COL9");
+                    List<String> rowKeyColumns = Lists.newArrayList("ID", "ZID");
+                    String
+                            tenantConnectUrl =
+                            getUrl() + ';' + TENANT_ID_ATTRIB + '=' + schemaBuilder
+                                    .getDataOptions().getTenantId();
+                    try (Connection writeConnection = DriverManager
+                            .getConnection(tenantConnectUrl)) {
+                        writeConnection.setAutoCommit(true);
+                        dataWriter.setConnection(writeConnection);
+                        dataWriter.setDataSupplier(dataSupplier);
+                        dataWriter.setUpsertColumns(columns);
+                        dataWriter.setRowKeyColumns(rowKeyColumns);
+                        dataWriter.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+                        dataReader.setValidationColumns(columns);
+                        dataReader.setRowKeyColumns(rowKeyColumns);
+                        dataReader.setDML(String.format("SELECT %s from %s",
+                                Joiner.on(",").join(columns),
+                                schemaBuilder.getEntityTenantViewName()));
+                        dataReader.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+                        // Validate data before and after ttl expiration.
+                        upsertDataAndRunValidations(viewTTL, DEFAULT_NUM_ROWS,
+                                dataWriter, dataReader, schemaBuilder);
+                    }
+
+
+                    long scnTimestamp = System.currentTimeMillis()+viewTTL;
+
+                    // Delete data by simulating expiration.
+                    deleteData(schemaBuilder, scnTimestamp);
+
+                    // Verify after deleting TTL expired data.
+                    Properties props = new Properties();
+                    props.setProperty("CurrentSCN", Long.toString(scnTimestamp));
+                    try (Connection readConnection = DriverManager
+                            .getConnection(tenantConnectUrl, props)) {
+
+                        dataReader.setConnection(readConnection);
+                        com.google.common.collect.Table<String, String, Object> fetchedData =
+                                fetchData(dataReader);
+                        assertTrue("Expired rows should not be fetched",
+                                fetchedData.rowKeySet().size() == 0);
+                    }
+
+                }
+            }
+        }
+    }
+
+    @Test public void testDeleteIfExpiredOnTenantView() throws Exception {
+
+        long viewTTL = 180000;
+        TableOptions tableOptions = TableOptions.withDefaults();
+        tableOptions.getTableColumns().clear();
+        tableOptions.getTableColumnTypes().clear();
+
+        TenantViewOptions tenantViewOptions = TenantViewOptions.withDefaults();
+        tenantViewOptions.setTableProps(String.format("VIEW_TTL=%d", viewTTL));
+
+        // Define the test schema.
+        final SchemaBuilder schemaBuilder = new SchemaBuilder(getUrl());
+        schemaBuilder.withTableOptions(tableOptions).withTenantViewOptions(tenantViewOptions)
+                .build();
+
+        // Define the test data.
+        DataSupplier dataSupplier = new DataSupplier() {
+
+            final String
+                    orgId =
+                    String.format("00D0x000%s", schemaBuilder.getDataOptions().getUniqueName());
+            final String kp = SchemaUtil.normalizeIdentifier(schemaBuilder.getEntityKeyPrefix());
+
+            @Override public List<Object> getValues(int rowIndex) {
+                Random rnd = new Random();
+                String zid = String.format("00A0y000%07d", rowIndex);
+                String col7 = String.format("g%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String col8 = String.format("h%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                String col9 = String.format("i%05d", rowIndex + rnd.nextInt(MAX_ROWS));
+                return Lists.newArrayList(new Object[] { zid, col7, col8, col9 });
+            }
+        };
+
+        // Create a test data reader/writer for the above schema.
+        DataWriter dataWriter = new BasicDataWriter();
+        DataReader dataReader = new BasicDataReader();
+
+        List<String> columns = Lists.newArrayList("ZID", "COL7", "COL8", "COL9");
+        List<String> rowKeyColumns = Lists.newArrayList("ZID");
+        String
+                tenantConnectUrl =
+                getUrl() + ';' + TENANT_ID_ATTRIB + '=' + schemaBuilder.getDataOptions()
+                        .getTenantId();
+        try (Connection writeConnection = DriverManager.getConnection(tenantConnectUrl)) {
+            writeConnection.setAutoCommit(true);
+            dataWriter.setConnection(writeConnection);
+            dataWriter.setDataSupplier(dataSupplier);
+            dataWriter.setUpsertColumns(columns);
+            dataWriter.setRowKeyColumns(rowKeyColumns);
+            dataWriter.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+            dataReader.setValidationColumns(columns);
+            dataReader.setRowKeyColumns(rowKeyColumns);
+            dataReader.setDML(String.format("SELECT %s from %s", Joiner.on(",").join(columns),
+                    schemaBuilder.getEntityTenantViewName()));
+            dataReader.setTargetEntity(schemaBuilder.getEntityTenantViewName());
+
+            // Validate data before and after ttl expiration.
+            upsertDataAndRunValidations(viewTTL, DEFAULT_NUM_ROWS, dataWriter,
+                    dataReader, schemaBuilder);
+        }
+
+        long scnTimestamp = System.currentTimeMillis()+viewTTL;
+
+        // Delete data by simulating expiration.
+        deleteData(schemaBuilder, scnTimestamp);
+
+        // Verify after deleting TTL expired data.
+        Properties props = new Properties();
+        props.setProperty("CurrentSCN", Long.toString(scnTimestamp));
+        try (Connection readConnection = DriverManager
+                .getConnection(tenantConnectUrl, props)) {
+
+            dataReader.setConnection(readConnection);
+            com.google.common.collect.Table<String, String, Object> fetchedData =
+                    fetchData(dataReader);
+            assertTrue("Expired rows should not be fetched",
+                    fetchedData.rowKeySet().size() == 0);
+        }
+    }
+
+    private void upsertDataAndRunValidations(long viewTTL, int numRowsToUpsert,
+            DataWriter dataWriter, DataReader dataReader,
+            SchemaBuilder schemaBuilder)
+            throws IOException, SQLException {
+
+        //Insert for the first time and validate them.
+        validateExpiredRowsAreNotReturnedUsingData(viewTTL, upsertData(dataWriter, numRowsToUpsert),
+                dataReader,
+                schemaBuilder);
+
+        // Update the above rows and validate the same.
+        validateExpiredRowsAreNotReturnedUsingData(viewTTL, upsertData(dataWriter, numRowsToUpsert),
+                dataReader,
+                schemaBuilder);
+
+    }
+
+
+    private void validateExpiredRowsAreNotReturnedUsingCounts(
+            long viewTTL,
+            DataReader dataReader,
+            SchemaBuilder schemaBuilder) throws SQLException {
+
+        String
+                tenantConnectUrl =
+                getUrl() + ';' + TENANT_ID_ATTRIB + '=' + schemaBuilder.getDataOptions()
+                        .getTenantId();
+
+        // Verify before TTL expiration
+        try (Connection readConnection = DriverManager
+                .getConnection(tenantConnectUrl)) {
+
+            dataReader.setConnection(readConnection);
+            com.google.common.collect.Table<String, String, Object> fetchedData =
+                    fetchData(dataReader);
+            assertTrue("Fetched data should not be null",
+                    fetchedData != null);
+            assertTrue("Rows should exists before expiration",
+                    fetchedData.rowKeySet().size() > 0);
+        }
+
+        // Verify after TTL expiration
+        long scnTimestamp = System.currentTimeMillis();
+        Properties props = new Properties();
+        props.setProperty("CurrentSCN", Long.toString(scnTimestamp+(2*viewTTL)));
+        try (Connection readConnection = DriverManager
+                .getConnection(tenantConnectUrl, props)) {
+
+            dataReader.setConnection(readConnection);
+            com.google.common.collect.Table<String, String, Object> fetchedData =
+                    fetchData(dataReader);
+            assertTrue("Fetched data should not be null",
+                    fetchedData != null);
+            assertTrue("Expired rows should not be fetched",
+                    fetchedData.rowKeySet().size() == 0);
+        }
+
+    }
+
+    private void validateExpiredRowsAreNotReturnedUsingData(
+            long viewTTL,
+            com.google.common.collect.Table<String, String, Object> upsertedData,
+            DataReader dataReader,
+            SchemaBuilder schemaBuilder) throws SQLException {
+
+        String
+                tenantConnectUrl =
+                getUrl() + ';' + TENANT_ID_ATTRIB + '=' + schemaBuilder.getDataOptions()
+                        .getTenantId();
+
+
+        // Verify before TTL expiration
+        try (Connection readConnection = DriverManager
+                .getConnection(tenantConnectUrl)) {
+
+            dataReader.setConnection(readConnection);
+            com.google.common.collect.Table<String, String, Object> fetchedData =
+                    fetchData(dataReader);
+            assertTrue("Upserted data should not be null",
+                    upsertedData != null);
+            assertTrue("Fetched data should not be null",
+                    fetchedData != null);
+
+            verifyRowsBeforeTTLExpiration(upsertedData, fetchedData);
+        }
+
+        // Verify after TTL expiration
+        long scnTimestamp = System.currentTimeMillis();
+        Properties props = new Properties();
+        props.setProperty("CurrentSCN", Long.toString(scnTimestamp+(2*viewTTL)));
+        try (Connection readConnection = DriverManager
+                .getConnection(tenantConnectUrl, props)) {
+
+            dataReader.setConnection(readConnection);
+            com.google.common.collect.Table<String, String, Object> fetchedData =
+                    fetchData(dataReader);
+            assertTrue("Fetched data should not be null",
+                    fetchedData != null);
+            assertTrue("Expired rows should not be fetched",
+                    fetchedData.rowKeySet().size() == 0);
+        }
+
+    }
+
+    private void verifyRowsBeforeTTLExpiration(
+            com.google.common.collect.Table<String, String, Object> upsertedData,
+            com.google.common.collect.Table<String, String, Object> fetchedData) {
+
+        Set<String> upsertedRowKeys = upsertedData.rowKeySet();
+        Set<String> fetchedRowKeys = fetchedData.rowKeySet();
+        assertTrue("Upserted row keys should not be null",
+                upsertedRowKeys != null);
+        assertTrue("Fetched row keys should not be null",
+                fetchedRowKeys != null);
+        assertTrue("Rows upserted and fetched do not match",
+                upsertedRowKeys.equals(fetchedRowKeys));
+
+
+        Set<String> fetchedCols = fetchedData.columnKeySet();
+
+        for (String rowKey : fetchedRowKeys) {
+            for (String columnKey : fetchedCols) {
+                Object upsertedValue = upsertedData.get(rowKey, columnKey);
+                Object fetchedValue = fetchedData.get(rowKey, columnKey);
+                assertTrue("Upserted values should not be null",
+                        upsertedValue != null);
+                assertTrue("Fetched values should not be null",
+                        fetchedValue != null);
+                assertTrue("Values upserted and fetched do not match",
+                        upsertedValue.equals(fetchedValue));
+                LOGGER.info(String.format("Row: %s, %s, %s, %s", rowKey, columnKey, upsertedValue, fetchedValue));
+            }
+        }
+    }
+
+    private com.google.common.collect.Table<String, String, Object> upsertData(
+            DataWriter dataWriter, int numRowsToUpsert) throws SQLException {
+        // Upsert rows
+        dataWriter.upsertRows(numRowsToUpsert);
+        return dataWriter.getDataTable();
+    }
+
+    private com.google.common.collect.Table<String, String, Object> fetchData(
+            DataReader dataReader) throws SQLException {
+
+        dataReader.readRows();
+        return dataReader.getDataTable();
+    }
+
+    private void deleteData(SchemaBuilder schemaBuilder, long scnTimestamp) throws SQLException {
+
+        String viewName = schemaBuilder.getEntityTenantViewName();
+        LOGGER.debug(String.format("Deleting from view :- " + viewName));
+
+
+        Properties props = new Properties();
+        props.setProperty("CurrentSCN", Long.toString(scnTimestamp));
+        String
+                tenantConnectUrl =
+                getUrl() + ';' + TENANT_ID_ATTRIB + '=' + schemaBuilder.getDataOptions()
+                        .getTenantId();
+
+        try (Connection deleteConnection = DriverManager.getConnection(tenantConnectUrl, props);
+                final Statement statement = deleteConnection.createStatement()) {
+            deleteConnection.setAutoCommit(true);
+
+            final String deleteIfExpiredStatement = String.format("select * from  %s", viewName);
+            Preconditions.checkNotNull(deleteIfExpiredStatement);
+
+            final PhoenixStatement pstmt = statement.unwrap(PhoenixStatement.class);
+            // Optimize the query plan so that we potentially use secondary indexes
+            final QueryPlan queryPlan = pstmt.optimizeQuery(deleteIfExpiredStatement);
+            final Scan scan = queryPlan.getContext().getScan();
+
+
+            PTable table = PhoenixRuntime.getTable(deleteConnection, schemaBuilder.getDataOptions().getTenantId(), viewName);
+
+            byte[] emptyColumnFamilyName = SchemaUtil.getEmptyColumnFamily(table);
+            byte[]
+                    emptyColumnName =
+                    table.getEncodingScheme() == PTable.QualifierEncodingScheme.NON_ENCODED_QUALIFIERS ?
+                            QueryConstants.EMPTY_COLUMN_BYTES :
+                            table.getEncodingScheme().encode(QueryConstants.ENCODED_EMPTY_COLUMN_NAME);
+
+            scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_FAMILY_NAME, emptyColumnFamilyName);
+            scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_QUALIFIER_NAME, emptyColumnName);
+            scan.setAttribute(BaseScannerRegionObserver.DELETE_VIEW_TTL_EXPIRED, PDataType.TRUE_BYTES);
+            scan.setAttribute(BaseScannerRegionObserver.MASK_VIEW_TTL_EXPIRED, PDataType.FALSE_BYTES);
+            scan.setAttribute(BaseScannerRegionObserver.VIEW_TTL, Bytes.toBytes(Long.valueOf(table.getViewTTL())));
+            PhoenixResultSet rs = pstmt.newResultSet(queryPlan.iterator(), queryPlan.getProjector(), queryPlan.getContext());
+            if (rs.next()) {
+                LOGGER.debug(String.format("Number of deleted rows :- " + rs.getString(1)));
+            }
+        }
+    }
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ViewTTLIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ViewTTLIT.java
@@ -59,8 +59,6 @@ import org.apache.phoenix.util.PhoenixRuntime;
 import org.apache.phoenix.util.SchemaUtil;
 import org.apache.phoenix.util.TestUtil;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -83,9 +81,6 @@ import static org.junit.Assert.fail;
 
 public class ViewTTLIT extends ParallelStatsDisabledIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ViewTTLIT.class);
-    private static final String ORG_ID_FMT = "00D0x000%s";
-    private static final String ID_FMT = "00A0y000%07d";
     private static final String VIEW_TTL_HEADER_SQL =  "SELECT VIEW_TTL FROM SYSTEM.CATALOG "
             + "WHERE %s AND TABLE_SCHEM = '%s' AND TABLE_NAME = '%s' AND TABLE_TYPE = '%s'";
 
@@ -494,11 +489,6 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
 
         // Define the test data.
         DataSupplier dataSupplier = new DataSupplier() {
-
-            final String
-                    orgId =
-                    String.format("00D0x000%s", schemaBuilder.getDataOptions().getUniqueName());
-            final String kp = SchemaUtil.normalizeIdentifier(schemaBuilder.getEntityKeyPrefix());
 
             @Override public List<Object> getValues(int rowIndex) {
                 Random rnd = new Random();
@@ -1129,11 +1119,6 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
         // Define the test data.
         DataSupplier dataSupplier = new DataSupplier() {
 
-            final String
-                    orgId =
-                    String.format("00D0x000%s", schemaBuilder.getDataOptions().getUniqueName());
-            final String kp = SchemaUtil.normalizeIdentifier(schemaBuilder.getEntityKeyPrefix());
-
             @Override public List<Object> getValues(int rowIndex) {
                 Random rnd = new Random();
                 String zid = String.format("00A0y000%07d", rowIndex);
@@ -1356,7 +1341,6 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
                         fetchedValue != null);
                 assertTrue("Values upserted and fetched do not match",
                         upsertedValue.equals(fetchedValue));
-                LOGGER.info(String.format("Row: %s, %s, %s, %s", rowKey, columnKey, upsertedValue, fetchedValue));
             }
         }
     }
@@ -1378,7 +1362,6 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
     private void deleteData(SchemaBuilder schemaBuilder, long scnTimestamp) throws SQLException {
 
         String viewName = schemaBuilder.getEntityTenantViewName();
-        LOGGER.debug(String.format("Deleting from view :- " + viewName));
 
         Properties props = new Properties();
         props.setProperty("CurrentSCN", Long.toString(scnTimestamp));
@@ -1415,9 +1398,6 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
             scan.setAttribute(BaseScannerRegionObserver.MASK_VIEW_TTL_EXPIRED, PDataType.FALSE_BYTES);
             scan.setAttribute(BaseScannerRegionObserver.VIEW_TTL, Bytes.toBytes(Long.valueOf(table.getViewTTL())));
             PhoenixResultSet rs = pstmt.newResultSet(queryPlan.iterator(), queryPlan.getProjector(), queryPlan.getContext());
-            if (rs.next()) {
-                LOGGER.debug(String.format("Number of deleted rows :- " + rs.getString(1)));
-            }
         }
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
@@ -50,10 +50,12 @@ import org.apache.phoenix.iterate.NonAggregateRegionScannerFactory;
 import org.apache.phoenix.iterate.RegionScannerFactory;
 import org.apache.phoenix.schema.StaleRegionBoundaryCacheException;
 import org.apache.phoenix.schema.types.PUnsignedTinyint;
+import org.apache.phoenix.util.EnvironmentEdgeManager;
 import org.apache.phoenix.util.ScanUtil;
 import org.apache.phoenix.util.ServerUtil;
 import org.apache.phoenix.util.TransactionUtil;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 abstract public class BaseScannerRegionObserver extends BaseRegionObserver {
 
@@ -98,6 +100,9 @@ abstract public class BaseScannerRegionObserver extends BaseRegionObserver {
     public static final String RUN_UPDATE_STATS_ASYNC_ATTRIB = "_RunUpdateStatsAsync";
     public static final String SKIP_REGION_BOUNDARY_CHECK = "_SKIP_REGION_BOUNDARY_CHECK";
     public static final String TX_SCN = "_TxScn";
+    public static final String VIEW_TTL = "_ViewTTL";
+    public static final String MASK_VIEW_TTL_EXPIRED = "_MASK_TTL_EXPIRED";
+    public static final String DELETE_VIEW_TTL_EXPIRED = "_DELETE_TTL_EXPIRED";
     public static final String SCAN_ACTUAL_START_ROW = "_ScanActualStartRow";
     public static final String REPLAY_WRITES = "_IGNORE_NEWER_MUTATIONS";
     public final static String SCAN_OFFSET = "_RowOffset";
@@ -121,7 +126,7 @@ abstract public class BaseScannerRegionObserver extends BaseRegionObserver {
     // In case of Index Write failure, we need to determine that Index mutation
     // is part of normal client write or Index Rebuilder. # PHOENIX-5080
     public final static byte[] REPLAY_INDEX_REBUILD_WRITES = PUnsignedTinyint.INSTANCE.toBytes(3);
-    
+
     public enum ReplayWrite {
         TABLE_AND_INDEX,
         INDEX_ONLY,
@@ -219,6 +224,7 @@ abstract public class BaseScannerRegionObserver extends BaseRegionObserver {
             TimeRange timeRange = scan.getTimeRange();
             scan.setTimeRange(timeRange.getMin(), Bytes.toLong(txnScn));
         }
+
         if (isRegionObserverFor(scan)) {
             // For local indexes, we need to throw if out of region as we'll get inconsistent
             // results otherwise while in other cases, it may just mean out client-side data
@@ -374,20 +380,23 @@ abstract public class BaseScannerRegionObserver extends BaseRegionObserver {
                 dataRegion, indexMaintainer, null, viewConstants, null, null, projector, ptr, useQualiferAsListIndex);
     }
 
-    @Override
-    public KeyValueScanner preStoreScannerOpen(final ObserverContext<RegionCoprocessorEnvironment> c,
-        final Store store, final Scan scan, final NavigableSet<byte[]> targetCols,
-        final KeyValueScanner s) throws IOException {
+    @Override public KeyValueScanner preStoreScannerOpen(
+            final ObserverContext<RegionCoprocessorEnvironment> c, final Store store,
+            final Scan scan, final NavigableSet<byte[]> targetCols, final KeyValueScanner s)
+            throws IOException {
 
-      if (scan.isRaw() || ScanInfoUtil.isKeepDeletedCells(store.getScanInfo()) || scan.getTimeRange().getMax() == HConstants.LATEST_TIMESTAMP || TransactionUtil.isTransactionalTimestamp(scan.getTimeRange().getMax())) {
-        return s;
-      }
-      
-      if (s!=null) {
-          s.close();
-      }
-      ScanInfo scanInfo = ScanInfoUtil.cloneScanInfoWithKeepDeletedCells(store.getScanInfo());
-      return ScanInfoUtil.createStoreScanner(store, scanInfo, scan, targetCols,
-          c.getEnvironment().getRegion().getReadpoint(scan.getIsolationLevel()));
+        if (scan.isRaw() || ScanInfoUtil.isKeepDeletedCells(store.getScanInfo())
+                || scan.getTimeRange().getMax() == HConstants.LATEST_TIMESTAMP || TransactionUtil
+                .isTransactionalTimestamp(scan.getTimeRange().getMax())) {
+            return s;
+        }
+
+        if (s != null) {
+            s.close();
+        }
+
+        ScanInfo scanInfo = ScanInfoUtil.cloneScanInfoWithKeepDeletedCells(store.getScanInfo());
+        return ScanInfoUtil.createStoreScanner(store, scanInfo, scan, targetCols,
+                c.getEnvironment().getRegion().getReadpoint(scan.getIsolationLevel()));
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
@@ -50,12 +50,9 @@ import org.apache.phoenix.iterate.NonAggregateRegionScannerFactory;
 import org.apache.phoenix.iterate.RegionScannerFactory;
 import org.apache.phoenix.schema.StaleRegionBoundaryCacheException;
 import org.apache.phoenix.schema.types.PUnsignedTinyint;
-import org.apache.phoenix.util.EnvironmentEdgeManager;
 import org.apache.phoenix.util.ScanUtil;
 import org.apache.phoenix.util.ServerUtil;
 import org.apache.phoenix.util.TransactionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 abstract public class BaseScannerRegionObserver extends BaseRegionObserver {
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/TTLAwareRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/TTLAwareRegionObserver.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.coprocessor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
+import org.apache.hadoop.hbase.io.TimeRange;
+import org.apache.hadoop.hbase.regionserver.Region;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScannerContext;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.filter.ColumnProjectionFilter;
+import org.apache.phoenix.filter.EncodedQualifiersColumnProjectionFilter;
+import org.apache.phoenix.filter.MultiEncodedCQKeyValueComparisonFilter;
+import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
+import org.apache.phoenix.util.EnvironmentEdgeManager;
+import org.apache.phoenix.util.ScanUtil;
+import org.apache.phoenix.util.ServerUtil;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+
+import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.EMPTY_COLUMN_FAMILY_NAME;
+import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.EMPTY_COLUMN_QUALIFIER_NAME;
+import static org.apache.phoenix.query.QueryConstants.ENCODED_EMPTY_COLUMN_NAME;
+
+/**
+ * 
+ * Coprocessor that checks whether the row is expired based on the TTL spec.
+ *
+ */
+public class TTLAwareRegionObserver extends BaseRegionObserver {
+    private static final Log LOG = LogFactory.getLog(TTLAwareRegionObserver.class);
+
+    /**
+     * A region scanner that checks the TTL expiration of rows
+     */
+    private static class TTLAwareRegionScanner implements RegionScanner {
+        RegionScanner scanner;
+        private Scan scan;
+        private byte[] emptyCF;
+        private byte[] emptyCQ;
+        private Region region;
+        private long minTimestamp;
+        private long maxTimestamp;
+        private long now;
+        private boolean deleteIfExpired;
+        private boolean maskIfExpired;
+
+        public TTLAwareRegionScanner(RegionCoprocessorEnvironment env,
+                                  Scan scan,
+                                  RegionScanner scanner) throws IOException {
+            this.scan = scan;
+            this.scanner = scanner;
+
+            deleteIfExpired = ScanUtil.isDeleteTTLExpiredRows(scan) ? true : false;
+            maskIfExpired = !deleteIfExpired && ScanUtil.isMaskTTLExpiredRows(scan) ? true : false;;
+
+            region = env.getRegion();
+            emptyCF = scan.getAttribute(EMPTY_COLUMN_FAMILY_NAME);
+            emptyCQ = scan.getAttribute(EMPTY_COLUMN_QUALIFIER_NAME);
+            byte[] txnScn = scan.getAttribute(BaseScannerRegionObserver.TX_SCN);
+            if (txnScn!=null) {
+                TimeRange timeRange = scan.getTimeRange();
+                scan.setTimeRange(timeRange.getMin(), Bytes.toLong(txnScn));
+            }
+            minTimestamp = scan.getTimeRange().getMin();
+            maxTimestamp = scan.getTimeRange().getMax();
+            now = maxTimestamp != HConstants.LATEST_TIMESTAMP ? maxTimestamp : EnvironmentEdgeManager.currentTimeMillis();
+        }
+
+        @Override
+        public int getBatch() {
+            return scanner.getBatch();
+        }
+
+        @Override
+        public long getMaxResultSize() {
+            return scanner.getMaxResultSize();
+        }
+
+        @Override
+        public boolean next(List<Cell> result) throws IOException {
+            try {
+                boolean hasMore;
+                do {
+                    hasMore = scanner.next(result);
+                    if (result.isEmpty()) {
+                        break;
+                    }
+
+                    if (maskIfExpired && checkRowNotExpired(result)) {
+                        break;
+                    }
+
+                    if (deleteIfExpired && deleteRowIfExpired(result)) {
+                        break;
+                    }
+                    // skip this row
+                    // 1. if the row has expired (checkRowNotExpired returned false)
+                    // 2. if the row was not deleted (deleteRowIfExpired returned false and
+                    //  do not want it to count towards the deleted count)
+                    result.clear();
+                } while (hasMore);
+                return hasMore;
+            } catch (Throwable t) {
+                ServerUtil.throwIOException(region.getRegionInfo().getRegionNameAsString(), t);
+                return false; // impossible
+            }
+        }
+
+        @Override
+        public boolean next(List<Cell> result, ScannerContext scannerContext) throws IOException {
+            throw new IOException("next with scannerContext should not be called in Phoenix environment");
+        }
+
+        @Override
+        public boolean nextRaw(List<Cell> result, ScannerContext scannerContext) throws IOException {
+            throw new IOException("NextRaw with scannerContext should not be called in Phoenix environment");
+        }
+
+        @Override
+        public void close() throws IOException {
+            scanner.close();
+        }
+
+        @Override
+        public HRegionInfo getRegionInfo() {
+            return scanner.getRegionInfo();
+        }
+
+        @Override
+        public boolean isFilterDone() throws IOException {
+            return scanner.isFilterDone();
+        }
+
+        @Override
+        public boolean reseek(byte[] row) throws IOException {
+            return scanner.reseek(row);
+        }
+
+        @Override
+        public long getMvccReadPoint() {
+            return scanner.getMvccReadPoint();
+        }
+
+        @Override
+        public boolean nextRaw(List<Cell> result) throws IOException {
+            try {
+                boolean hasMore;
+                do {
+                    hasMore = scanner.nextRaw(result);
+                    if (result.isEmpty()) {
+                        break;
+                    }
+                    if (maskIfExpired && checkRowNotExpired(result)) {
+                        break;
+                    }
+
+                    if (deleteIfExpired && deleteRowIfExpired(result)) {
+                        break;
+                    }
+                    // skip this row
+                    // 1. if the row has expired (checkRowNotExpired returned false)
+                    // 2. if the row was not deleted (deleteRowIfExpired returned false and
+                    //  do not want it to count towards the deleted count)
+                    result.clear();
+                } while (hasMore);
+                return hasMore;
+            } catch (Throwable t) {
+                ServerUtil.throwIOException(region.getRegionInfo().getRegionNameAsString(), t);
+                return false; // impossible
+            }
+        }
+
+        /**
+         * @param cellList is an input and output parameter and will either include a valid row or be an empty list
+         * @return true if row expired and deleted or empty, otherwise false
+         * @throws IOException
+         */
+        private boolean deleteRowIfExpired(List<Cell> cellList) throws IOException {
+
+            long cellListSize = cellList.size();
+            if (cellListSize == 0) {
+                return true;
+            }
+
+            Iterator<Cell> cellIterator = cellList.iterator();
+            Cell firstCell = cellIterator.next();
+            byte[] rowKey = new byte[firstCell.getRowLength()];
+            System.arraycopy(firstCell.getRowArray(), firstCell.getRowOffset(), rowKey, 0, firstCell.getRowLength());
+
+            boolean isRowExpired = !checkRowNotExpired(cellList);
+            if (isRowExpired) {
+                long ttl = ScanUtil.getViewTTL(this.scan) ;
+                long ts = getMaxTimestamp(cellList);
+                LOG.debug(String.format("***** VIEW-TTL: Deleting region = %s, row = %s, delete-ts = %d, max-ts = %d ****** ",
+                        region.getRegionInfo().getTable().getNameAsString(),
+                        Bytes.toString(rowKey),
+                        now-ttl, ts));
+                Delete del = new Delete(rowKey, now-ttl);
+                //del.addFamily(CellUtil.cloneFamily(firstCell));
+                Mutation[] mutations = new Mutation[]{del};
+                region.batchMutate(mutations, HConstants.NO_NONCE, HConstants.NO_NONCE);
+                return true;
+            }
+            return false;
+        }
+
+
+        private boolean isEmptyColumn(Cell cell) {
+            return Bytes.compareTo(cell.getFamilyArray(), cell.getFamilyOffset(), cell.getFamilyLength(),
+                    emptyCF, 0, emptyCF.length) == 0 &&
+                    Bytes.compareTo(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength(),
+                            emptyCQ, 0, emptyCQ.length) == 0;
+        }
+
+        // TODO : Remove it after we verify all SQLs include the empty column.
+        private boolean checkEmptyColumnNotExpired(byte[] rowKey) throws IOException {
+            LOG.warn("Scan " + scan + " did not return the empty column for " + region.getRegionInfo().getTable().getNameAsString());
+            Get get = new Get(rowKey);
+            get.setTimeRange(minTimestamp, maxTimestamp);
+            get.addColumn(emptyCF, emptyCQ);
+            Result result = region.get(get);
+            if (result.isEmpty()) {
+                LOG.warn("The empty column does not exist in a row in " + region.getRegionInfo().getTable().getNameAsString());
+                return false;
+            }
+            return !isTTLExpired(result.getColumnLatestCell(emptyCF, emptyCQ));
+        }
+
+        /**
+         * @param cellList is an input and output parameter and will either include a valid row or be an empty list
+         * @return true if row not expired, otherwise false
+         * @throws IOException
+         */
+        private boolean checkRowNotExpired(List<Cell> cellList) throws IOException {
+            long cellListSize = cellList.size();
+            Cell cell = null;
+            if (cellListSize == 0) {
+                return true;
+            }
+            Iterator<Cell> cellIterator = cellList.iterator();
+            while (cellIterator.hasNext()) {
+                cell = cellIterator.next();
+                if (isEmptyColumn(cell)) {
+                    LOG.debug(String.format("**********VIEW-TTL: Row expired for [%s], expired = %s ***************", cell.toString(), isTTLExpired(cell)));
+                    // Empty column is not supposed to be returned to the client except it is the only column included
+                    // in the scan
+                    if (cellListSize > 1) {
+                        cellIterator.remove();
+                    }
+                    return !isTTLExpired(cell);
+                }
+            }
+            byte[] rowKey = new byte[cell.getRowLength()];
+            System.arraycopy(cell.getRowArray(), cell.getRowOffset(), rowKey, 0, cell.getRowLength());
+            return checkEmptyColumnNotExpired(rowKey);
+        }
+
+        private long getMaxTimestamp(List<Cell> cellList) {
+            long maxTs = 0;
+            long ts = 0;
+            Iterator<Cell> cellIterator = cellList.iterator();
+            while (cellIterator.hasNext()) {
+                Cell cell = cellIterator.next();
+                ts = cell.getTimestamp();
+                if (ts > maxTs) {
+                    maxTs = ts;
+                }
+            }
+            return maxTs;
+        }
+
+        private boolean isTTLExpired(Cell cell) {
+            long ts = cell.getTimestamp();
+            long ttl = ScanUtil.getViewTTL(this.scan) ;
+            if (ts + ttl < now) {
+                return true;
+            }
+            return false;
+        }
+    }
+
+
+
+    @Override
+    public RegionScanner postScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c,
+                                         Scan scan, RegionScanner s) throws IOException {
+
+        if (!ScanUtil.isMaskTTLExpiredRows(scan) && !ScanUtil.isDeleteTTLExpiredRows(scan)) {
+            return s;
+        }
+
+        LOG.debug(String.format(
+                "********** VIEW-TTL: TTLAwareRegionObserver::postScannerOpen TTL for table = [%s], scan = [%s], VIEW_TTL = %d ***************",
+                s.getRegionInfo().getTable().getNameAsString(),
+                scan.toJSON(Integer.MAX_VALUE),
+                ScanUtil.getViewTTL(scan)));
+        return new TTLAwareRegionScanner(c.getEnvironment(), scan, s);
+    }
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/TTLAwareRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/TTLAwareRegionObserver.java
@@ -249,6 +249,8 @@ public class TTLAwareRegionObserver extends BaseRegionObserver {
         }
 
         // TODO : Remove it after we verify all SQLs include the empty column.
+        // Before we added ScanUtil.addEmptyColumnToScan some queries like select count(*) did not include
+        // the empty column in scan, thus this method was the fallback in those cases.
         private boolean checkEmptyColumnNotExpired(byte[] rowKey) throws IOException {
             LOG.warn("Scan " + scan + " did not return the empty column for " + region.getRegionInfo().getTable().getNameAsString());
             Get get = new Get(rowKey);

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/TTLAwareRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/TTLAwareRegionObserver.java
@@ -232,7 +232,6 @@ public class TTLAwareRegionObserver extends BaseRegionObserver {
                         Bytes.toString(rowKey),
                         now-ttl, ts));
                 Delete del = new Delete(rowKey, now-ttl);
-                //del.addFamily(CellUtil.cloneFamily(firstCell));
                 Mutation[] mutations = new Mutation[]{del};
                 region.batchMutate(mutations, HConstants.NO_NONCE, HConstants.NO_NONCE);
                 return true;

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableResultIterator.java
@@ -133,7 +133,8 @@ public class TableResultIterator implements ResultIterator {
         this.caches = caches;
         this.retry=plan.getContext().getConnection().getQueryServices().getProps()
                 .getInt(QueryConstants.HASH_JOIN_CACHE_RETRIES, QueryConstants.DEFAULT_HASH_JOIN_CACHE_RETRIES);
-        IndexUtil.setScanAttributesForIndexReadRepair(scan, table, plan.getContext().getConnection());
+        ScanUtil.setScanAttributesForIndexReadRepair(scan, table, plan.getContext().getConnection());
+        ScanUtil.setScanAttributesForViewTTL(scan, table, plan.getContext().getConnection());
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -1068,6 +1068,8 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                 }
             }
 
+            // The priority for this co-processor should be set higher than the GlobalIndexChecker so that the read repair scans
+            // are intercepted by the TTLAwareRegionObserver and only the rows that are not ttl-expired are returned.
             if (!SchemaUtil.isSystemTable(tableName)) {
                 if (!descriptor.hasCoprocessor(TTLAwareRegionObserver.class.getName())) {
                     descriptor.addCoprocessor(TTLAwareRegionObserver.class.getName(), null, priority-2, null);

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -158,6 +158,7 @@ import org.apache.phoenix.coprocessor.MetaDataRegionObserver;
 import org.apache.phoenix.coprocessor.ScanRegionObserver;
 import org.apache.phoenix.coprocessor.SequenceRegionObserver;
 import org.apache.phoenix.coprocessor.ServerCachingEndpointImpl;
+import org.apache.phoenix.coprocessor.TTLAwareRegionObserver;
 import org.apache.phoenix.coprocessor.TaskRegionObserver;
 import org.apache.phoenix.coprocessor.UngroupedAggregateRegionObserver;
 import org.apache.phoenix.coprocessor.generated.ChildLinkMetaDataProtos.CreateViewAddChildLinkRequest;
@@ -1066,6 +1067,13 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                     }
                 }
             }
+
+            if (!SchemaUtil.isSystemTable(tableName)) {
+                if (!descriptor.hasCoprocessor(TTLAwareRegionObserver.class.getName())) {
+                    descriptor.addCoprocessor(TTLAwareRegionObserver.class.getName(), null, priority-2, null);
+                }
+            }
+
         } catch (IOException e) {
             throw ServerUtil.parseServerException(e);
         }

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/IndexUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/IndexUtil.java
@@ -21,11 +21,9 @@ import static org.apache.phoenix.coprocessor.MetaDataProtocol.PHOENIX_MAJOR_VERS
 import static org.apache.phoenix.coprocessor.MetaDataProtocol.PHOENIX_MINOR_VERSION;
 import static org.apache.phoenix.coprocessor.MetaDataProtocol.PHOENIX_PATCH_NUMBER;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_FAMILY_BYTES;
-import static org.apache.phoenix.query.QueryConstants.ENCODED_EMPTY_COLUMN_NAME;
 import static org.apache.phoenix.query.QueryConstants.LOCAL_INDEX_COLUMN_FAMILY_PREFIX;
 import static org.apache.phoenix.query.QueryConstants.VALUE_COLUMN_FAMILY;
 import static org.apache.phoenix.query.QueryConstants.VALUE_COLUMN_QUALIFIER;
-import static org.apache.phoenix.schema.types.PDataType.TRUE_BYTES;
 import static org.apache.phoenix.util.PhoenixRuntime.getTable;
 
 import java.io.ByteArrayInputStream;
@@ -39,11 +37,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
@@ -60,8 +59,6 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.coprocessor.Batch;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
-import org.apache.hadoop.hbase.filter.Filter;
-import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.ipc.BlockingRpcCallback;
 import org.apache.hadoop.hbase.ipc.ServerRpcController;
@@ -83,7 +80,6 @@ import org.apache.phoenix.coprocessor.generated.MetaDataProtos.MetaDataService;
 import org.apache.phoenix.coprocessor.generated.MetaDataProtos.UpdateIndexStateRequest;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.exception.SQLExceptionInfo;
-import org.apache.phoenix.execute.BaseQueryPlan;
 import org.apache.phoenix.execute.MutationState.MultiRowMutationState;
 import org.apache.phoenix.execute.TupleProjector;
 import org.apache.phoenix.expression.Expression;
@@ -91,9 +87,6 @@ import org.apache.phoenix.expression.KeyValueColumnExpression;
 import org.apache.phoenix.expression.RowKeyColumnExpression;
 import org.apache.phoenix.expression.SingleCellColumnExpression;
 import org.apache.phoenix.expression.visitor.RowKeyExpressionVisitor;
-import org.apache.phoenix.filter.ColumnProjectionFilter;
-import org.apache.phoenix.filter.EncodedQualifiersColumnProjectionFilter;
-import org.apache.phoenix.filter.MultiEncodedCQKeyValueComparisonFilter;
 import org.apache.phoenix.hbase.index.ValueGetter;
 import org.apache.phoenix.hbase.index.covered.update.ColumnReference;
 import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
@@ -101,7 +94,6 @@ import org.apache.phoenix.hbase.index.util.KeyValueBuilder;
 import org.apache.phoenix.hbase.index.util.VersionUtil;
 import org.apache.phoenix.index.GlobalIndexChecker;
 import org.apache.phoenix.index.IndexMaintainer;
-import org.apache.phoenix.index.PhoenixIndexCodec;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
 import org.apache.phoenix.jdbc.PhoenixStatement;
@@ -141,6 +133,7 @@ import org.apache.phoenix.transaction.PhoenixTransactionProvider.Feature;
 import com.google.common.collect.Lists;
 
 public class IndexUtil {
+
     public static final String INDEX_COLUMN_NAME_SEP = ":";
     public static final byte[] INDEX_COLUMN_NAME_SEP_BYTES = Bytes.toBytes(INDEX_COLUMN_NAME_SEP);
 
@@ -918,87 +911,5 @@ public class IndexUtil {
         } catch (SQLException e) {
             throw new IOException(e);
         }
-    }
-
-    private static boolean containsOneOrMoreColumn(Scan scan) {
-        Map<byte[], NavigableSet<byte[]>> familyMap = scan.getFamilyMap();
-        if (familyMap == null || familyMap.isEmpty()) {
-            return false;
-        }
-        for (Map.Entry<byte[], NavigableSet<byte[]>> entry : familyMap.entrySet()) {
-            NavigableSet<byte[]> family = entry.getValue();
-            if (family != null && !family.isEmpty()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static void addEmptyColumnToScan(Scan scan, byte[] emptyCF, byte[] emptyCQ) {
-        boolean addedEmptyColumn = false;
-        Iterator<Filter> iterator = ScanUtil.getFilterIterator(scan);
-        while (iterator.hasNext()) {
-            Filter filter = iterator.next();
-            if (filter instanceof EncodedQualifiersColumnProjectionFilter) {
-                ((EncodedQualifiersColumnProjectionFilter) filter).addTrackedColumn(ENCODED_EMPTY_COLUMN_NAME);
-                if (!addedEmptyColumn && containsOneOrMoreColumn(scan)) {
-                    scan.addColumn(emptyCF, emptyCQ);
-                }
-            }
-            else if (filter instanceof ColumnProjectionFilter) {
-                ((ColumnProjectionFilter) filter).addTrackedColumn(new ImmutableBytesPtr(emptyCF), new ImmutableBytesPtr(emptyCQ));
-                if (!addedEmptyColumn && containsOneOrMoreColumn(scan)) {
-                    scan.addColumn(emptyCF, emptyCQ);
-                }
-            }
-            else if (filter instanceof MultiEncodedCQKeyValueComparisonFilter) {
-                ((MultiEncodedCQKeyValueComparisonFilter) filter).setMinQualifier(ENCODED_EMPTY_COLUMN_NAME);
-            }
-            else if (!addedEmptyColumn && filter instanceof FirstKeyOnlyFilter) {
-                scan.addColumn(emptyCF, emptyCQ);
-                addedEmptyColumn = true;
-            }
-        }
-        if (!addedEmptyColumn && containsOneOrMoreColumn(scan)) {
-            scan.addColumn(emptyCF, emptyCQ);
-        }
-    }
-
-    public static void setScanAttributesForIndexReadRepair(Scan scan, PTable table, PhoenixConnection phoenixConnection) throws SQLException {
-        if (table.isTransactional() || table.getType() != PTableType.INDEX) {
-            return;
-        }
-        PTable indexTable = table;
-        if (indexTable.getIndexType() != PTable.IndexType.GLOBAL) {
-            return;
-        }
-        String schemaName = indexTable.getParentSchemaName().getString();
-        String tableName = indexTable.getParentTableName().getString();
-        PTable dataTable;
-        try {
-            dataTable = PhoenixRuntime.getTable(phoenixConnection, SchemaUtil.getTableName(schemaName, tableName));
-        } catch (TableNotFoundException e) {
-            // This index table must be being deleted. No need to set the scan attributes
-            return;
-        }
-        if (!dataTable.getIndexes().contains(indexTable)) {
-            return;
-        }
-        if (scan.getAttribute(PhoenixIndexCodec.INDEX_PROTO_MD) == null) {
-            ImmutableBytesWritable ptr = new ImmutableBytesWritable();
-            IndexMaintainer.serialize(dataTable, ptr, Collections.singletonList(indexTable), phoenixConnection);
-            scan.setAttribute(PhoenixIndexCodec.INDEX_PROTO_MD, ByteUtil.copyKeyBytesIfNecessary(ptr));
-        }
-        scan.setAttribute(BaseScannerRegionObserver.CHECK_VERIFY_COLUMN, TRUE_BYTES);
-        scan.setAttribute(BaseScannerRegionObserver.PHYSICAL_DATA_TABLE_NAME, dataTable.getPhysicalName().getBytes());
-        IndexMaintainer indexMaintainer = indexTable.getIndexMaintainer(dataTable, phoenixConnection);
-        byte[] emptyCF = indexMaintainer.getEmptyKeyValueFamily().copyBytesIfNecessary();
-        byte[] emptyCQ = indexMaintainer.getEmptyKeyValueQualifier();
-        scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_FAMILY_NAME, emptyCF);
-        scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_QUALIFIER_NAME, emptyCQ);
-        if (scan.getAttribute(BaseScannerRegionObserver.VIEW_CONSTANTS) == null) {
-            BaseQueryPlan.serializeViewConstantsIntoScan(scan, dataTable);
-        }
-        addEmptyColumnToScan(scan, emptyCF, emptyCQ);
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/IndexUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/IndexUtil.java
@@ -41,8 +41,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
@@ -23,6 +23,8 @@ import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CUSTOM_AN
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.SCAN_ACTUAL_START_ROW;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.SCAN_START_ROW_SUFFIX;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.SCAN_STOP_ROW_SUFFIX;
+import static org.apache.phoenix.query.QueryConstants.ENCODED_EMPTY_COLUMN_NAME;
+import static org.apache.phoenix.schema.types.PDataType.TRUE_BYTES;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -35,17 +37,21 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeMap;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.io.TimeRange;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.io.WritableComparator;
+import org.apache.hadoop.yarn.webapp.hamlet.Hamlet;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.compile.ScanRanges;
 import org.apache.phoenix.compile.StatementContext;
@@ -53,13 +59,19 @@ import org.apache.phoenix.coprocessor.BaseScannerRegionObserver;
 import org.apache.phoenix.coprocessor.MetaDataProtocol;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.exception.SQLExceptionInfo;
+import org.apache.phoenix.execute.BaseQueryPlan;
 import org.apache.phoenix.execute.DescVarLengthFastByteComparisons;
 import org.apache.phoenix.filter.BooleanExpressionFilter;
+import org.apache.phoenix.filter.ColumnProjectionFilter;
 import org.apache.phoenix.filter.DistinctPrefixFilter;
+import org.apache.phoenix.filter.EncodedQualifiersColumnProjectionFilter;
 import org.apache.phoenix.filter.MultiEncodedCQKeyValueComparisonFilter;
 import org.apache.phoenix.filter.SkipScanFilter;
 import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
 import org.apache.phoenix.hbase.index.util.VersionUtil;
+import org.apache.phoenix.index.IndexMaintainer;
+import org.apache.phoenix.index.PhoenixIndexCodec;
+import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.query.KeyRange.Bound;
 import org.apache.phoenix.query.QueryConstants;
@@ -70,8 +82,10 @@ import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PName;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTable.IndexType;
+import org.apache.phoenix.schema.PTableType;
 import org.apache.phoenix.schema.RowKeySchema;
 import org.apache.phoenix.schema.SortOrder;
+import org.apache.phoenix.schema.TableNotFoundException;
 import org.apache.phoenix.schema.ValueSchema.Field;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.schema.types.PVarbinary;
@@ -87,6 +101,8 @@ import com.google.common.collect.Lists;
  * @since 0.1
  */
 public class ScanUtil {
+    private static final Log LOG = LogFactory.getLog(IndexUtil.class);
+
     public static final int[] SINGLE_COLUMN_SLOT_SPAN = new int[1];
     public static final int UNKNOWN_CLIENT_VERSION = VersionUtil.encodeVersion(4, 4, 0);
 
@@ -95,9 +111,11 @@ public class ScanUtil {
      * into a exclusive key.
      */
     private static final byte[] MAX_FILL_LENGTH_FOR_PREVIOUS_KEY = new byte[16];
+
     static {
-        Arrays.fill(MAX_FILL_LENGTH_FOR_PREVIOUS_KEY, (byte)-1);
+        Arrays.fill(MAX_FILL_LENGTH_FOR_PREVIOUS_KEY, (byte) -1);
     }
+
     private static final byte[] ZERO_BYTE_ARRAY = new byte[1024];
 
     private ScanUtil() {
@@ -115,6 +133,27 @@ public class ScanUtil {
         return scan.getAttribute(BaseScannerRegionObserver.LOCAL_INDEX) != null;
     }
 
+    public static long getViewTTL(Scan scan) {
+        byte[] viewTTL = scan.getAttribute(BaseScannerRegionObserver.VIEW_TTL);
+        if (viewTTL == null) {
+            return 0L;
+        }
+        return Bytes.toLong(viewTTL);
+    }
+
+    public static boolean isMaskTTLExpiredRows(Scan scan) {
+        return scan.getAttribute(BaseScannerRegionObserver.MASK_VIEW_TTL_EXPIRED) != null && (Bytes.compareTo(scan.getAttribute(BaseScannerRegionObserver.MASK_VIEW_TTL_EXPIRED),
+                        PDataType.TRUE_BYTES) == 0)
+                && scan.getAttribute(BaseScannerRegionObserver.VIEW_TTL) != null;
+    }
+
+    public static boolean isDeleteTTLExpiredRows(Scan scan) {
+        return scan.getAttribute(BaseScannerRegionObserver.DELETE_VIEW_TTL_EXPIRED) != null && (
+                Bytes.compareTo(scan.getAttribute(BaseScannerRegionObserver.DELETE_VIEW_TTL_EXPIRED),
+                        PDataType.TRUE_BYTES) == 0)
+                && scan.getAttribute(BaseScannerRegionObserver.VIEW_TTL) != null;
+    }
+
     public static boolean isNonAggregateScan(Scan scan) {
         return scan.getAttribute(BaseScannerRegionObserver.NON_AGGREGATE_QUERY) != null;
     }
@@ -122,9 +161,9 @@ public class ScanUtil {
     // Designates a "simple scan", i.e. a scan that does not need to be scoped
     // to a single region.
     public static boolean isSimpleScan(Scan scan) {
-        return  ScanUtil.isNonAggregateScan(scan) &&
-                scan.getAttribute(BaseScannerRegionObserver.TOPN) == null &&
-                scan.getAttribute(BaseScannerRegionObserver.SCAN_OFFSET) == null;
+        return ScanUtil.isNonAggregateScan(scan)
+                && scan.getAttribute(BaseScannerRegionObserver.TOPN) == null
+                && scan.getAttribute(BaseScannerRegionObserver.SCAN_OFFSET) == null;
     }
 
     // Use getTenantId and pass in column name to match against
@@ -138,13 +177,13 @@ public class ScanUtil {
         }
         return new ImmutableBytesPtr(tenantId);
     }
-    
+
     public static void setCustomAnnotations(Scan scan, byte[] annotations) {
-    	scan.setAttribute(CUSTOM_ANNOTATIONS, annotations);
+        scan.setAttribute(CUSTOM_ANNOTATIONS, annotations);
     }
-    
+
     public static byte[] getCustomAnnotations(Scan scan) {
-    	return scan.getAttribute(CUSTOM_ANNOTATIONS);
+        return scan.getAttribute(CUSTOM_ANNOTATIONS);
     }
 
     public static Scan newScan(Scan scan) {
@@ -153,8 +192,10 @@ public class ScanUtil {
             // Clone the underlying family map instead of sharing it between
             // the existing and cloned Scan (which is the retarded default
             // behavior).
-            TreeMap<byte [], NavigableSet<byte []>> existingMap = (TreeMap<byte[], NavigableSet<byte[]>>)scan.getFamilyMap();
-            Map<byte [], NavigableSet<byte []>> clonedMap = new TreeMap<byte [], NavigableSet<byte []>>(existingMap);
+            TreeMap<byte[], NavigableSet<byte[]>>
+                    existingMap =
+                    (TreeMap<byte[], NavigableSet<byte[]>>) scan.getFamilyMap();
+            Map<byte[], NavigableSet<byte[]>> clonedMap = new TreeMap<byte[], NavigableSet<byte[]>>(existingMap);
             newScan.setFamilyMap(clonedMap);
             // Carry over the reversed attribute
             newScan.setReversed(scan.isReversed());
@@ -164,8 +205,10 @@ public class ScanUtil {
             throw new RuntimeException(e);
         }
     }
+
     /**
      * Intersects the scan start/stop row with the startKey and stopKey
+     *
      * @param scan
      * @param startKey
      * @param stopKey
@@ -202,7 +245,7 @@ public class ScanUtil {
         if (offset > 0 && useSkipScan) {
             byte[] temp = null;
             if (startKey.length != 0) {
-                temp =new byte[startKey.length - offset];
+                temp = new byte[startKey.length - offset];
                 System.arraycopy(startKey, offset, temp, 0, startKey.length - offset);
                 startKey = temp;
             }
@@ -213,12 +256,12 @@ public class ScanUtil {
             }
         }
         mayHaveRows = mayHaveRows || Bytes.compareTo(scan.getStartRow(), scan.getStopRow()) < 0;
-        
+
         // If the scan is using skip scan filter, intersect and replace the filter.
         if (mayHaveRows && useSkipScan) {
             Filter filter = scan.getFilter();
             if (filter instanceof SkipScanFilter) {
-                SkipScanFilter oldFilter = (SkipScanFilter)filter;
+                SkipScanFilter oldFilter = (SkipScanFilter) filter;
                 SkipScanFilter newFilter = oldFilter.intersect(startKey, stopKey);
                 if (newFilter == null) {
                     return false;
@@ -226,11 +269,11 @@ public class ScanUtil {
                 // Intersect found: replace skip scan with intersected one
                 scan.setFilter(newFilter);
             } else if (filter instanceof FilterList) {
-                FilterList oldList = (FilterList)filter;
+                FilterList oldList = (FilterList) filter;
                 FilterList newList = new FilterList(FilterList.Operator.MUST_PASS_ALL);
                 for (Filter f : oldList.getFilters()) {
                     if (f instanceof SkipScanFilter) {
-                        SkipScanFilter newFilter = ((SkipScanFilter)f).intersect(startKey, stopKey);
+                        SkipScanFilter newFilter = ((SkipScanFilter) f).intersect(startKey, stopKey);
                         if (newFilter == null) {
                             return false;
                         }
@@ -240,7 +283,7 @@ public class ScanUtil {
                     }
                 }
                 scan.setFilter(newList);
-           }
+            }
         }
         return mayHaveRows;
     }
@@ -251,15 +294,16 @@ public class ScanUtil {
         }
         Filter filter = scan.getFilter();
         if (filter == null) {
-            scan.setFilter(andWithFilter); 
-        } else if (filter instanceof FilterList && ((FilterList)filter).getOperator() == FilterList.Operator.MUST_PASS_ALL) {
-            FilterList filterList = (FilterList)filter;
+            scan.setFilter(andWithFilter);
+        } else if (filter instanceof FilterList && ((FilterList) filter).getOperator() == FilterList.Operator.MUST_PASS_ALL) {
+            FilterList filterList = (FilterList) filter;
             List<Filter> allFilters = new ArrayList<Filter>(filterList.getFilters().size() + 1);
             allFilters.add(andWithFilter);
             allFilters.addAll(filterList.getFilters());
-            scan.setFilter(new FilterList(FilterList.Operator.MUST_PASS_ALL,allFilters));
+            scan.setFilter(new FilterList(FilterList.Operator.MUST_PASS_ALL, allFilters));
         } else {
-            scan.setFilter(new FilterList(FilterList.Operator.MUST_PASS_ALL,Arrays.asList(andWithFilter, filter)));
+            scan.setFilter(new FilterList(FilterList.Operator.MUST_PASS_ALL,
+                    Arrays.asList(andWithFilter, filter)));
         }
     }
 
@@ -269,29 +313,30 @@ public class ScanUtil {
         }
         Filter filter = scan.getFilter();
         if (filter == null) {
-            scan.setFilter(andWithFilter); 
-        } else if (filter instanceof FilterList && ((FilterList)filter).getOperator() == FilterList.Operator.MUST_PASS_ALL) {
-            FilterList filterList = (FilterList)filter;
+            scan.setFilter(andWithFilter);
+        } else if (filter instanceof FilterList && ((FilterList) filter).getOperator() == FilterList.Operator.MUST_PASS_ALL) {
+            FilterList filterList = (FilterList) filter;
             List<Filter> allFilters = new ArrayList<Filter>(filterList.getFilters().size() + 1);
             allFilters.addAll(filterList.getFilters());
             allFilters.add(andWithFilter);
-            scan.setFilter(new FilterList(FilterList.Operator.MUST_PASS_ALL,allFilters));
+            scan.setFilter(new FilterList(FilterList.Operator.MUST_PASS_ALL, allFilters));
         } else {
-            scan.setFilter(new FilterList(FilterList.Operator.MUST_PASS_ALL,Arrays.asList(filter, andWithFilter)));
+            scan.setFilter(new FilterList(FilterList.Operator.MUST_PASS_ALL,
+                    Arrays.asList(filter, andWithFilter)));
         }
     }
-    
+
     public static void setQualifierRangesOnFilter(Scan scan, Pair<Integer, Integer> minMaxQualifiers) {
         Filter filter = scan.getFilter();
         if (filter != null) {
             if (filter instanceof FilterList) {
-                for (Filter f : ((FilterList)filter).getFilters()) {
+                for (Filter f : ((FilterList) filter).getFilters()) {
                     if (f instanceof MultiEncodedCQKeyValueComparisonFilter) {
-                        ((MultiEncodedCQKeyValueComparisonFilter)f).setMinMaxQualifierRange(minMaxQualifiers);
+                        ((MultiEncodedCQKeyValueComparisonFilter) f).setMinMaxQualifierRange(minMaxQualifiers);
                     }
                 }
             } else if (filter instanceof MultiEncodedCQKeyValueComparisonFilter) {
-                ((MultiEncodedCQKeyValueComparisonFilter)filter).setMinMaxQualifierRange(minMaxQualifiers);
+                ((MultiEncodedCQKeyValueComparisonFilter) filter).setMinMaxQualifierRange(minMaxQualifiers);
             }
         }
     }
@@ -311,14 +356,14 @@ public class ScanUtil {
             throw new RuntimeException(e);
         }
     }
-    
-	public static void setTimeRange(Scan scan, long minStamp, long maxStamp) {
-		try {
-			scan.setTimeRange(minStamp, maxStamp);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+
+    public static void setTimeRange(Scan scan, long minStamp, long maxStamp) {
+        try {
+            scan.setTimeRange(minStamp, maxStamp);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public static byte[] getMinKey(RowKeySchema schema, List<List<KeyRange>> slots, int[] slotSpan) {
         return getKey(schema, slots, slotSpan, Bound.LOWER);
@@ -328,14 +373,15 @@ public class ScanUtil {
         return getKey(schema, slots, slotSpan, Bound.UPPER);
     }
 
-    private static byte[] getKey(RowKeySchema schema, List<List<KeyRange>> slots, int[] slotSpan, Bound bound) {
+    private static byte[] getKey(RowKeySchema schema, List<List<KeyRange>> slots, int[] slotSpan,
+            Bound bound) {
         if (slots.isEmpty()) {
             return KeyRange.UNBOUND;
         }
         int[] position = new int[slots.size()];
         int maxLength = 0;
         for (int i = 0; i < position.length; i++) {
-            position[i] = bound == Bound.LOWER ? 0 : slots.get(i).size()-1;
+            position[i] = bound == Bound.LOWER ? 0 : slots.get(i).size() - 1;
             KeyRange range = slots.get(i).get(position[i]);
             Field field = schema.getField(i + slotSpan[i]);
             int keyLength = range.getRange(bound).length;
@@ -362,7 +408,7 @@ public class ScanUtil {
 
     /*
      * Set the key by appending the keyRanges inside slots at positions as specified by the position array.
-     * 
+     *
      * We need to increment part of the key range, or increment the whole key at the end, depending on the
      * bound we are setting and whether the key range is inclusive or exclusive. The logic for determining
      * whether to increment or not is:
@@ -376,7 +422,8 @@ public class ScanUtil {
      */
     public static int setKey(RowKeySchema schema, List<List<KeyRange>> slots, int[] slotSpan, int[] position,
             Bound bound, byte[] key, int byteOffset, int slotStartIndex, int slotEndIndex) {
-        return setKey(schema, slots, slotSpan, position, bound, key, byteOffset, slotStartIndex, slotEndIndex, slotStartIndex);
+        return setKey(schema, slots, slotSpan, position, bound, key, byteOffset, slotStartIndex,
+                slotEndIndex, slotStartIndex);
     }
 
     public static int setKey(RowKeySchema schema, List<List<KeyRange>> slots, int[] slotSpan, int[] position,
@@ -410,15 +457,15 @@ public class ScanUtil {
              *    information to the key after that.
              */
             lastUnboundUpper = false;
-            if (  range.isUnbound(bound) &&
-                ( bound == Bound.UPPER || isFixedWidth || range == KeyRange.EVERYTHING_RANGE) ){
+            if (range.isUnbound(bound) && (bound == Bound.UPPER || isFixedWidth
+                    || range == KeyRange.EVERYTHING_RANGE)) {
                 lastUnboundUpper = (bound == Bound.UPPER);
                 break;
             }
             byte[] bytes = range.getRange(bound);
             System.arraycopy(bytes, 0, key, offset, bytes.length);
             offset += bytes.length;
-            
+
             /*
              * We must add a terminator to a variable length key even for the last PK column if
              * the lower key is non inclusive or the upper key is inclusive. Otherwise, we'd be
@@ -440,11 +487,13 @@ public class ScanUtil {
             lastInclusiveUpperSingleKey = range.isSingleKey() && inclusiveUpper;
             anyInclusiveUpperRangeKey |= !range.isSingleKey() && inclusiveUpper;
             // A null or empty byte array is always represented as a zero byte
-            byte sepByte = SchemaUtil.getSeparatorByte(schema.rowKeyOrderOptimizable(), bytes.length == 0, field);
-            
-            if ( !isFixedWidth && ( sepByte == QueryConstants.DESC_SEPARATOR_BYTE 
-                                    || ( !exclusiveUpper 
-                                         && (fieldIndex < schema.getMaxFields() || inclusiveUpper || exclusiveLower) ) ) ) {
+            byte
+                    sepByte =
+                    SchemaUtil.getSeparatorByte(schema.rowKeyOrderOptimizable(), bytes.length == 0,
+                            field);
+
+            if (!isFixedWidth && (sepByte == QueryConstants.DESC_SEPARATOR_BYTE || (!exclusiveUpper
+                    && (fieldIndex < schema.getMaxFields() || inclusiveUpper || exclusiveLower)))) {
                 key[offset++] = sepByte;
                 // Set lastInclusiveUpperSingleKey back to false if this is the last pk column
                 // as we don't want to increment the QueryConstants.SEPARATOR_BYTE byte in this case.
@@ -453,8 +502,9 @@ public class ScanUtil {
                 // But if last field of rowKey is variable length and also DESC, the trailing 0xFF
                 // is not removed when stored in HBASE, so for such case, we should not set
                 // lastInclusiveUpperSingleKey back to false.
-                if(sepByte != QueryConstants.DESC_SEPARATOR_BYTE) {
-                    lastInclusiveUpperSingleKey &= (fieldIndex + slotSpan[i]) < schema.getMaxFields()-1;
+                if (sepByte != QueryConstants.DESC_SEPARATOR_BYTE) {
+                    lastInclusiveUpperSingleKey &=
+                            (fieldIndex + slotSpan[i]) < schema.getMaxFields() - 1;
                 }
             }
             if (exclusiveUpper) {
@@ -479,12 +529,13 @@ public class ScanUtil {
                 // terminator, since DESC keys ignore the last byte as it's expected to be 
                 // the terminator. Without this, we'd ignore the separator byte that was
                 // just added and incremented.
-                if (!isFixedWidth && bytes.length == 0 
-                    && SchemaUtil.getSeparatorByte(schema.rowKeyOrderOptimizable(), false, field) == QueryConstants.DESC_SEPARATOR_BYTE) {
+                if (!isFixedWidth && bytes.length == 0
+                        && SchemaUtil.getSeparatorByte(schema.rowKeyOrderOptimizable(), false, field)
+                        == QueryConstants.DESC_SEPARATOR_BYTE) {
                     key[offset++] = QueryConstants.DESC_SEPARATOR_BYTE;
                 }
             }
-            
+
             fieldIndex += slotSpan[i] + 1;
         }
         if (lastInclusiveUpperSingleKey || anyInclusiveUpperRangeKey || lastUnboundUpper) {
@@ -501,54 +552,61 @@ public class ScanUtil {
         // after the table has data, in which case there won't be a separator
         // byte.
         if (bound == Bound.LOWER) {
-            while (--i >= schemaStartIndex && offset > byteOffset && 
-                    !(field=schema.getField(--fieldIndex)).getDataType().isFixedWidth() && 
-                    field.getSortOrder() == SortOrder.ASC &&
-                    key[offset-1] == QueryConstants.SEPARATOR_BYTE) {
+            while (--i >= schemaStartIndex && offset > byteOffset && !(field = schema.getField(--fieldIndex)).getDataType().isFixedWidth()
+                    && field.getSortOrder() == SortOrder.ASC && key[offset - 1] == QueryConstants.SEPARATOR_BYTE) {
                 offset--;
                 fieldIndex -= slotSpan[i];
             }
         }
         return offset - byteOffset;
     }
-    
+
     public static interface BytesComparator {
         public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2);
-    };
+    }
+
+    ;
 
     private static final BytesComparator DESC_VAR_WIDTH_COMPARATOR = new BytesComparator() {
 
-        @Override
-        public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+        @Override public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
             return DescVarLengthFastByteComparisons.compareTo(b1, s1, l1, b2, s2, l2);
         }
-        
+
     };
-    
+
     private static final BytesComparator ASC_FIXED_WIDTH_COMPARATOR = new BytesComparator() {
 
-        @Override
-        public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+        @Override public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
             return WritableComparator.compareBytes(b1, s1, l1, b2, s2, l2);
         }
-        
+
     };
+
     public static BytesComparator getComparator(boolean isFixedWidth, SortOrder sortOrder) {
-        return isFixedWidth || sortOrder == SortOrder.ASC ? ASC_FIXED_WIDTH_COMPARATOR : DESC_VAR_WIDTH_COMPARATOR;
+        return isFixedWidth || sortOrder == SortOrder.ASC ?
+                ASC_FIXED_WIDTH_COMPARATOR :
+                DESC_VAR_WIDTH_COMPARATOR;
     }
+
     public static BytesComparator getComparator(Field field) {
-        return getComparator(field.getDataType().isFixedWidth(),field.getSortOrder());
+        return getComparator(field.getDataType().isFixedWidth(), field.getSortOrder());
     }
+
     /**
      * Perform a binary lookup on the list of KeyRange for the tightest slot such that the slotBound
-     * of the current slot is higher or equal than the slotBound of our range. 
-     * @return  the index of the slot whose slot bound equals or are the tightest one that is 
-     *          smaller than rangeBound of range, or slots.length if no bound can be found.
+     * of the current slot is higher or equal than the slotBound of our range.
+     *
+     * @return the index of the slot whose slot bound equals or are the tightest one that is
+     * smaller than rangeBound of range, or slots.length if no bound can be found.
      */
-    public static int searchClosestKeyRangeWithUpperHigherThanPtr(List<KeyRange> slots, ImmutableBytesWritable ptr, int lower, Field field) {
+    public static int searchClosestKeyRangeWithUpperHigherThanPtr(List<KeyRange> slots,
+            ImmutableBytesWritable ptr, int lower, Field field) {
         int upper = slots.size() - 1;
         int mid;
-        BytesComparator comparator = ScanUtil.getComparator(field.getDataType().isFixedWidth(), field.getSortOrder());
+        BytesComparator
+                comparator =
+                ScanUtil.getComparator(field.getDataType().isFixedWidth(), field.getSortOrder());
         while (lower <= upper) {
             mid = (lower + upper) / 2;
             int cmp = slots.get(mid).compareUpperToLowerBound(ptr, true, comparator);
@@ -567,7 +625,7 @@ public class ScanUtil {
             return ++mid;
         }
     }
-    
+
     public static ScanRanges newScanRanges(List<? extends Mutation> mutations) throws SQLException {
         List<KeyRange> keys = Lists.newArrayListWithExpectedSize(mutations.size());
         for (Mutation m : mutations) {
@@ -582,7 +640,7 @@ public class ScanUtil {
      * inclusive lower bound and an exclusive upper bound, widening
      * as necessary.
      */
-    public static KeyRange convertToInclusiveExclusiveRange (KeyRange partialRange, RowKeySchema schema, ImmutableBytesWritable ptr) {
+    public static KeyRange convertToInclusiveExclusiveRange(KeyRange partialRange, RowKeySchema schema, ImmutableBytesWritable ptr) {
         // Ensure minMaxRange is lower inclusive and upper exclusive, as that's
         // what we need to intersect against for the HBase scan.
         byte[] lowerRange = partialRange.getLowerRange();
@@ -591,7 +649,7 @@ public class ScanUtil {
                 lowerRange = ScanUtil.nextKey(lowerRange, schema, ptr);
             }
         }
-        
+
         byte[] upperRange = partialRange.getUpperRange();
         if (!partialRange.upperUnbound()) {
             if (partialRange.isUpperInclusive()) {
@@ -603,7 +661,7 @@ public class ScanUtil {
         }
         return partialRange;
     }
-    
+
     private static byte[] nextKey(byte[] key, RowKeySchema schema, ImmutableBytesWritable ptr) {
         int pos = 0;
         int maxOffset = schema.iterator(key, ptr);
@@ -614,7 +672,9 @@ public class ScanUtil {
         if (!field.getDataType().isFixedWidth()) {
             byte[] newLowerRange = new byte[key.length + 1];
             System.arraycopy(key, 0, newLowerRange, 0, key.length);
-            newLowerRange[key.length] = SchemaUtil.getSeparatorByte(schema.rowKeyOrderOptimizable(), key.length==0, field);
+            newLowerRange[key.length] =
+                    SchemaUtil.getSeparatorByte(schema.rowKeyOrderOptimizable(), key.length == 0,
+                            field);
             key = newLowerRange;
         } else {
             key = Arrays.copyOf(key, key.length);
@@ -626,7 +686,7 @@ public class ScanUtil {
     public static boolean isReversed(Scan scan) {
         return scan.getAttribute(BaseScannerRegionObserver.REVERSE_SCAN) != null;
     }
-    
+
     public static void setReversed(Scan scan) {
         scan.setAttribute(BaseScannerRegionObserver.REVERSE_SCAN, PDataType.TRUE_BYTES);
         scan.setLoadColumnFamiliesOnDemand(false);
@@ -673,67 +733,77 @@ public class ScanUtil {
     /**
      * Start key and stop key of the original scan from client are regions start and end keys so
      * prefix scan start/stop key to the start row/stop row suffix and set them as scan boundaries.
+     *
      * @param scan
      */
     public static void setupLocalIndexScan(Scan scan) {
-        byte[] prefix = scan.getStartRow().length == 0 ? new byte[scan.getStopRow().length]: scan.getStartRow();
-        int prefixLength = scan.getStartRow().length == 0? scan.getStopRow().length: scan.getStartRow().length;
-        if(scan.getAttribute(SCAN_START_ROW_SUFFIX)!=null) {
-            scan.setStartRow(ScanRanges.prefixKey(scan.getAttribute(SCAN_START_ROW_SUFFIX), 0, prefix, prefixLength));
+        byte[] prefix = scan.getStartRow().length == 0 ? new byte[scan.getStopRow().length] : scan.getStartRow();
+        int prefixLength = scan.getStartRow().length == 0 ? scan.getStopRow().length : scan.getStartRow().length;
+        if (scan.getAttribute(SCAN_START_ROW_SUFFIX) != null) {
+            scan.setStartRow(ScanRanges
+                    .prefixKey(scan.getAttribute(SCAN_START_ROW_SUFFIX), 0, prefix, prefixLength));
         }
-        if(scan.getAttribute(SCAN_STOP_ROW_SUFFIX)!=null) {
-            scan.setStopRow(ScanRanges.prefixKey(scan.getAttribute(SCAN_STOP_ROW_SUFFIX), 0, prefix, prefixLength));
+        if (scan.getAttribute(SCAN_STOP_ROW_SUFFIX) != null) {
+            scan.setStopRow(ScanRanges
+                    .prefixKey(scan.getAttribute(SCAN_STOP_ROW_SUFFIX), 0, prefix, prefixLength));
         }
     }
 
     public static byte[] getActualStartRow(Scan localIndexScan, HRegionInfo regionInfo) {
-        return localIndexScan.getAttribute(SCAN_START_ROW_SUFFIX) == null ? localIndexScan
-                .getStartRow() : ScanRanges.prefixKey(localIndexScan.getAttribute(SCAN_START_ROW_SUFFIX), 0 ,
-            regionInfo.getStartKey().length == 0 ? new byte[regionInfo.getEndKey().length]
-                    : regionInfo.getStartKey(),
-            regionInfo.getStartKey().length == 0 ? regionInfo.getEndKey().length : regionInfo
-                    .getStartKey().length);
+        return localIndexScan.getAttribute(SCAN_START_ROW_SUFFIX) == null ?
+                localIndexScan.getStartRow() :
+                ScanRanges.prefixKey(localIndexScan.getAttribute(SCAN_START_ROW_SUFFIX), 0,
+                        regionInfo.getStartKey().length == 0 ?
+                                new byte[regionInfo.getEndKey().length] :
+                                regionInfo.getStartKey(), regionInfo.getStartKey().length == 0 ?
+                                regionInfo.getEndKey().length :
+                                regionInfo.getStartKey().length);
     }
 
     /**
      * Set all attributes required and boundaries for local index scan.
+     *
      * @param keyOffset
      * @param regionStartKey
      * @param regionEndKey
      * @param newScan
      */
-    public static void setLocalIndexAttributes(Scan newScan, int keyOffset, byte[] regionStartKey, byte[] regionEndKey, byte[] startRowSuffix, byte[] stopRowSuffix) {
-        if(ScanUtil.isLocalIndex(newScan)) {
-             newScan.setAttribute(SCAN_ACTUAL_START_ROW, regionStartKey);
-             newScan.setStartRow(regionStartKey);
-             newScan.setStopRow(regionEndKey);
-             if (keyOffset > 0 ) {
-                 newScan.setAttribute(SCAN_START_ROW_SUFFIX, ScanRanges.stripPrefix(startRowSuffix, keyOffset));
-             } else {
-                 newScan.setAttribute(SCAN_START_ROW_SUFFIX, startRowSuffix);
-             }
-             if (keyOffset > 0) {
-                 newScan.setAttribute(SCAN_STOP_ROW_SUFFIX, ScanRanges.stripPrefix(stopRowSuffix, keyOffset));
-             } else {
-                 newScan.setAttribute(SCAN_STOP_ROW_SUFFIX, stopRowSuffix);
-             }
-         }
+    public static void setLocalIndexAttributes(Scan newScan, int keyOffset, byte[] regionStartKey,
+            byte[] regionEndKey, byte[] startRowSuffix, byte[] stopRowSuffix) {
+        if (ScanUtil.isLocalIndex(newScan)) {
+            newScan.setAttribute(SCAN_ACTUAL_START_ROW, regionStartKey);
+            newScan.setStartRow(regionStartKey);
+            newScan.setStopRow(regionEndKey);
+            if (keyOffset > 0) {
+                newScan.setAttribute(SCAN_START_ROW_SUFFIX,
+                        ScanRanges.stripPrefix(startRowSuffix, keyOffset));
+            } else {
+                newScan.setAttribute(SCAN_START_ROW_SUFFIX, startRowSuffix);
+            }
+            if (keyOffset > 0) {
+                newScan.setAttribute(SCAN_STOP_ROW_SUFFIX,
+                        ScanRanges.stripPrefix(stopRowSuffix, keyOffset));
+            } else {
+                newScan.setAttribute(SCAN_STOP_ROW_SUFFIX, stopRowSuffix);
+            }
+        }
     }
 
     public static boolean isContextScan(Scan scan, StatementContext context) {
-        return Bytes.compareTo(context.getScan().getStartRow(), scan.getStartRow()) == 0 && Bytes
-                .compareTo(context.getScan().getStopRow(), scan.getStopRow()) == 0;
+        return Bytes.compareTo(context.getScan().getStartRow(), scan.getStartRow()) == 0
+                && Bytes.compareTo(context.getScan().getStopRow(), scan.getStopRow()) == 0;
     }
+
     public static int getRowKeyOffset(byte[] regionStartKey, byte[] regionEndKey) {
         return regionStartKey.length > 0 ? regionStartKey.length : regionEndKey.length;
     }
-    
+
     private static void setRowKeyOffset(Filter filter, int offset) {
         if (filter instanceof BooleanExpressionFilter) {
-            BooleanExpressionFilter boolFilter = (BooleanExpressionFilter)filter;
+            BooleanExpressionFilter boolFilter = (BooleanExpressionFilter) filter;
             IndexUtil.setRowKeyExpressionOffset(boolFilter.getExpression(), offset);
         } else if (filter instanceof SkipScanFilter) {
-            SkipScanFilter skipScanFilter = (SkipScanFilter)filter;
+            SkipScanFilter skipScanFilter = (SkipScanFilter) filter;
             skipScanFilter.setOffset(offset);
         } else if (filter instanceof DistinctPrefixFilter) {
             DistinctPrefixFilter prefixFilter = (DistinctPrefixFilter) filter;
@@ -747,7 +817,7 @@ public class ScanUtil {
             return;
         }
         if (filter instanceof FilterList) {
-            FilterList filterList = (FilterList)filter;
+            FilterList filterList = (FilterList) filter;
             for (Filter childFilter : filterList.getFilters()) {
                 setRowKeyOffset(childFilter, offset);
             }
@@ -766,14 +836,15 @@ public class ScanUtil {
      * that the slot at index 2 has a slot index of 2 but a row key index of 3.
      * To calculate the "adjusted position" index, we simply add up the number of extra slots spanned and offset
      * the slotPosition by that much.
-     * @param slotSpan  the extra span per skip scan slot. corresponds to {@link ScanRanges#slotSpan}
-     * @param slotPosition  the index of a slot in the SkipScan slots list.
-     * @return  the equivalent row key position in the RowKeySchema
+     *
+     * @param slotSpan     the extra span per skip scan slot. corresponds to {@link ScanRanges#slotSpan}
+     * @param slotPosition the index of a slot in the SkipScan slots list.
+     * @return the equivalent row key position in the RowKeySchema
      */
     public static int getRowKeyPosition(int[] slotSpan, int slotPosition) {
         int offset = 0;
 
-        for(int i = 0; i < slotPosition; i++) {
+        for (int i = 0; i < slotPosition; i++) {
             offset += slotSpan[i];
         }
 
@@ -802,7 +873,8 @@ public class ScanUtil {
     private static boolean hasNonZeroLeadingBytes(byte[] key, int nBytesToCheck) {
         if (nBytesToCheck > ZERO_BYTE_ARRAY.length) {
             do {
-                if (Bytes.compareTo(key, nBytesToCheck - ZERO_BYTE_ARRAY.length, ZERO_BYTE_ARRAY.length, ScanUtil.ZERO_BYTE_ARRAY, 0, ScanUtil.ZERO_BYTE_ARRAY.length) != 0) {
+                if (Bytes.compareTo(key, nBytesToCheck - ZERO_BYTE_ARRAY.length, ZERO_BYTE_ARRAY.length, ScanUtil.ZERO_BYTE_ARRAY, 0,
+                        ScanUtil.ZERO_BYTE_ARRAY.length) != 0) {
                     return true;
                 }
                 nBytesToCheck -= ZERO_BYTE_ARRAY.length;
@@ -811,16 +883,16 @@ public class ScanUtil {
         return Bytes.compareTo(key, 0, nBytesToCheck, ZERO_BYTE_ARRAY, 0, nBytesToCheck) != 0;
     }
 
-    public static byte[] getTenantIdBytes(RowKeySchema schema, boolean isSalted, PName tenantId, boolean isMultiTenantTable, boolean isSharedIndex)
-            throws SQLException {
+    public static byte[] getTenantIdBytes(RowKeySchema schema, boolean isSalted, PName tenantId,
+            boolean isMultiTenantTable, boolean isSharedIndex) throws SQLException {
         return isMultiTenantTable ?
-                  getTenantIdBytes(schema, isSalted, tenantId, isSharedIndex)
-                : tenantId.getBytes();
+                getTenantIdBytes(schema, isSalted, tenantId, isSharedIndex) :
+                tenantId.getBytes();
     }
 
-    public static byte[] getTenantIdBytes(RowKeySchema schema, boolean isSalted, PName tenantId, boolean isSharedIndex)
-            throws SQLException {
-        int pkPos = (isSalted ? 1 : 0) + (isSharedIndex ? 1 : 0); 
+    public static byte[] getTenantIdBytes(RowKeySchema schema, boolean isSalted, PName tenantId,
+            boolean isSharedIndex) throws SQLException {
+        int pkPos = (isSalted ? 1 : 0) + (isSharedIndex ? 1 : 0);
         Field field = schema.getField(pkPos);
         PDataType dataType = field.getDataType();
         byte[] convertedValue;
@@ -830,9 +902,8 @@ public class ScanUtil {
             ImmutableBytesWritable ptr = new ImmutableBytesWritable(convertedValue);
             dataType.pad(ptr, field.getMaxLength(), field.getSortOrder());
             convertedValue = ByteUtil.copyKeyBytesIfNecessary(ptr);
-        } catch(IllegalDataException ex) {
-            throw new SQLExceptionInfo.Builder(SQLExceptionCode.TENANTID_IS_OF_WRONG_TYPE)
-                    .build().buildException();
+        } catch (IllegalDataException ex) {
+            throw new SQLExceptionInfo.Builder(SQLExceptionCode.TENANTID_IS_OF_WRONG_TYPE).build().buildException();
         }
         return convertedValue;
     }
@@ -849,7 +920,7 @@ public class ScanUtil {
         }
         return filterIterator;
     }
-    
+
     /**
      * Selecting underlying scanners in a round-robin fashion is possible if there is no ordering of
      * rows needed, not even row key order. Also no point doing round robin of scanners if fetch
@@ -858,19 +929,18 @@ public class ScanUtil {
     public static boolean isRoundRobinPossible(OrderBy orderBy, StatementContext context)
             throws SQLException {
         int fetchSize = context.getStatement().getFetchSize();
-        return fetchSize > 1 && !shouldRowsBeInRowKeyOrder(orderBy, context)
-                && orderBy.getOrderByExpressions().isEmpty();
+        return fetchSize > 1 && !shouldRowsBeInRowKeyOrder(orderBy, context) && orderBy.getOrderByExpressions().isEmpty();
     }
-    
+
     public static boolean forceRowKeyOrder(StatementContext context) {
         return context.getConnection().getQueryServices().getProps()
                 .getBoolean(QueryServices.FORCE_ROW_KEY_ORDER_ATTRIB, QueryServicesOptions.DEFAULT_FORCE_ROW_KEY_ORDER);
     }
-    
+
     public static boolean shouldRowsBeInRowKeyOrder(OrderBy orderBy, StatementContext context) {
         return forceRowKeyOrder(context) || orderBy == FWD_ROW_KEY_ORDER_BY || orderBy == REV_ROW_KEY_ORDER_BY;
     }
-    
+
     public static TimeRange intersectTimeRange(TimeRange rowTimestampColRange, TimeRange scanTimeRange, Long scn) throws IOException, SQLException {
         long scnToUse = scn == null ? HConstants.LATEST_TIMESTAMP : scn;
         long lowerRangeToBe = 0;
@@ -899,17 +969,17 @@ public class ScanUtil {
         }
         return new TimeRange(lowerRangeToBe, upperRangeToBe);
     }
-    
+
     public static boolean isDefaultTimeRange(TimeRange range) {
         return range.getMin() == 0 && range.getMax() == Long.MAX_VALUE;
     }
-    
+
     /**
      * @return true if scanners could be left open and records retrieved by simply advancing them on
-     *         the server side. To make sure HBase doesn't cancel the leases and close the open
-     *         scanners, we need to periodically renew leases. To look at the earliest HBase version
-     *         that supports renewing leases, see
-     *         {@link MetaDataProtocol#MIN_RENEW_LEASE_VERSION}
+     * the server side. To make sure HBase doesn't cancel the leases and close the open
+     * scanners, we need to periodically renew leases. To look at the earliest HBase version
+     * that supports renewing leases, see
+     * {@link MetaDataProtocol#MIN_RENEW_LEASE_VERSION}
      */
     public static boolean isPacingScannersPossible(StatementContext context) {
         return context.getConnection().getQueryServices().isRenewingLeasesEnabled();
@@ -918,8 +988,9 @@ public class ScanUtil {
     public static void addOffsetAttribute(Scan scan, Integer offset) {
         scan.setAttribute(BaseScannerRegionObserver.SCAN_OFFSET, Bytes.toBytes(offset));
     }
-    
-    public static final boolean canQueryBeExecutedSerially(PTable table, OrderBy orderBy, StatementContext context) {
+
+    public static final boolean canQueryBeExecutedSerially(PTable table, OrderBy orderBy,
+            StatementContext context) {
         /*
          * If ordering by columns not on the PK axis, we can't execute a query serially because we
          * need to do a merge sort across all the scans which isn't possible with SerialIterators.
@@ -927,14 +998,13 @@ public class ScanUtil {
          * key order. Serial execution is OK in other cases since SerialIterators will execute scans
          * in the correct order.
          */
-        if (!orderBy.getOrderByExpressions().isEmpty()
-                || ((table.getBucketNum() != null || table.getIndexType() == IndexType.LOCAL) && shouldRowsBeInRowKeyOrder(
-                    orderBy, context))) {
+        if (!orderBy.getOrderByExpressions().isEmpty() || (
+                (table.getBucketNum() != null || table.getIndexType() == IndexType.LOCAL) && shouldRowsBeInRowKeyOrder(orderBy, context))) {
             return false;
         }
         return true;
     }
-    
+
     public static boolean hasDynamicColumns(PTable table) {
         for (PColumn col : table.getColumns()) {
             if (col.isDynamic()) {
@@ -947,7 +1017,7 @@ public class ScanUtil {
     public static boolean isIndexRebuild(Scan scan) {
         return scan.getAttribute((BaseScannerRegionObserver.REBUILD_INDEXES)) != null;
     }
- 
+
     public static int getClientVersion(Scan scan) {
         int clientVersion = UNKNOWN_CLIENT_VERSION;
         byte[] clientVersionBytes = scan.getAttribute(BaseScannerRegionObserver.CLIENT_VERSION);
@@ -956,8 +1026,130 @@ public class ScanUtil {
         }
         return clientVersion;
     }
-    
+
     public static void setClientVersion(Scan scan, int version) {
         scan.setAttribute(BaseScannerRegionObserver.CLIENT_VERSION, Bytes.toBytes(version));
+    }
+
+    private static void addEmptyColumnToScan(Scan scan, byte[] emptyCF, byte[] emptyCQ) {
+        boolean addedEmptyColumn = false;
+        Iterator<Filter> iterator = ScanUtil.getFilterIterator(scan);
+        while (iterator.hasNext()) {
+            Filter filter = iterator.next();
+            if (filter instanceof EncodedQualifiersColumnProjectionFilter) {
+                ((EncodedQualifiersColumnProjectionFilter) filter).addTrackedColumn(ENCODED_EMPTY_COLUMN_NAME);
+                if (!addedEmptyColumn && containsOneOrMoreColumn(scan)) {
+                    scan.addColumn(emptyCF, emptyCQ);
+                }
+            } else if (filter instanceof ColumnProjectionFilter) {
+                ((ColumnProjectionFilter) filter).addTrackedColumn(new ImmutableBytesPtr(emptyCF),
+                        new ImmutableBytesPtr(emptyCQ));
+                if (!addedEmptyColumn && containsOneOrMoreColumn(scan)) {
+                    scan.addColumn(emptyCF, emptyCQ);
+                }
+            } else if (filter instanceof MultiEncodedCQKeyValueComparisonFilter) {
+                ((MultiEncodedCQKeyValueComparisonFilter) filter).setMinQualifier(ENCODED_EMPTY_COLUMN_NAME);
+            } else if (!addedEmptyColumn && filter instanceof FirstKeyOnlyFilter) {
+                scan.addColumn(emptyCF, emptyCQ);
+                addedEmptyColumn = true;
+            }
+        }
+        if (!addedEmptyColumn && containsOneOrMoreColumn(scan)) {
+            scan.addColumn(emptyCF, emptyCQ);
+        }
+    }
+
+    private static boolean containsOneOrMoreColumn(Scan scan) {
+        Map<byte[], NavigableSet<byte[]>> familyMap = scan.getFamilyMap();
+        if (familyMap == null || familyMap.isEmpty()) {
+            return false;
+        }
+        for (Map.Entry<byte[], NavigableSet<byte[]>> entry : familyMap.entrySet()) {
+            NavigableSet<byte[]> family = entry.getValue();
+            if (family != null && !family.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void setScanAttributesForIndexReadRepair(Scan scan, PTable table,
+            PhoenixConnection phoenixConnection) throws SQLException {
+        if (table.isTransactional() || table.getType() != PTableType.INDEX) {
+            return;
+        }
+
+        try {
+            LOG.debug(String.format(
+                    "********** VIEW-TTL: In ScanUtil::setScanAttributesForIndexReadRepair [table = %s] TTL for scan = [%s], VIEW_TTL = %d ***************",
+                    table.getTableName().getString(), scan.toJSON(Integer.MAX_VALUE), ScanUtil.getViewTTL(scan)));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        PTable indexTable = table;
+        if (indexTable.getIndexType() != PTable.IndexType.GLOBAL) {
+            return;
+        }
+        String schemaName = indexTable.getParentSchemaName().getString();
+        String tableName = indexTable.getParentTableName().getString();
+        PTable dataTable;
+        try {
+            dataTable =
+                    PhoenixRuntime.getTable(phoenixConnection,
+                            SchemaUtil.getTableName(schemaName, tableName));
+        } catch (TableNotFoundException e) {
+            // This index table must be being deleted. No need to set the scan attributes
+            return;
+        }
+        // MetaDataClient modifies the index table name for view indexes if the parent view of an index has a child
+        // view. This, we need to recreate a PTable object with the correct table name for the rest of this code to work
+        if (table.getName().getString().contains(QueryConstants.CHILD_VIEW_INDEX_NAME_SEPARATOR)) {
+            int lastIndexOf = table.getName().getString().lastIndexOf(QueryConstants.CHILD_VIEW_INDEX_NAME_SEPARATOR);
+            String indexName = table.getName().getString().substring(lastIndexOf + 1);
+            indexTable = PhoenixRuntime.getTable(phoenixConnection, indexName);
+        }
+
+        if (!dataTable.getIndexes().contains(indexTable)) {
+            return;
+        }
+        if (scan.getAttribute(PhoenixIndexCodec.INDEX_PROTO_MD) == null) {
+            ImmutableBytesWritable ptr = new ImmutableBytesWritable();
+            IndexMaintainer.serialize(dataTable, ptr, Collections.singletonList(indexTable),
+                    phoenixConnection);
+            scan.setAttribute(PhoenixIndexCodec.INDEX_PROTO_MD, ByteUtil.copyKeyBytesIfNecessary(ptr));
+        }
+        scan.setAttribute(BaseScannerRegionObserver.CHECK_VERIFY_COLUMN, TRUE_BYTES);
+        scan.setAttribute(BaseScannerRegionObserver.PHYSICAL_DATA_TABLE_NAME,
+                dataTable.getPhysicalName().getBytes());
+        IndexMaintainer indexMaintainer = indexTable.getIndexMaintainer(dataTable, phoenixConnection);
+        byte[] emptyCF = indexMaintainer.getEmptyKeyValueFamily().copyBytesIfNecessary();
+        byte[] emptyCQ = indexMaintainer.getEmptyKeyValueQualifier();
+        scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_FAMILY_NAME, emptyCF);
+        scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_QUALIFIER_NAME, emptyCQ);
+        if (scan.getAttribute(BaseScannerRegionObserver.VIEW_CONSTANTS) == null) {
+            BaseQueryPlan.serializeViewConstantsIntoScan(scan, dataTable);
+        }
+        addEmptyColumnToScan(scan, emptyCF, emptyCQ);
+    }
+
+    public static void setScanAttributesForViewTTL(Scan scan, PTable table,
+            PhoenixConnection phoenixConnection) throws SQLException {
+
+        if (table.getViewTTL() != 0) {
+            byte[] emptyColumnFamilyName = SchemaUtil.getEmptyColumnFamily(table);
+            byte[]
+                    emptyColumnName =
+                    table.getEncodingScheme() == PTable.QualifierEncodingScheme.NON_ENCODED_QUALIFIERS ?
+                            QueryConstants.EMPTY_COLUMN_BYTES :
+                            table.getEncodingScheme().encode(QueryConstants.ENCODED_EMPTY_COLUMN_NAME);
+
+            scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_FAMILY_NAME, emptyColumnFamilyName);
+            scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_QUALIFIER_NAME, emptyColumnName);
+            scan.setAttribute(BaseScannerRegionObserver.MASK_VIEW_TTL_EXPIRED, PDataType.TRUE_BYTES);
+            scan.setAttribute(BaseScannerRegionObserver.VIEW_TTL, Bytes.toBytes(Long.valueOf(table.getViewTTL())));
+            addEmptyColumnToScan(scan, emptyColumnFamilyName, emptyColumnName);
+        }
+
     }
 }


### PR DESCRIPTION
 * Add a New coprocessor - ViewTTLAware Coprocessor that will intercept scan/get requests to inject a new ViewTTLAware scanner.

The scanner will -
  * Use the row timestamp of the empty column to determine whether row TTL has expired  and mask the rows from underlying query results.
  * Use the row timestamp to delete expired rows when DELETE_VIEW_TTL_EXPIRED flag is present.