### PR TITLE
PHOENIX-5902 Document or fix new compat jar behavior.

### DIFF
--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -97,6 +97,7 @@
                 <artifactSet>
                 <includes>
                   <include>org.apache.phoenix:phoenix-core</include>
+                  <include>org.apache.phoenix:phoenix-hbase-compat-${hbase.compat.version}</include>
                   <include>org.iq80.snappy:snappy</include>
                   <include>org.antlr:antlr*</include>
                   <include>org.apache.tephra:tephra*</include>


### PR DESCRIPTION
add the appropriate hbase-compat module to the shaded server JAR