### PR TITLE
PHOENIX-5630: MAX_MUTATION_SIZE_EXCEEDED and MAX_MUTATION_SIZE_BYTES_EXCEEDED SQLExceptions should print existing size

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MutationStateIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MutationStateIT.java
@@ -366,6 +366,8 @@ public class MutationStateIT extends ParallelStatsDisabledIT {
                 e.getErrorCode());
             assertTrue(e.getMessage().contains(
                     SQLExceptionCode.MAX_MUTATION_SIZE_EXCEEDED.getMessage()));
+            assertTrue(e.getMessage().contains(
+                    connectionProperties.getProperty(QueryServices.MAX_MUTATION_SIZE_ATTRIB)));
         }
 
         // set the max mutation size (bytes) to a low value
@@ -381,6 +383,8 @@ public class MutationStateIT extends ParallelStatsDisabledIT {
                 e.getErrorCode());
             assertTrue(e.getMessage().contains(
                     SQLExceptionCode.MAX_MUTATION_SIZE_BYTES_EXCEEDED.getMessage()));
+            assertTrue(e.getMessage().contains(connectionProperties.getProperty
+                    (QueryServices.MAX_MUTATION_SIZE_BYTES_ATTRIB)));
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
@@ -47,6 +47,8 @@ import org.apache.phoenix.schema.TableAlreadyExistsException;
 import org.apache.phoenix.schema.TableNotFoundException;
 import org.apache.phoenix.schema.TypeMismatchException;
 import org.apache.phoenix.schema.types.PDataType;
+import org.apache.phoenix.schema.MaxMutationSizeBytesExceededException;
+import org.apache.phoenix.schema.MaxMutationSizeExceededException;
 import org.apache.phoenix.util.MetaDataUtil;
 
 import com.google.common.collect.Maps;
