### PR TITLE
PHOENIX-5920 Skip SYSTEM TABLE checks while creating phoenix connection if client has set the DoNotUpgrade config

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/BasePermissionsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/BasePermissionsIT.java
@@ -932,7 +932,8 @@ public abstract class BasePermissionsIT extends BaseTest {
             // NS is disabled, CQSI tries creating SYSCAT, Two cases here
             // 1. First client ever --> Gets ADE, runs client server compatibility check again and gets TableNotFoundException since SYSCAT doesn't exist
             // 2. Any other client --> Gets ADE, runs client server compatibility check again and gets AccessDeniedException since it doesn't have EXEC perms
-            verifyDenied(getConnectionAction(), org.apache.hadoop.hbase.TableNotFoundException.class, regularUser1);
+            verifyDenied(getConnectionAction(),
+                    org.apache.hadoop.hbase.TableNotFoundException.class, regularUser1);
         }
 
         // Phoenix Client caches connection per user

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/BasePermissionsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/BasePermissionsIT.java
@@ -932,7 +932,7 @@ public abstract class BasePermissionsIT extends BaseTest {
             // NS is disabled, CQSI tries creating SYSCAT, Two cases here
             // 1. First client ever --> Gets ADE, runs client server compatibility check again and gets TableNotFoundException since SYSCAT doesn't exist
             // 2. Any other client --> Gets ADE, runs client server compatibility check again and gets AccessDeniedException since it doesn't have EXEC perms
-            verifyDenied(getConnectionAction(), TableNotFoundException.class, regularUser1);
+            verifyDenied(getConnectionAction(), org.apache.hadoop.hbase.TableNotFoundException.class, regularUser1);
         }
 
         // Phoenix Client caches connection per user

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/SystemCatalogCreationOnConnectionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/SystemCatalogCreationOnConnectionIT.java
@@ -674,9 +674,11 @@ public class SystemCatalogCreationOnConnectionIT {
         startMiniClusterWithToggleNamespaceMapping(Boolean.FALSE.toString());
         Properties propsDoNotUpgradePropSet = new Properties();
         // Create a dummy connection to make sure we have all system tables in place
-        try (Connection con1 = DriverManager.getConnection(getJdbcUrl(), propsDoNotUpgradePropSet)) {
-            String ddl = "CREATE TABLE " + tableName + " (PK1 VARCHAR not null, PK2 VARCHAR not null, "
-                    + "COL1 varchar, COL2 varchar " + "CONSTRAINT pk PRIMARY KEY(PK1,PK2))";
+        try (Connection con1 = DriverManager.getConnection(getJdbcUrl(), propsDoNotUpgradePropSet))
+        {
+            String ddl = "CREATE TABLE " + tableName + " (PK1 VARCHAR not null, " +
+                    "PK2 VARCHAR not null, COL1 varchar, COL2 varchar "
+                    + "CONSTRAINT pk PRIMARY KEY(PK1,PK2))";
             con1.createStatement().execute(ddl);
             con1.createStatement().execute(
                     "UPSERT INTO " + tableName + " values ('pk1','pk2','c1','c2')");
@@ -693,5 +695,6 @@ public class SystemCatalogCreationOnConnectionIT {
             assertEquals("pk2", rs.getString(2));
             assertFalse(rs.next());
         }
+        testUtil.getMiniHBaseCluster().startMaster();
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -1417,14 +1417,16 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                         // Cannot switch between different providers
                         if (hasTxCoprocessor(existingDesc)) {
                             throw new SQLExceptionInfo.Builder(SQLExceptionCode.CANNOT_SWITCH_TXN_PROVIDERS)
-                                    .setSchemaName(SchemaUtil.getSchemaNameFromFullName(physicalTableName))
-                                    .setTableName(SchemaUtil.getTableNameFromFullName(physicalTableName)).build().buildException();
+                            .setSchemaName(SchemaUtil.getSchemaNameFromFullName(physicalTableName))
+                            .setTableName(SchemaUtil.getTableNameFromFullName(physicalTableName))
+                            .build().buildException();
                         }
                         if (provider.getTransactionProvider().isUnsupported(PhoenixTransactionProvider.Feature.ALTER_NONTX_TO_TX)) {
                             throw new SQLExceptionInfo.Builder(SQLExceptionCode.CANNOT_ALTER_TABLE_FROM_NON_TXN_TO_TXNL)
-                                    .setMessage(provider.name())
-                                    .setSchemaName(SchemaUtil.getSchemaNameFromFullName(physicalTableName))
-                                    .setTableName(SchemaUtil.getTableNameFromFullName(physicalTableName)).build().buildException();
+                            .setMessage(provider.name())
+                            .setSchemaName(SchemaUtil.getSchemaNameFromFullName(physicalTableName))
+                            .setTableName(SchemaUtil.getTableNameFromFullName(physicalTableName))
+                            .build().buildException();
                         }
                         newDesc.setValue(PhoenixTransactionContext.READ_NON_TX_DATA, Boolean.TRUE.toString());
                     }
@@ -1433,8 +1435,9 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                     // transactional, don't allow.
                     if (hasTxCoprocessor(existingDesc)) {
                         throw new SQLExceptionInfo.Builder(SQLExceptionCode.TX_MAY_NOT_SWITCH_TO_NON_TX)
-                                .setSchemaName(SchemaUtil.getSchemaNameFromFullName(physicalTableName))
-                                .setTableName(SchemaUtil.getTableNameFromFullName(physicalTableName)).build().buildException();
+                        .setSchemaName(SchemaUtil.getSchemaNameFromFullName(physicalTableName))
+                        .setTableName(SchemaUtil.getTableNameFromFullName(physicalTableName))
+                        .build().buildException();
                     }
                     newDesc.removeValue(Bytes.toBytes(PhoenixTransactionContext.READ_NON_TX_DATA));
                 }


### PR DESCRIPTION
I've made following changes to honor "DoNotUpgrade" config:
1. This PR makes a strong assumption that if client has set "DoNotUpgrade" config server already has SYSCAT tables even for firstConnection where isAutoUpgrade prop is enabled by default.
2. If "DoNotUpgrade" is set we are only doing client-server compatibility check and namespace checks.
3. We are skipping SYSCAT existence and timestamp related checks if "DoNotUpgrade" config is set.
I can remove the test cases that I've marked as ignore once we finalize its a valid removal.
@ChinmaySKulkarni @dbwong @gjacoby126 @jpisaac can you please review this PR ?