### PR TITLE
PHOENIX-5654: String values (ALWAYS and NEVER) don't work for connect…

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -216,6 +216,7 @@ import org.apache.phoenix.parse.PSchema;
 import org.apache.phoenix.protobuf.ProtobufUtil;
 import org.apache.phoenix.schema.ColumnAlreadyExistsException;
 import org.apache.phoenix.schema.ColumnFamilyNotFoundException;
+import org.apache.phoenix.schema.ConnectionProperty;
 import org.apache.phoenix.schema.EmptySequenceCacheException;
 import org.apache.phoenix.schema.FunctionNotFoundException;
 import org.apache.phoenix.schema.MetaDataClient;
@@ -752,16 +753,27 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
         });
     }
 
+    /**
+     * Check that the supplied connection properties are set to valid values.
+     * @param info The properties to be validated.
+     * @throws IllegalArgumentException when a property is not set to a valid value.
+     */
+    private void validateConnectionProperties(Properties info) {
+        if (info.get(QueryServices.DEFAULT_UPDATE_CACHE_FREQUENCY_ATRRIB) != null) {
+            ConnectionProperty.UPDATE_CACHE_FREQUENCY.getValue(
+                    info.getProperty(QueryServices.DEFAULT_UPDATE_CACHE_FREQUENCY_ATRRIB));
+        }
+    }
 
     @Override
     public PhoenixConnection connect(String url, Properties info) throws SQLException {
         checkClosed();
         PMetaData metadata = latestMetaData;
         throwConnectionClosedIfNullMetaData();
+        validateConnectionProperties(info);
         metadata = metadata.clone();
         return new PhoenixConnection(this, url, info, metadata);
     }
-
 
     private ColumnFamilyDescriptor generateColumnFamilyDescriptor(Pair<byte[],Map<String,Object>> family, PTableType tableType) throws SQLException {
         ColumnFamilyDescriptorBuilder columnDescBuilder = ColumnFamilyDescriptorBuilder.newBuilder(family.getFirst());

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -324,7 +324,7 @@ public class QueryServicesOptions {
     public static final boolean DEFAULT_PHOENIX_ACLS_ENABLED = false;
 
     //default update cache frequency
-    public static final int DEFAULT_UPDATE_CACHE_FREQUENCY = 0;
+    public static final long DEFAULT_UPDATE_CACHE_FREQUENCY = 0;
     public static final int DEFAULT_SMALL_SCAN_THRESHOLD = 100;
 
     // default system task handling interval in milliseconds

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/ConnectionProperty.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/ConnectionProperty.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.schema;
+
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.query.QueryServicesOptions;
+
+public enum ConnectionProperty {
+    /**
+     * Connection level property phoenix.default.update.cache.frequency
+     */
+    UPDATE_CACHE_FREQUENCY() {
+        @Override
+        public Object getValue(String value) {
+            if (value == null) {
+                return QueryServicesOptions.DEFAULT_UPDATE_CACHE_FREQUENCY;
+            }
+
+            if ("ALWAYS".equalsIgnoreCase(value)) {
+                return 0L;
+            }
+
+            if ("NEVER".equalsIgnoreCase(value)) {
+                return Long.MAX_VALUE;
+            }
+
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Connection's " +
+                        QueryServices.DEFAULT_UPDATE_CACHE_FREQUENCY_ATRRIB +
+                        " can only be set to 'ALWAYS', 'NEVER' or a millisecond numeric value.");
+            }
+        }
+    };
+
+    public Object getValue(String value) {
+        return value;
+    }
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -78,7 +78,6 @@ import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.STORE_NULLS;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYNC_INDEX_CREATED_DATE;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CATALOG_SCHEMA;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CATALOG_TABLE;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CHILD_LINK_TABLE;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_FUNCTION_TABLE;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_NAME;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_SCHEM;
@@ -998,8 +997,9 @@ public class MetaDataClient {
         populatePropertyMaps(statement.getProps(), tableProps, commonFamilyProps, statement.getTableType());
 
         boolean isAppendOnlySchema = false;
-        long updateCacheFrequency = connection.getQueryServices().getProps().getLong(
-            QueryServices.DEFAULT_UPDATE_CACHE_FREQUENCY_ATRRIB, QueryServicesOptions.DEFAULT_UPDATE_CACHE_FREQUENCY);
+        long updateCacheFrequency = (Long) ConnectionProperty.UPDATE_CACHE_FREQUENCY.getValue(
+                connection.getQueryServices().getProps().get(
+                        QueryServices.DEFAULT_UPDATE_CACHE_FREQUENCY_ATRRIB));
         Long updateCacheFrequencyProp = (Long) TableProperty.UPDATE_CACHE_FREQUENCY.getValue(tableProps);
         if (parent==null) {
 	        Boolean appendOnlySchemaProp = (Boolean) TableProperty.APPEND_ONLY_SCHEMA.getValue(tableProps);
@@ -2098,8 +2098,9 @@ public class MetaDataClient {
             if (disableWALProp != null) {
                 disableWAL = disableWALProp;
             }
-            long updateCacheFrequency = connection.getQueryServices().getProps().getLong(
-                QueryServices.DEFAULT_UPDATE_CACHE_FREQUENCY_ATRRIB, QueryServicesOptions.DEFAULT_UPDATE_CACHE_FREQUENCY);
+            long updateCacheFrequency = (Long) ConnectionProperty.UPDATE_CACHE_FREQUENCY.getValue(
+                    connection.getQueryServices().getProps().get(
+                            QueryServices.DEFAULT_UPDATE_CACHE_FREQUENCY_ATRRIB));
             if (tableType == PTableType.INDEX && parent != null) {
                 updateCacheFrequency = parent.getUpdateCacheFrequency();
             }

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/TableProperty.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/TableProperty.java
@@ -115,17 +115,32 @@ public enum TableProperty {
     UPDATE_CACHE_FREQUENCY(PhoenixDatabaseMetaData.UPDATE_CACHE_FREQUENCY, true, true, true) {
         @Override
         public Object getValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
             if (value instanceof String) {
                 String strValue = (String) value;
                 if ("ALWAYS".equalsIgnoreCase(strValue)) {
                     return 0L;
-                } else if ("NEVER".equalsIgnoreCase(strValue)) {
+                }
+
+                if ("NEVER".equalsIgnoreCase(strValue)) {
                     return Long.MAX_VALUE;
                 }
-            } else {
-                return value == null ? null : ((Number) value).longValue();
+
+                throw new IllegalArgumentException("Table's " +
+                        PhoenixDatabaseMetaData.UPDATE_CACHE_FREQUENCY +
+                        " can only be set to 'ALWAYS', 'NEVER' or a millisecond numeric value.");
             }
-            return value;
+
+            if (value instanceof Integer || value instanceof Long) {
+                return ((Number) value).longValue();
+            }
+
+            throw new IllegalArgumentException("Table's " +
+                    PhoenixDatabaseMetaData.UPDATE_CACHE_FREQUENCY +
+                    " can only be set to 'ALWAYS', 'NEVER' or a millisecond numeric value.");
         }
 
         @Override


### PR DESCRIPTION
…ion level config phoenix.default.update.cache.frequency.

- Introduced a new enum ConnectionProperty (similar to the existing TableProperty)
for connection level properties.
- Added validation code for connection properties at connection creation time.
- Changed the type of DEFAULT_UPDATE_CACHE_FREQUENCY from int to long.

Other changes made as part of this JIRA:
- Updated TableProperty.UPDATE_CACHE_FREQUENCY to raise relevant error message
for invalid table level property
- More tests for valid and invalid table/connection level property.