### PR TITLE
PHOENIX-5888 [DOCS] update sqlline manual URL

### DIFF
--- a/bin/readme.txt
+++ b/bin/readme.txt
@@ -2,7 +2,7 @@ SqlLine
 =======
 https://github.com/julianhyde/sqlline
 
-Execute SQL from command line. Sqlline manual is available at http://www.hydromatic.net/sqlline/manual.html
+Execute SQL from command line. Sqlline manual is available at https://julianhyde.github.io/sqlline/manual.html
 	
 	Usage: 
 	$ sqlline.py <zookeeper> <optional_sql_file> 


### PR DESCRIPTION
the old sqlline manual url in homepage is invalid. Update to the new url address.

Related to https://issues.apache.org/jira/browse/PHOENIX-5888