### PR TITLE
PHOENIX-5808 Improve shaded artifact naming convetions

### DIFF
--- a/bin/phoenix_utils.py
+++ b/bin/phoenix_utils.py
@@ -68,7 +68,7 @@ def findClasspath(command_name):
     return subprocess.Popen(command, shell=True, stdout=subprocess.PIPE).stdout.read()
 
 def setPath():
-    PHOENIX_CLIENT_JAR_PATTERN = "phoenix-*-client.jar"
+    PHOENIX_CLIENT_JAR_PATTERN = "phoenix-client.jar"
     PHOENIX_THIN_CLIENT_JAR_PATTERN = "phoenix-*-thin-client.jar"
     PHOENIX_QUERYSERVER_JAR_PATTERN = "phoenix-*-queryserver.jar"
     PHOENIX_LOADBALANCER_JAR_PATTERN = "phoenix-load-balancer-*[!t][!e][!s][!t][!s].jar"

--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -42,7 +42,27 @@
         <groupId>org.codehaus.mojo</groupId>
         <executions>
           <execution>
-            <id>Symlink to deprecated client jar name</id>
+            <id>client without classifier</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>ln</executable>
+              <workingDirectory></workingDirectory>
+              <arguments>
+                <argument>-fnsv</argument>
+                <argument>
+                  phoenix-client-${project.version}-${hbase.profile.string}.jar
+                </argument>
+                <argument>
+                  phoenix-client-${project.version}.jar
+                </argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>client without version and classifier</id>
             <phase>compile</phase>
             <goals>
               <goal>exec</goal>
@@ -56,7 +76,49 @@
                   phoenix-client-${project.version}-${hbase.profile.string}.jar
                 </argument>
                 <argument>
-                  phoenix-${project.version}-${hbase.profile.string}-client.jar
+                  <!-- We are overwriting the unshaded client JAR, but we don't care -->
+                  phoenix-client.jar
+                </argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>server without classifier</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>ln</executable>
+              <workingDirectory>${project.basedir}/../phoenix-server/target</workingDirectory>
+              <arguments>
+                <argument>-fnsv</argument>
+                <argument>
+                  phoenix-server-${project.version}-${hbase.profile.string}.jar
+                </argument>
+                <argument>
+                  phoenix-server-${project.version}.jar
+                </argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>server without version and classifier</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>ln</executable>
+              <workingDirectory>${project.basedir}/../phoenix-server/target</workingDirectory>
+              <arguments>
+                <argument>-fnsv</argument>
+                <argument>
+                  phoenix-server-${project.version}-${hbase.profile.string}.jar
+                </argument>
+                <argument>
+                  <!-- We are overwriting the unshaded server JAR, but we don't care -->
+                  phoenix-server.jar
                 </argument>
               </arguments>
             </configuration>

--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -49,7 +49,7 @@
             </goals>
             <configuration>
               <executable>ln</executable>
-              <workingDirectory></workingDirectory>
+              <workingDirectory>${project.basedir}/../phoenix-client/target</workingDirectory>
               <arguments>
                 <argument>-fnsv</argument>
                 <argument>
@@ -183,7 +183,19 @@
     <!-- Depend on all other internal projects -->
     <dependency>
       <groupId>org.apache.phoenix</groupId>
-      <artifactId>phoenix-core</artifactId>
+      <artifactId>phoenix-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-pherf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-tracing-webapp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.omid</groupId>

--- a/phoenix-assembly/src/build/components/all-common-jars.xml
+++ b/phoenix-assembly/src/build/components/all-common-jars.xml
@@ -28,15 +28,17 @@
       <outputDirectory>/</outputDirectory>
       <includes>
         <include>phoenix-client-${project.version}-${hbase.profile.string}.jar</include>
-        <!-- deprecated jar name, which we now have a symlink for -->
-        <include>phoenix-${project.version}-${hbase.profile.string}-client.jar</include>
+        <include>phoenix-client-${project.version}.jar</include>
+        <include>phoenix-client.jar</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/../phoenix-server/target</directory>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>phoenix-*-server.jar</include>
+        <include>phoenix-server-${project.version}-${hbase.profile.string}.jar</include>
+        <include>phoenix-server-${project.version}.jar</include>
+        <include>phoenix-server.jar</include>
       </includes>
     </fileSet>
 

--- a/phoenix-client/pom.xml
+++ b/phoenix-client/pom.xml
@@ -354,8 +354,8 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <shadedClassifierName>${hbase.profile.string}</shadedClassifierName>
               <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>${hbase.profile.string}</shadedClassifierName>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <shadeTestJar>false</shadeTestJar>
               <createSourcesJar>true</createSourcesJar>
@@ -394,8 +394,8 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <shadedClassifierName>${hbase.profile.string}-embedded</shadedClassifierName>
               <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>${hbase.profile.string}-embedded</shadedClassifierName>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <shadeTestJar>false</shadeTestJar>
               <artifactSet>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -59,29 +59,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <finalName>phoenix-${project.version}-server</finalName>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>install-file</goal>
-            </goals>
-            <id>default-install</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-            <phase>install</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <file>${basedir}/target/phoenix-${project.version}-server.jar</file>
- 	  <pomFile>${basedir}/pom.xml</pomFile>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -102,10 +83,8 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-                <finalName>
-                  phoenix-${project.version}-${hbase.profile.string}-server
-                </finalName>
-                <shadedArtifactAttached>false</shadedArtifactAttached>
+                <shadedArtifactAttached>true</shadedArtifactAttached>
+                <shadedClassifierName>${hbase.profile.string}</shadedClassifierName>
                 <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                 <shadeTestJar>false</shadeTestJar>
                 <transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -602,6 +602,26 @@
       </dependency>
       <dependency>
         <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-server</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-pherf</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-tracing-webapp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
         <artifactId>phoenix-hbase-compat-2.0.1</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
provide unversioned symlinks in the assembly for -server and -client
drop the deprecated phoenix-<version>-client/server symlinks/jars
update the python lib to look for the unversioned client jar