@@ -478,13 +480,24 @@ public enum SQLExceptionCode {
     NEW_CONNECTION_THROTTLED(728, "410M1", "Could not create connection " +
         "because this client already has the maximum number" +
         " of connections to the target cluster."),
-    
     MAX_MUTATION_SIZE_EXCEEDED(729, "LIM01", "MutationState size is bigger" +
             " than maximum allowed number of rows, try upserting rows in smaller batches or " +
-            "using autocommit on for deletes."),
+            "using autocommit on for deletes.", new Factory() {
+        @Override
+        public SQLException newException(SQLExceptionInfo info) {
+            return new MaxMutationSizeExceededException(
+                    info.getMaxMutationSize(), info.getMutationSize());
+        }
+    }),
     MAX_MUTATION_SIZE_BYTES_EXCEEDED(730, "LIM02", "MutationState size is " +
             "bigger than maximum allowed number of bytes, try upserting rows in smaller batches " +
-            "or using autocommit on for deletes."),
+            "or using autocommit on for deletes.", new Factory() {
+        @Override
+        public SQLException newException(SQLExceptionInfo info) {
+            return new MaxMutationSizeBytesExceededException(info.getMaxMutationSizeBytes(),
+                    info.getMutationSizeBytes());
+        }
+    }),
     INSUFFICIENT_MEMORY(999, "50M01", "Unable to allocate enough memory."),
     HASH_JOIN_CACHE_NOT_FOUND(900, "HJ01", "Hash Join cache not found"),
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionInfo.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionInfo.java
@@ -38,6 +38,10 @@ public class SQLExceptionInfo {
     public static final String FAMILY_NAME = "familyName";
     public static final String COLUMN_NAME = "columnName";
     public static final String FUNCTION_NAME = "functionName";
+    public static final String MAX_MUTATION_SIZE = "maxMutationSize";
+    public static final String MUTATION_SIZE = "mutationSize";
+    public static final String MAX_MUTATION_SIZE_BYTES = "maxMutationSizeBytes";
+    public static final String MUTATION_SIZE_BYTES = "mutationSizeBytes";
 
     private final Throwable rootCause;
     private final SQLExceptionCode code; // Should always have one.
@@ -47,6 +51,10 @@ public class SQLExceptionInfo {
     private final String familyName;
     private final String columnName;
     private final String functionName;
+    private final int maxMutationSize;
+    private final int mutationSize;
+    private final long maxMutationSizeBytes;
+    private final long mutationSizeBytes;
 
     public static class Builder {
 
@@ -58,6 +66,10 @@ public class SQLExceptionInfo {
         private String familyName;
         private String columnName;
         private String functionName;
+        private int maxMutationSize;
+        private int mutationSize;
+        private long maxMutationSizeBytes;
+        private long mutationSizeBytes;
 
         public Builder(SQLExceptionCode code) {
             this.code = code;
@@ -97,6 +109,27 @@ public class SQLExceptionInfo {
             this.functionName = functionName;
             return this;
         }
+
+        public Builder setMaxMutationSize(int maxMutationSize) {
+            this.maxMutationSize = maxMutationSize;
+            return this;
+        }
+
+        public Builder setMutationSize(int mutationSize) {
+            this.mutationSize = mutationSize;
+            return this;
+        }
+
+        public Builder setMaxMutationSizeBytes(long maxMutationSizeBytes) {
+            this.maxMutationSizeBytes = maxMutationSizeBytes;
+            return this;
+        }
+
+        public Builder setMutationSizeBytes(long mutationSizeBytes) {
+            this.mutationSizeBytes = mutationSizeBytes;
+            return this;
+        }
+
         public SQLExceptionInfo build() {
             return new SQLExceptionInfo(this);
         }
@@ -116,6 +149,10 @@ public class SQLExceptionInfo {
         familyName = builder.familyName;
         columnName = builder.columnName;
         functionName = builder.functionName;
+        maxMutationSize = builder.maxMutationSize;
+        mutationSize = builder.mutationSize;
+        maxMutationSizeBytes = builder.maxMutationSizeBytes;
+        mutationSizeBytes = builder.mutationSizeBytes;
     }
 
     @Override
@@ -142,6 +179,14 @@ public class SQLExceptionInfo {
             builder.append(" ").append(TABLE_NAME).append("=").append(columnDisplayName);
         } else if (schemaName != null) {
             builder.append(" ").append(SCHEMA_NAME).append("=").append(columnDisplayName);
+        }
+        if (maxMutationSize != 0) {
+            builder.append(" ").append(MAX_MUTATION_SIZE).append("=").append(maxMutationSize);
+            builder.append(" ").append(MUTATION_SIZE).append("=").append(mutationSize);
+        } else if (maxMutationSizeBytes != 0) {
+            builder.append(" ").append(MAX_MUTATION_SIZE_BYTES).append("=").
+                    append(maxMutationSizeBytes);
+            builder.append(" ").append(MUTATION_SIZE_BYTES).append("=").append(mutationSizeBytes);
         }
         return builder.toString();
     }
@@ -180,6 +225,22 @@ public class SQLExceptionInfo {
 
     public String getMessage() {
         return message;
+    }
+
+    public int getMaxMutationSize() {
+        return maxMutationSize;
+    }
+
+    public int getMutationSize() {
+        return mutationSize;
+    }
+
+    public long getMaxMutationSizeBytes() {
+        return maxMutationSizeBytes;
+    }
+
+    public long getMutationSizeBytes() {
+        return mutationSizeBytes;
     }
 
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MaxMutationSizeBytesExceededException.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MaxMutationSizeBytesExceededException.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.schema;
+
+import org.apache.phoenix.exception.SQLExceptionCode;
+import org.apache.phoenix.exception.SQLExceptionInfo;
+import org.apache.phoenix.exception.SQLExceptionInfo.Builder;
+
+import java.sql.SQLException;
+
+/**
+ *
+ * Exception thrown when MutationState size is bigger than
+ * maximum allowed number of Bytes
+ *
+ */
+
+public class MaxMutationSizeBytesExceededException extends SQLException {
+
+    private static final long serialVersionUID = 1L;
+    private static SQLExceptionCode code = SQLExceptionCode.MAX_MUTATION_SIZE_BYTES_EXCEEDED;
+
+    public MaxMutationSizeBytesExceededException() {
+        super(new Builder(code).build().toString(), code.getSQLState(), code.getErrorCode(), null);
+    }
+
+    public MaxMutationSizeBytesExceededException(long maxMutationSizeBytes,
+           long mutationSizeBytes) {
+        super(new SQLExceptionInfo.Builder(code).setMaxMutationSizeBytes(maxMutationSizeBytes)
+                .setMutationSizeBytes(mutationSizeBytes).build().toString(),
+                code.getSQLState(), code.getErrorCode(), null);
+    }
+
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MaxMutationSizeExceededException.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MaxMutationSizeExceededException.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.schema;
+
+import org.apache.phoenix.exception.SQLExceptionCode;
+import org.apache.phoenix.exception.SQLExceptionInfo;
+import java.sql.SQLException;
+
+/**
+ *
+ * Exception thrown when MutationState size is bigger than
+ * maximum allowed number of rows
+ *
+ */
+
+public class MaxMutationSizeExceededException extends SQLException {
+    private static final long serialVersionUID = 1L;
+    private static SQLExceptionCode code = SQLExceptionCode.MAX_MUTATION_SIZE_EXCEEDED;
+
+    public MaxMutationSizeExceededException() {
+        super(new SQLExceptionInfo.Builder(code).build().toString(), code.getSQLState(),
+                code.getErrorCode(), null);
+    }
+
+    public MaxMutationSizeExceededException(int maxMutationSize, int mutationSize) {
+        super(new SQLExceptionInfo.Builder(code).setMaxMutationSize(maxMutationSize)
+                .setMutationSize(mutationSize).build().toString(),
+                code.getSQLState(), code.getErrorCode(), null);
+    }
+}


### PR DESCRIPTION
Hi @ChinmaySKulkarni , @yanxinyi  can you please review this patch ?