### PR TITLE
PHOENIX-5928 Index rebuilds without replaying data table mutations

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexExtendedIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexExtendedIT.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.coprocessor.IndexRebuildRegionScanner;
 import org.apache.phoenix.hbase.index.IndexRegionObserver;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.mapreduce.index.IndexTool;
@@ -341,7 +342,7 @@ public class IndexExtendedIT extends BaseTest {
 
             // Configure IndexRegionObserver to fail the first write phase. This should not
             // lead to any change on index and thus index verify during index rebuild should fail
-            IndexRegionObserver.setIgnoreIndexRebuildForTesting(true);
+            IndexRebuildRegionScanner.setIgnoreIndexRebuildForTesting(true);
             stmt.execute(String.format(
                     "CREATE INDEX %s ON %s (NAME) INCLUDE (ZIP) ASYNC",
                     indexTableName, dataTableFullName));
@@ -353,7 +354,7 @@ public class IndexExtendedIT extends BaseTest {
             IndexToolIT.runIndexTool(true, false, schemaName, dataTableName,
                     indexTableName, null, -1, IndexTool.IndexVerifyType.AFTER);
 
-            IndexRegionObserver.setIgnoreIndexRebuildForTesting(false);
+            IndexRebuildRegionScanner.setIgnoreIndexRebuildForTesting(false);
 
             // job failed, verify that the index table is still not in the ACTIVE state
             assertFalse(checkIndexState(conn, indexFullName, PIndexState.ACTIVE, 0L));

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexToolForNonTxGlobalIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexToolForNonTxGlobalIndexIT.java
@@ -465,7 +465,7 @@ public class IndexToolForNonTxGlobalIndexIT extends BaseUniqueNamesOwnClusterIT 
             conn.commit();
             // Configure IndexRegionObserver to fail the first write phase. This should not
             // lead to any change on index and thus the index verify during index rebuild should fail
-            IndexRegionObserver.setIgnoreIndexRebuildForTesting(true);
+            IndexRebuildRegionScanner.setIgnoreIndexRebuildForTesting(true);
             conn.createStatement().execute(String.format(
                     "CREATE INDEX %s ON %s (NAME) INCLUDE (ZIP) ASYNC", indexTableName, viewFullName));
             // Run the index MR job and verify that the index table rebuild fails
@@ -480,7 +480,7 @@ public class IndexToolForNonTxGlobalIndexIT extends BaseUniqueNamesOwnClusterIT 
             } catch(Exception ex){
                 Assert.fail("Fail to parsing the error message from IndexToolOutputTable");
             }
-            IndexRegionObserver.setIgnoreIndexRebuildForTesting(false);
+            IndexRebuildRegionScanner.setIgnoreIndexRebuildForTesting(false);
         }
     }
 
@@ -659,11 +659,10 @@ public class IndexToolForNonTxGlobalIndexIT extends BaseUniqueNamesOwnClusterIT 
                 TableName.valueOf(IndexVerificationOutputRepository.OUTPUT_TABLE_NAME));
             deleteAllRows(conn, TableName.valueOf(indexTableFullName));
 
-            //now check that disabling logging BEFORE creates only the AFTER logs on a BOTH run
-            //which in this case should be 0 since the rebuild succeeds and after-validation passes
-            assertDisableLogging(conn, 0, IndexTool.IndexVerifyType.BOTH,
-                IndexTool.IndexDisableLoggingType.BEFORE,
-                IndexVerificationOutputRepository.PHASE_AFTER_VALUE, schemaName,
+            //now check that disabling logging AFTER creates only the BEFORE logs on a BOTH run
+            assertDisableLogging(conn, 2, IndexTool.IndexVerifyType.BOTH,
+                IndexTool.IndexDisableLoggingType.AFTER,
+                IndexVerificationOutputRepository.PHASE_BEFORE_VALUE, schemaName,
                 dataTableName, indexTableName,
                 indexTableFullName, 0);
 
@@ -673,7 +672,7 @@ public class IndexToolForNonTxGlobalIndexIT extends BaseUniqueNamesOwnClusterIT 
             //now check that disabling logging BOTH creates no logs on a BOTH run
             assertDisableLogging(conn, 0, IndexTool.IndexVerifyType.BOTH,
                 IndexTool.IndexDisableLoggingType.BOTH,
-                IndexVerificationOutputRepository.PHASE_AFTER_VALUE, schemaName,
+                IndexVerificationOutputRepository.PHASE_BEFORE_VALUE, schemaName,
                 dataTableName, indexTableName,
                 indexTableFullName, 0);
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ServerBuildIndexCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ServerBuildIndexCompiler.java
@@ -89,7 +89,7 @@ public class ServerBuildIndexCompiler {
 
     public MutationPlan compile(PTable index) throws SQLException {
         try (final PhoenixStatement statement = new PhoenixStatement(connection)) {
-            String query = "SELECT count(*) FROM " + tableName;
+            String query = "SELECT /*+ NO_INDEX */ count(*) FROM " + tableName;
             this.plan = statement.compileQuery(query);
             TableRef tableRef = plan.getTableRef();
             Scan scan = plan.getContext().getScan();

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/IndexRebuildRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/IndexRebuildRegionScanner.java
@@ -20,12 +20,10 @@ package org.apache.phoenix.coprocessor;
 import static org.apache.phoenix.hbase.index.IndexRegionObserver.UNVERIFIED_BYTES;
 import static org.apache.phoenix.hbase.index.IndexRegionObserver.VERIFIED_BYTES;
 import static org.apache.phoenix.hbase.index.IndexRegionObserver.removeEmptyColumn;
-import static org.apache.phoenix.hbase.index.write.AbstractParallelWriterIndexCommitter.INDEX_WRITER_KEEP_ALIVE_TIME_CONF_KEY;
 import static org.apache.phoenix.query.QueryConstants.AGG_TIMESTAMP;
 import static org.apache.phoenix.query.QueryConstants.SINGLE_COLUMN;
 import static org.apache.phoenix.query.QueryConstants.SINGLE_COLUMN_FAMILY;
 import static org.apache.phoenix.query.QueryConstants.UNGROUPED_AGG_ROW_KEY;
-import static org.apache.phoenix.query.QueryServices.MUTATE_BATCH_SIZE_BYTES_ATTRIB;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,13 +32,14 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
@@ -48,8 +47,6 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Durability;
-import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
@@ -61,28 +58,23 @@ import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.mapreduce.index.IndexVerificationResultRepository;
+import org.apache.phoenix.query.HBaseFactoryProvider;
 import org.apache.phoenix.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.Pair;
-import org.apache.phoenix.cache.ServerCacheClient;
 import org.apache.phoenix.compile.ScanRanges;
 import org.apache.phoenix.filter.SkipScanFilter;
 import org.apache.phoenix.hbase.index.ValueGetter;
 import org.apache.phoenix.hbase.index.parallel.EarlyExitFailure;
 import org.apache.phoenix.hbase.index.parallel.Task;
 import org.apache.phoenix.hbase.index.parallel.TaskBatch;
-import org.apache.phoenix.hbase.index.parallel.ThreadPoolBuilder;
-import org.apache.phoenix.hbase.index.parallel.ThreadPoolManager;
-import org.apache.phoenix.hbase.index.parallel.WaitForCompletionTaskRunner;
 import org.apache.phoenix.hbase.index.util.GenericKeyValueBuilder;
 import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
 import org.apache.phoenix.hbase.index.util.IndexManagementUtil;
 import org.apache.phoenix.index.GlobalIndexChecker;
 import org.apache.phoenix.index.IndexMaintainer;
 import org.apache.phoenix.mapreduce.index.IndexVerificationOutputRepository;
-import org.apache.phoenix.index.PhoenixIndexCodec;
 import org.apache.phoenix.mapreduce.index.IndexTool;
 import org.apache.phoenix.query.KeyRange;
-import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.types.PLong;
 import org.apache.phoenix.schema.types.PVarbinary;
 import org.apache.phoenix.util.IndexUtil;
@@ -91,90 +83,51 @@ import org.apache.phoenix.util.ServerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 
 public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexRebuildRegionScanner.class);
 
-    private final long maxBatchSizeBytes;
-    private final long blockingMemstoreSize;
-    private final byte[] clientVersionBytes;
-    private boolean useProto = true;
+    private static boolean ignoreIndexRebuildForTesting  = false;
+    public static void setIgnoreIndexRebuildForTesting(boolean ignore) { ignoreIndexRebuildForTesting = ignore; }
     private byte[] indexRowKey;
-    private IndexTool.IndexVerifyType verifyType = IndexTool.IndexVerifyType.NONE;
     private IndexTool.IndexDisableLoggingType disableLoggingVerifyType = IndexTool.IndexDisableLoggingType.NONE;
-    private boolean verify = false;
-    private Map<byte[], List<Mutation>> indexKeyToMutationMap;
-    private Map<byte[], Pair<Put, Delete>> dataKeyToMutationMap;
-    private UngroupedAggregateRegionObserver ungroupedAggregateRegionObserver;
-    protected UngroupedAggregateRegionObserver.MutationList mutations;
-    private boolean isBeforeRebuilt = true;
-    private boolean partialRebuild = false;
     private int singleRowRebuildReturnCode;
-    private Map<byte[], NavigableSet<byte[]>> familyMap;
     private byte[][] viewConstants;
-    private IndexVerificationOutputRepository verificationOutputRepository;
+    private IndexVerificationOutputRepository verificationOutputRepository = null;
     private boolean skipped = false;
     private boolean shouldVerifyCheckDone = false;
-
+    final private RegionCoprocessorEnvironment env;
+    byte[][] endKeys;
     @VisibleForTesting
     public IndexRebuildRegionScanner(final RegionScanner innerScanner, final Region region, final Scan scan,
-                              final RegionCoprocessorEnvironment env,
-                              UngroupedAggregateRegionObserver ungroupedAggregateRegionObserver) throws IOException {
+                              final RegionCoprocessorEnvironment env) throws IOException {
         super(innerScanner, region, scan, env);
-        final Configuration config = env.getConfiguration();
-        if (scan.getAttribute(BaseScannerRegionObserver.INDEX_REBUILD_PAGING) == null) {
-            partialRebuild = true;
+        this.env = env;
+        try (org.apache.hadoop.hbase.client.Connection connection =
+                     HBaseFactoryProvider.getHConnectionFactory().createConnection(env.getConfiguration())) {
+            endKeys = connection.getRegionLocator(indexHTable.getName()).getEndKeys();
         }
-        maxBatchSizeBytes = config.getLong(MUTATE_BATCH_SIZE_BYTES_ATTRIB,
-                QueryServicesOptions.DEFAULT_MUTATE_BATCH_SIZE_BYTES);
-        mutations = new UngroupedAggregateRegionObserver.MutationList(maxBatchSize);
-        blockingMemstoreSize = UngroupedAggregateRegionObserver.getBlockingMemstoreSize(region, config);
-        clientVersionBytes = scan.getAttribute(BaseScannerRegionObserver.CLIENT_VERSION);
-        indexMetaData = scan.getAttribute(PhoenixIndexCodec.INDEX_PROTO_MD);
-        if (indexMetaData == null) {
-            useProto = false;
-        }
-        familyMap = scan.getFamilyMap();
-        if (familyMap.isEmpty()) {
-            familyMap = null;
-        }
-        this.ungroupedAggregateRegionObserver = ungroupedAggregateRegionObserver;
         indexRowKey = scan.getAttribute(BaseScannerRegionObserver.INDEX_ROW_KEY);
         if (indexRowKey != null) {
             setReturnCodeForSingleRowRebuild();
             pageSizeInRows = 1;
         }
-        byte[] valueBytes = scan.getAttribute(BaseScannerRegionObserver.INDEX_REBUILD_VERIFY_TYPE);
-        if (valueBytes != null) {
-            verifyType = IndexTool.IndexVerifyType.fromValue(valueBytes);
-            if (verifyType != IndexTool.IndexVerifyType.NONE) {
-                verify = true;
-                viewConstants = IndexUtil.deserializeViewConstantsFromScan(scan);
-                byte[] disableLoggingValueBytes =
-                    scan.getAttribute(BaseScannerRegionObserver.INDEX_REBUILD_DISABLE_LOGGING_VERIFY_TYPE);
-                if (disableLoggingValueBytes != null) {
-                    disableLoggingVerifyType =
-                        IndexTool.IndexDisableLoggingType.fromValue(disableLoggingValueBytes);
-                }
-                verificationOutputRepository =
-                    new IndexVerificationOutputRepository(indexMaintainer.getIndexTableName()
-                        , hTableFactory, disableLoggingVerifyType);
-                verificationResult = new IndexToolVerificationResult(scan);
-                        new IndexVerificationOutputRepository(indexMaintainer.getIndexTableName()
-                            , hTableFactory, disableLoggingVerifyType);
-                verificationResultRepository =
-                    new IndexVerificationResultRepository(indexMaintainer.getIndexTableName(), hTableFactory);
-                indexKeyToMutationMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-                dataKeyToMutationMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-                pool = new WaitForCompletionTaskRunner(ThreadPoolManager.getExecutor(
-                        new ThreadPoolBuilder("IndexVerify",
-                                env.getConfiguration()).setMaxThread(NUM_CONCURRENT_INDEX_VERIFY_THREADS_CONF_KEY,
-                                DEFAULT_CONCURRENT_INDEX_VERIFY_THREADS).setCoreTimeout(
-                                INDEX_WRITER_KEEP_ALIVE_TIME_CONF_KEY), env));
+        if (verify) {
+            viewConstants = IndexUtil.deserializeViewConstantsFromScan(scan);
+            byte[] disableLoggingValueBytes =
+                scan.getAttribute(BaseScannerRegionObserver.INDEX_REBUILD_DISABLE_LOGGING_VERIFY_TYPE);
+            if (disableLoggingValueBytes != null) {
+                disableLoggingVerifyType =
+                    IndexTool.IndexDisableLoggingType.fromValue(disableLoggingValueBytes);
             }
+            verificationOutputRepository =
+                new IndexVerificationOutputRepository(indexMaintainer.getIndexTableName()
+                    , hTableFactory, disableLoggingVerifyType);
+            verificationResult = new IndexToolVerificationResult(scan);
+            verificationResultRepository =
+                new IndexVerificationResultRepository(indexMaintainer.getIndexTableName(), hTableFactory);
         }
     }
 
@@ -193,8 +146,8 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
     }
 
     private boolean shouldVerify() throws IOException {
-        //In case of read repair, proceed with rebuild
-        //All other types of rebuilds/verification should be incrementally performed if appropriate param is passed
+        // In case of read repair, proceed with rebuild
+        // All other types of rebuilds/verification should be incrementally performed if appropriate param is passed
         byte[] lastVerifyTimeValue = scan.getAttribute(UngroupedAggregateRegionObserver.INDEX_RETRY_VERIFY);
         Long lastVerifyTime = lastVerifyTimeValue == null ? 0 : Bytes.toLong(lastVerifyTimeValue);
         if(indexRowKey != null || lastVerifyTime == 0 || shouldVerifyCheckDone) {
@@ -243,8 +196,6 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
         return false;
     }
 
-
-
     @Override
     public void close() throws IOException {
         innerScanner.close();
@@ -268,26 +219,6 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
         }
     }
 
-    private void setMutationAttributes(Mutation m, byte[] uuidValue) {
-        m.setAttribute(useProto ? PhoenixIndexCodec.INDEX_PROTO_MD : PhoenixIndexCodec.INDEX_MD, indexMetaData);
-        m.setAttribute(PhoenixIndexCodec.INDEX_UUID, uuidValue);
-        m.setAttribute(BaseScannerRegionObserver.REPLAY_WRITES,
-                BaseScannerRegionObserver.REPLAY_INDEX_REBUILD_WRITES);
-        m.setAttribute(BaseScannerRegionObserver.CLIENT_VERSION, clientVersionBytes);
-        // Since we're replaying existing mutations, it makes no sense to write them to the wal
-        m.setDurability(Durability.SKIP_WAL);
-    }
-
-    private byte[] commitIfReady(byte[] uuidValue, UngroupedAggregateRegionObserver.MutationList mutationList) throws IOException {
-        if (ServerUtil.readyToCommit(mutationList.size(), mutationList.byteSize(), maxBatchSize, maxBatchSizeBytes)) {
-            ungroupedAggregateRegionObserver.checkForRegionClosing();
-            ungroupedAggregateRegionObserver.commitBatchWithRetries(region, mutationList, blockingMemstoreSize);
-            uuidValue = ServerCacheClient.generateId();
-            mutationList.clear();
-        }
-        return uuidValue;
-    }
-
     @VisibleForTesting
     public int setIndexTableTTL(int ttl) {
         indexTableTTL = ttl;
@@ -301,17 +232,10 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
     }
 
     @VisibleForTesting
-    public int setIndexKeyToMutationMap(Map<byte[], List<Mutation>> newTreeMap) {
-        this.indexKeyToMutationMap = newTreeMap;
-        return 0;
-    }
-
-    @VisibleForTesting
     public long setMaxLookBackInMills(long maxLookBackInMills) {
         this.maxLookBackInMills = maxLookBackInMills;
         return 0;
     }
-
 
     private boolean checkIndexRow(final byte[] indexRowKey, final Put put) throws IOException {
         byte[] builtIndexRowKey = getIndexRowKey(indexMaintainer, put);
@@ -323,17 +247,17 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
     }
 
     public void logToIndexToolOutputTable(byte[] dataRowKey, byte[] indexRowKey, long dataRowTs, long indexRowTs,
-            String errorMsg) throws IOException {
-        logToIndexToolOutputTable(dataRowKey, indexRowKey, dataRowTs, indexRowTs, errorMsg, null, null);
+            String errorMsg, boolean isBeforeRebuild) throws IOException {
+        logToIndexToolOutputTable(dataRowKey, indexRowKey, dataRowTs, indexRowTs, errorMsg, null, null, isBeforeRebuild);
     }
 
     @VisibleForTesting
     public void logToIndexToolOutputTable(byte[] dataRowKey, byte[] indexRowKey, long dataRowTs, long indexRowTs,
-            String errorMsg, byte[] expectedVaue, byte[] actualValue)
+            String errorMsg, byte[] expectedVaue, byte[] actualValue, boolean isBeforeRebuild)
             throws IOException {
         verificationOutputRepository.logToIndexToolOutputTable(dataRowKey, indexRowKey, dataRowTs, indexRowTs,
                 errorMsg, expectedVaue, actualValue, scan.getTimeRange().getMax(),
-                region.getRegionInfo().getTable().getName(), isBeforeRebuilt);
+                region.getRegionInfo().getTable().getName(), isBeforeRebuild);
     }
 
     private static Cell getCell(Mutation m, byte[] family, byte[] qualifier) {
@@ -349,12 +273,12 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
         return null;
     }
 
-    private void logMismatch(Mutation expected, Mutation actual, int iteration, IndexToolVerificationResult.PhaseResult verificationPhaseResult) throws IOException {
+    private void logMismatch(Mutation expected, Mutation actual, int iteration, IndexToolVerificationResult.PhaseResult verificationPhaseResult, boolean isBeforeRebuild) throws IOException {
         if (getTimestamp(expected) != getTimestamp(actual)) {
             String errorMsg = "Not matching timestamp";
             byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(expected.getRow()), viewConstants);
             logToIndexToolOutputTable(dataKey, expected.getRow(), getTimestamp(expected), getTimestamp(actual),
-                    errorMsg, null, null);
+                    errorMsg, null, null, isBeforeRebuild);
             return;
         }
         int expectedCellCount = 0;
@@ -371,7 +295,7 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
                         !CellUtil.matchingType(expectedCell, actualCell)) {
                     byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(expected.getRow()), viewConstants);
                     String errorMsg = "Missing cell (in iteration " + iteration + ") " + Bytes.toString(family) + ":" + Bytes.toString(qualifier);
-                    logToIndexToolOutputTable(dataKey, expected.getRow(), getTimestamp(expected), getTimestamp(actual), errorMsg);
+                    logToIndexToolOutputTable(dataKey, expected.getRow(), getTimestamp(expected), getTimestamp(actual), errorMsg,isBeforeRebuild);
                     verificationPhaseResult.setIndexHasMissingCellsCount(verificationPhaseResult.getIndexHasMissingCellsCount() + 1);
                     return;
                 }
@@ -379,7 +303,7 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
                     String errorMsg = "Not matching value (in iteration " + iteration + ") for " + Bytes.toString(family) + ":" + Bytes.toString(qualifier);
                     byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(expected.getRow()), viewConstants);
                     logToIndexToolOutputTable(dataKey, expected.getRow(), getTimestamp(expected), getTimestamp(actual),
-                            errorMsg, CellUtil.cloneValue(expectedCell), CellUtil.cloneValue(actualCell));
+                            errorMsg, CellUtil.cloneValue(expectedCell), CellUtil.cloneValue(actualCell), isBeforeRebuild);
                     return;
                 }
             }
@@ -395,12 +319,12 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
             String errorMsg = "Index has extra cells (in iteration " + iteration + ")";
             byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(expected.getRow()), viewConstants);
             logToIndexToolOutputTable(dataKey, expected.getRow(), getTimestamp(expected), getTimestamp(actual),
-                    errorMsg);
+                    errorMsg, isBeforeRebuild);
             verificationPhaseResult.setIndexHasExtraCellsCount(verificationPhaseResult.getIndexHasExtraCellsCount() + 1);
         }
     }
 
-    private boolean isMatchingMutation(Mutation expected, Mutation actual) throws IOException {
+    private boolean isMatchingMutation(Mutation expected, Mutation actual) {
         if (getTimestamp(expected) != getTimestamp(actual)) {
             return false;
         }
@@ -508,29 +432,6 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
 
     private void updateUnverifiedIndexRowCounters(Put actual,
                                                   IndexToolVerificationResult.PhaseResult verificationPhaseResult) {
-        // We are given an index row and need to check if this index row is unverified. However, before doing
-        // that we need to check if this index row is the most recent version. To do that, we need to check its data
-        // table row first.
-        // Get the data row key from the index row key
-        byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(actual.getRow()), viewConstants);
-        // Get the data table row mutations using the data row key
-        Pair<Put, Delete> putDeletePair = dataKeyToMutationMap.get(dataKey);
-        Put put = putDeletePair.getFirst();
-        if (put == null) {
-            // The data table row does not exist, so there is nothing to do
-            return;
-        }
-        Delete del = putDeletePair.getSecond();
-        if (del != null && getMaxTimestamp(del) >= getTimestamp(put)) {
-            // The data table row is deleted, i.e., the most recent mutation is delete. So there is nothing to do
-            return;
-        }
-        // Get the index row key from the data table row and check if the given index row has the same row key
-        byte[] indexRowKey = getIndexRowKey(indexMaintainer, put);
-        if (Bytes.compareTo(actual.getRow(), 0, actual.getRow().length,
-                indexRowKey, 0, indexRowKey.length) != 0) {
-            return;
-        }
         // Get the empty column of the given index row
         List<Cell> cellList = actual.get(indexMaintainer.getEmptyKeyValueFamily().copyBytesIfNecessary(),
                 indexMaintainer.getEmptyKeyValueQualifier());
@@ -608,9 +509,9 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
                     (mutation instanceof Delete && !isDeleteFamily(mutation))) {
                 iterator.remove();
             } else {
-                if (previous != null && getTimestamp(previous) == getTimestamp(mutation) &&
-                        ((previous instanceof Put && mutation instanceof Put) ||
-                                previous instanceof Delete && mutation instanceof Delete)) {
+                if (((previous instanceof Put && mutation instanceof Put) ||
+                                previous instanceof Delete && mutation instanceof Delete) &&
+                        isMatchingMutation(previous, mutation)) {
                     iterator.remove();
                 } else {
                     previous = mutation;
@@ -687,9 +588,12 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
      */
 
     @VisibleForTesting
-    public boolean verifySingleIndexRow(Result indexRow, IndexToolVerificationResult.PhaseResult verificationPhaseResult)
+    public boolean verifySingleIndexRow(Result indexRow, Map<byte[], List<Mutation>> perTaskIndexKeyToMutationMap,
+                                        Set<byte[]> mostRecentIndexRowKeys,
+                                        IndexToolVerificationResult.PhaseResult verificationPhaseResult,
+                                        boolean isBeforeRebuild)
             throws IOException {
-        List<Mutation> expectedMutationList = indexKeyToMutationMap.get(indexRow.getRow());
+        List<Mutation> expectedMutationList = perTaskIndexKeyToMutationMap.get(indexRow.getRow());
         if (expectedMutationList == null) {
             throw new DoNotRetryIOException(NO_EXPECTED_MUTATION);
         }
@@ -700,7 +604,8 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
         Collections.sort(expectedMutationList, MUTATION_TS_DESC_COMPARATOR);
         Collections.sort(actualMutationList, MUTATION_TS_DESC_COMPARATOR);
         if (verifyType == IndexTool.IndexVerifyType.ONLY) {
-            if (actualMutationList.get(0) instanceof Put) {
+            Mutation m = actualMutationList.get(0);
+            if (m instanceof Put && mostRecentIndexRowKeys.contains(m.getRow())) {
                 // We do check here only the latest version as older versions will always be unverified before
                 // newer versions are inserted.
                 updateUnverifiedIndexRowCounters((Put) actualMutationList.get(0), verificationPhaseResult);
@@ -804,27 +709,33 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
                     actualSize);
             logToIndexToolOutputTable(dataKey, indexRow.getRow(),
                     getTimestamp(expectedMutationList.get(expectedIndex)),
-                    0, errorMsg);
+                    0, errorMsg, isBeforeRebuild);
             return false;
         }
         else {
             if (actualIndex < actualSize && actual instanceof Put  &&  expected instanceof Put){
-                logMismatch(expected, actual, expectedIndex, verificationPhaseResult);
+                logMismatch(expected, actual, expectedIndex, verificationPhaseResult, isBeforeRebuild);
             }
             else {
                 byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(indexRow.getRow()), viewConstants);
                 String errorMsg = "Not matching index row";
                 logToIndexToolOutputTable(dataKey, indexRow.getRow(),
-                        getTimestamp(expectedMutationList.get(0)), 0L, errorMsg);
+                        getTimestamp(expectedMutationList.get(0)), 0L, errorMsg, isBeforeRebuild);
             }
             verificationPhaseResult.setInvalidIndexRowCount(verificationPhaseResult.getInvalidIndexRowCount() + 1);
             return false;
         }
     }
 
-    private void verifyIndexRows(List<KeyRange> keys,
-            IndexToolVerificationResult.PhaseResult verificationPhaseResult) throws IOException {
-        List<KeyRange> invalidKeys = new ArrayList<>();
+    private void verifyIndexRows(Map<byte[], List<Mutation>> indexKeyToMutationMap,
+                                 Set<byte[]> mostRecentIndexRowKeys,
+                                 IndexToolVerificationResult.PhaseResult verificationPhaseResult,
+                                 boolean isBeforeRebuild) throws IOException {
+        List<KeyRange> keys = new ArrayList<>(indexKeyToMutationMap.size());
+        for (byte[] indexKey: indexKeyToMutationMap.keySet()) {
+            keys.add(PVarbinary.INSTANCE.getKeyRange(indexKey));
+        }
+        Map<byte[], List<Mutation>> invalidIndexRows = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
         ScanRanges scanRanges = ScanRanges.createPointLookup(keys);
         Scan indexScan = new Scan();
         indexScan.setTimeRange(scan.getTimeRange().getMin(), scan.getTimeRange().getMax());
@@ -836,74 +747,122 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
         indexScan.setCacheBlocks(false);
         try (ResultScanner resultScanner = indexHTable.getScanner(indexScan)) {
             for (Result result = resultScanner.next(); (result != null); result = resultScanner.next()) {
-                KeyRange keyRange = PVarbinary.INSTANCE.getKeyRange(result.getRow());
-                if (!keys.contains(keyRange)) {
-                    continue;
+                if (!verifySingleIndexRow(result, indexKeyToMutationMap, mostRecentIndexRowKeys,
+                        verificationPhaseResult, isBeforeRebuild)) {
+                    invalidIndexRows.put(result.getRow(), indexKeyToMutationMap.get(result.getRow()));
                 }
-                if (!verifySingleIndexRow(result, verificationPhaseResult)) {
-                    invalidKeys.add(keyRange);
-                }
-                keys.remove(keyRange);
+                indexKeyToMutationMap.remove(result.getRow());
             }
         } catch (Throwable t) {
             ServerUtil.throwIOException(indexHTable.getName().toString(), t);
         }
+        List<byte[]> expiredIndexRows = new ArrayList<>();
         // Check if any expected rows from index(which we didn't get) are already expired due to TTL
         // TODO: metrics for expired rows
-        if (!keys.isEmpty()) {
-            Iterator<KeyRange> itr = keys.iterator();
-            long currentTime = EnvironmentEdgeManager.currentTimeMillis();
-            while(itr.hasNext()) {
-                KeyRange keyRange = itr.next();
-                byte[] key = keyRange.getLowerRange();
-                List<Mutation> mutationList = indexKeyToMutationMap.get(key);
-                if (isTimestampBeforeTTL(indexTableTTL, currentTime, getTimestamp(mutationList.get(mutationList.size() - 1)))) {
-                    itr.remove();
-                    verificationPhaseResult.setExpiredIndexRowCount(verificationPhaseResult.getExpiredIndexRowCount() + 1);
-                }
+        long currentTime = EnvironmentEdgeManager.currentTimeMillis();
+        for (Map.Entry<byte[], List<Mutation>> entry: indexKeyToMutationMap.entrySet()) {
+            List<Mutation> mutationList = entry.getValue();
+            if (isTimestampBeforeTTL(indexTableTTL, currentTime, getTimestamp(mutationList.get(mutationList.size() - 1)))) {
+                verificationPhaseResult.setExpiredIndexRowCount(verificationPhaseResult.getExpiredIndexRowCount() + 1);
+                expiredIndexRows.add(entry.getKey());
             }
         }
-        if (keys.size() > 0) {
-            for (KeyRange keyRange : keys) {
-                byte[] key = keyRange.getLowerRange();
-                List<Mutation> mutationList = indexKeyToMutationMap.get(key);
-                Mutation mutation = mutationList.get(mutationList.size() - 1);
-                if (mutation instanceof Delete) {
-                    continue;
-                }
-                long currentTime = EnvironmentEdgeManager.currentTimeMillis();
-                String errorMsg;
-                if (isTimestampBeyondMaxLookBack(maxLookBackInMills, currentTime, getTimestamp(mutation))){
-                    errorMsg = ERROR_MESSAGE_MISSING_INDEX_ROW_BEYOND_MAX_LOOKBACK;
-                    verificationPhaseResult.
-                            setBeyondMaxLookBackMissingIndexRowCount(verificationPhaseResult.getBeyondMaxLookBackMissingIndexRowCount() + 1);
-                }
-                else {
-                    errorMsg = ERROR_MESSAGE_MISSING_INDEX_ROW;
-                    verificationPhaseResult.setMissingIndexRowCount(verificationPhaseResult.getMissingIndexRowCount() + 1);
-                }
-                byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(keyRange.getLowerRange()), viewConstants);
-                logToIndexToolOutputTable(dataKey,
-                        keyRange.getLowerRange(),
-                        getMaxTimestamp(dataKeyToMutationMap.get(dataKey)),
-                        getTimestamp(mutation), errorMsg);
-            }
+        // Remove the expired rows from indexKeyToMutationMap
+        for (byte[] indexKey : expiredIndexRows) {
+            indexKeyToMutationMap.remove(indexKey);
         }
-
-        keys.addAll(invalidKeys);
+        // Count and log missing rows
+        for (Map.Entry<byte[], List<Mutation>> entry: indexKeyToMutationMap.entrySet()) {
+            byte[] indexKey = entry.getKey();
+            List<Mutation> mutationList = entry.getValue();
+            Mutation mutation = mutationList.get(mutationList.size() - 1);
+            if (mutation instanceof Delete) {
+                continue;
+            }
+            currentTime = EnvironmentEdgeManager.currentTimeMillis();
+            String errorMsg;
+            if (isTimestampBeyondMaxLookBack(maxLookBackInMills, currentTime, getTimestamp(mutation))){
+                errorMsg = ERROR_MESSAGE_MISSING_INDEX_ROW_BEYOND_MAX_LOOKBACK;
+                verificationPhaseResult.
+                        setBeyondMaxLookBackMissingIndexRowCount(verificationPhaseResult.getBeyondMaxLookBackMissingIndexRowCount() + 1);
+            }
+            else {
+                errorMsg = ERROR_MESSAGE_MISSING_INDEX_ROW;
+                verificationPhaseResult.setMissingIndexRowCount(verificationPhaseResult.getMissingIndexRowCount() + 1);
+            }
+            byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(indexKey), viewConstants);
+            logToIndexToolOutputTable(dataKey, indexKey, getTimestamp(mutation), 0, errorMsg, isBeforeRebuild);
+        }
+        // Leave the invalid and missing rows in indexKeyToMutationMap
+        indexKeyToMutationMap.putAll(invalidIndexRows);
     }
 
-    private void addVerifyTask(final List<KeyRange> keys,
-            final IndexToolVerificationResult.PhaseResult verificationPhaseResult) {
+    private void rebuildIndexRows(Map<byte[], List<Mutation>> indexKeyToMutationMap,
+                                  IndexToolVerificationResult verificationResult) throws IOException {
+        if (ignoreIndexRebuildForTesting) {
+            return;
+        }
+        try {
+            int batchSize = 0;
+            List<Mutation> indexUpdates = new ArrayList<Mutation>(maxBatchSize);
+            for (List<Mutation> mutationList : indexKeyToMutationMap.values()) {
+                indexUpdates.addAll(mutationList);
+                batchSize += mutationList.size();
+                if (batchSize >= maxBatchSize) {
+                    indexHTable.batch(indexUpdates);
+                    batchSize = 0;
+                    indexUpdates = new ArrayList<Mutation>(maxBatchSize);
+                }
+            }
+            if (batchSize > 0) {
+                indexHTable.batch(indexUpdates);
+            }
+            if (verify) {
+                verificationResult.setRebuiltIndexRowCount(verificationResult.getRebuiltIndexRowCount() + indexKeyToMutationMap.size());
+            }
+        } catch (Throwable t) {
+            ServerUtil.throwIOException(indexHTable.getName().toString(), t);
+        }
+    }
+
+    private void rebuildAndOrVerifyIndexRows(Map<byte[], List<Mutation>> indexKeyToMutationMap,
+                                             Set<byte[]> mostRecentIndexRowKeys,
+                                             IndexToolVerificationResult verificationResult) throws IOException {
+        if (verifyType == IndexTool.IndexVerifyType.NONE) {
+            rebuildIndexRows(indexKeyToMutationMap, verificationResult);
+        } else if (verifyType == IndexTool.IndexVerifyType.ONLY) {
+            verifyIndexRows(indexKeyToMutationMap, mostRecentIndexRowKeys, verificationResult.getBefore(), true);
+        } else if (verifyType == IndexTool.IndexVerifyType.BEFORE) {
+            verifyIndexRows(indexKeyToMutationMap, mostRecentIndexRowKeys, verificationResult.getBefore(), true);
+            if (!indexKeyToMutationMap.isEmpty()) {
+                rebuildIndexRows(indexKeyToMutationMap, verificationResult);
+            }
+        } else if (verifyType == IndexTool.IndexVerifyType.AFTER) {
+            rebuildIndexRows(indexKeyToMutationMap, verificationResult);
+            verifyIndexRows(indexKeyToMutationMap, mostRecentIndexRowKeys, verificationResult.getAfter(), false);
+        } else { // verifyType == IndexTool.IndexVerifyType.BOTH
+            verifyIndexRows(indexKeyToMutationMap, mostRecentIndexRowKeys, verificationResult.getBefore(), true);
+            if (!indexKeyToMutationMap.isEmpty()) {
+                rebuildIndexRows(indexKeyToMutationMap, verificationResult);
+                verifyIndexRows(indexKeyToMutationMap, mostRecentIndexRowKeys, verificationResult.getAfter(), false);
+            }
+        }
+    }
+
+    private void addRebuildAndOrVerifyTask(TaskBatch<Boolean> tasks,
+                                           final Map<byte[], List<Mutation>> indexKeyToMutationMap,
+                                           final Set<byte[]> mostRecentIndexRowKeys,
+                                           final IndexToolVerificationResult verificationResult) {
         tasks.add(new Task<Boolean>() {
             @Override
             public Boolean call() throws Exception {
                 try {
-                    if (Thread.currentThread().isInterrupted()) {
-                        exceptionMessage = "Pool closed, not attempting to verify index rows! " + indexHTable.getName();
+                    if (Thread.currentThread().isInterrupted() || env.getRegionServerServices().isAborted() ||
+                            env.getRegionServerServices().isStopped()) {
+                        exceptionMessage = "Pool closed, not attempting to rebuild and/or verify index rows! " + indexHTable.getName();
                         throw new IOException(exceptionMessage);
                     }
-                    verifyIndexRows(keys, verificationPhaseResult);
+                    rebuildAndOrVerifyIndexRows(indexKeyToMutationMap, mostRecentIndexRowKeys, verificationResult);
                 } catch (Exception e) {
                     throw e;
                 }
@@ -912,31 +871,10 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
         });
     }
 
-    private void parallelizeIndexVerify(IndexToolVerificationResult.PhaseResult verificationPhaseResult) throws IOException {
-        int taskCount = (indexKeyToMutationMap.size() + rowCountPerTask - 1) / rowCountPerTask;
-        tasks = new TaskBatch<>(taskCount);
-        List<List<KeyRange>> listOfKeyRangeList = new ArrayList<>(taskCount);
-        List<IndexToolVerificationResult.PhaseResult> verificationPhaseResultList = new ArrayList<>(taskCount);
-        List<KeyRange> keys = new ArrayList<>(rowCountPerTask);
-        listOfKeyRangeList.add(keys);
-        IndexToolVerificationResult.PhaseResult perTaskVerificationPhaseResult = new IndexToolVerificationResult.PhaseResult();
-        verificationPhaseResultList.add(perTaskVerificationPhaseResult);
-        for (byte[] indexKey: indexKeyToMutationMap.keySet()) {
-            keys.add(PVarbinary.INSTANCE.getKeyRange(indexKey));
-            if (keys.size() == rowCountPerTask) {
-                addVerifyTask(keys, perTaskVerificationPhaseResult);
-                keys = new ArrayList<>(rowCountPerTask);
-                listOfKeyRangeList.add(keys);
-                perTaskVerificationPhaseResult = new IndexToolVerificationResult.PhaseResult();
-                verificationPhaseResultList.add(perTaskVerificationPhaseResult);
-            }
-        }
-        if (keys.size() > 0) {
-            addVerifyTask(keys, perTaskVerificationPhaseResult);
-        }
+    private void submitTasks(TaskBatch<Boolean> tasks) throws IOException{
         Pair<List<Boolean>, List<Future<Boolean>>> resultsAndFutures = null;
         try {
-            LOGGER.debug("Waiting on index verify tasks to complete...");
+            LOGGER.debug("Waiting on index verify and/or rebuild tasks to complete...");
             resultsAndFutures = this.pool.submitUninterruptible(tasks);
         } catch (ExecutionException e) {
             throw new RuntimeException("Should not fail on the results while using a WaitForCompletionTaskRunner", e);
@@ -952,111 +890,89 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
             }
             index++;
         }
-        for (IndexToolVerificationResult.PhaseResult result : verificationPhaseResultList) {
-            verificationPhaseResult.add(result);
-        }
-        if (verifyType == IndexTool.IndexVerifyType.BEFORE || verifyType == IndexTool.IndexVerifyType.BOTH) {
-            Map<byte[], Pair<Put, Delete>> newDataKeyToMutationMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-            for (List<KeyRange> keyRangeList : listOfKeyRangeList) {
-                for (KeyRange keyRange : keyRangeList) {
-                    byte[] dataKey = indexMaintainer.buildDataRowKey(new ImmutableBytesWritable(keyRange.getLowerRange()), viewConstants);
-                    newDataKeyToMutationMap.put(dataKey, dataKeyToMutationMap.get(dataKey));
-                }
-            }
-            dataKeyToMutationMap.clear();
-            dataKeyToMutationMap = newDataKeyToMutationMap;
-        }
     }
 
-    private void rebuildIndexRows(UngroupedAggregateRegionObserver.MutationList mutationList) throws IOException {
-        byte[] uuidValue = ServerCacheClient.generateId();
-        UngroupedAggregateRegionObserver.MutationList currentMutationList =
-                new UngroupedAggregateRegionObserver.MutationList(maxBatchSize);
-        Put put = null;
-        for (Mutation mutation : mutationList) {
-            if (mutation instanceof Put) {
-                if (put != null) {
-                    // back to back put, i.e., no delete in between. we can commit the previous put
-                    uuidValue = commitIfReady(uuidValue, currentMutationList);
-                }
-                currentMutationList.add(mutation);
-                setMutationAttributes(mutation, uuidValue);
-                put = (Put)mutation;
-            } else {
-                currentMutationList.add(mutation);
-                setMutationAttributes(mutation, uuidValue);
-                uuidValue = commitIfReady(uuidValue, currentMutationList);
-                put = null;
+    public static List<Map<byte[], List<Mutation>>> getPerTaskIndexKeyToMutationMaps(
+            Map<byte[], List<Mutation>> indexKeyToMutationMap, int splitSize) {
+        int splitCount = (indexKeyToMutationMap.size() + splitSize - 1) / splitSize;
+        List<Map<byte[], List<Mutation>>> mapList = new ArrayList<>(splitCount);
+        Map<byte[], List<Mutation>> perTaskIndexKeyToMutationMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+        mapList.add(perTaskIndexKeyToMutationMap);
+        for (Map.Entry<byte[], List<Mutation>> entry: indexKeyToMutationMap.entrySet()) {
+            if (perTaskIndexKeyToMutationMap.size() == splitSize) {
+                perTaskIndexKeyToMutationMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+                mapList.add(perTaskIndexKeyToMutationMap);
             }
+            perTaskIndexKeyToMutationMap.put(entry.getKey(), entry.getValue());
         }
-        if (!currentMutationList.isEmpty()) {
-            ungroupedAggregateRegionObserver.checkForRegionClosing();
-            ungroupedAggregateRegionObserver.commitBatchWithRetries(region, currentMutationList, blockingMemstoreSize);
-        }
+        return mapList;
     }
 
-    private void verifyAndOrRebuildIndex() throws IOException {
-        isBeforeRebuilt = true;
-        IndexToolVerificationResult nextVerificationResult = new IndexToolVerificationResult(scan);
-        nextVerificationResult.setScannedDataRowCount(dataKeyToMutationMap.size());
-        if (verifyType == IndexTool.IndexVerifyType.AFTER || verifyType == IndexTool.IndexVerifyType.NONE) {
-            // For these options we start with rebuilding index rows
-            rebuildIndexRows(mutations);
-            nextVerificationResult.setRebuiltIndexRowCount(dataKeyToMutationMap.size());
-            isBeforeRebuilt = false;
+    public static List<Map<byte[], List<Mutation>>> getPerTaskIndexKeyToMutationMaps(
+            TreeMap<byte[], List<Mutation>> indexKeyToMutationMap, byte[][] endKeys, int maxMapSize) {
+        List<Map<byte[], List<Mutation>>> mapList = new ArrayList<>();
+        int regionCount = endKeys.length;
+        int regionIndex = 0;
+        byte[] indexKey = indexKeyToMutationMap.firstKey();
+        while (regionIndex < regionCount) {
+            Map<byte[], List<Mutation>> perTaskIndexKeyToMutationMap;
+            // Find the region including indexKey
+            while (regionIndex < regionCount - 1 && Bytes.compareTo(indexKey, endKeys[regionIndex]) != 1) {
+                regionIndex++;
+            }
+            if (regionIndex == regionCount - 1) {
+                perTaskIndexKeyToMutationMap = indexKeyToMutationMap.subMap(indexKey,
+                        true, indexKeyToMutationMap.lastKey(), true);
+            }
+            else {
+                perTaskIndexKeyToMutationMap = indexKeyToMutationMap.subMap(indexKey,
+                        true, endKeys[regionIndex], true);
+            }
+            if (perTaskIndexKeyToMutationMap.size() > maxMapSize) {
+                // Further partition this map
+                mapList.addAll(getPerTaskIndexKeyToMutationMaps(perTaskIndexKeyToMutationMap, maxMapSize));
+            }
+            else {
+                mapList.add(perTaskIndexKeyToMutationMap);
+            }
+            if (regionIndex == regionCount - 1) {
+                break;
+            }
+            indexKey = indexKeyToMutationMap.higherKey(endKeys[regionIndex]);
+            regionIndex++;
         }
-        if (verifyType == IndexTool.IndexVerifyType.NONE) {
+        return mapList;
+    }
+
+    private void verifyAndOrRebuildIndex(Map<byte[], List<Mutation>> indexKeyToMutationMap,
+                                         Set<byte[]> mostRecentIndexRowKeys) throws IOException {
+        if (indexKeyToMutationMap.size() == 0) {
             return;
         }
-        if (verifyType == IndexTool.IndexVerifyType.BEFORE || verifyType == IndexTool.IndexVerifyType.BOTH ||
-                verifyType == IndexTool.IndexVerifyType.ONLY) {
-            IndexToolVerificationResult.PhaseResult verificationPhaseResult = new IndexToolVerificationResult.PhaseResult();
-            // For these options we start with verifying index rows
-            parallelizeIndexVerify(verificationPhaseResult);
-            nextVerificationResult.getBefore().add(verificationPhaseResult);
-        }
-        if (verifyType == IndexTool.IndexVerifyType.BEFORE || verifyType == IndexTool.IndexVerifyType.BOTH) {
-            // For these options, we have identified the rows to be rebuilt and now need to rebuild them
-            // At this point, dataKeyToDataPutMap includes mapping only for the rows to be rebuilt
-            mutations.clear();
-
-            for (Map.Entry<byte[], Pair<Put, Delete>> entry: dataKeyToMutationMap.entrySet()) {
-                if (entry.getValue().getFirst() != null) {
-                    mutations.add(entry.getValue().getFirst());
-                }
-                if (entry.getValue().getSecond() != null) {
-                    mutations.add(entry.getValue().getSecond());
-                }
+        if (verifyType != IndexTool.IndexVerifyType.ONLY) {
+            // Since we are building the index table, the region boundaries may change while we are building. Thus,
+            // we should update endKeys
+            try (org.apache.hadoop.hbase.client.Connection connection =
+                         HBaseFactoryProvider.getHConnectionFactory().createConnection(env.getConfiguration())) {
+                endKeys = connection.getRegionLocator(indexHTable.getName()).getEndKeys();
             }
-            rebuildIndexRows(mutations);
-            nextVerificationResult.setRebuiltIndexRowCount(nextVerificationResult.getRebuiltIndexRowCount() + dataKeyToMutationMap.size());
-            isBeforeRebuilt = false;
         }
-
-        if (verifyType == IndexTool.IndexVerifyType.AFTER || verifyType == IndexTool.IndexVerifyType.BOTH) {
-            // We have rebuilt index row and now we need to verify them
-            IndexToolVerificationResult.PhaseResult verificationPhaseResult = new IndexToolVerificationResult.PhaseResult();
-            indexKeyToMutationMap.clear();
-            for (Map.Entry<byte[], Pair<Put, Delete>> entry: dataKeyToMutationMap.entrySet()) {
-                prepareIndexMutations(entry.getValue().getFirst(), entry.getValue().getSecond());
+        List<Map<byte[], List<Mutation>>> mapList = getPerTaskIndexKeyToMutationMaps((TreeMap)indexKeyToMutationMap,
+                endKeys, rowCountPerTask);
+        int taskCount = mapList.size();
+        TaskBatch<Boolean> tasks = new TaskBatch<>(taskCount);
+        List<IndexToolVerificationResult> verificationResultList = new ArrayList<>(taskCount);
+        for (int i = 0; i < taskCount; i++) {
+            IndexToolVerificationResult perTaskVerificationResult = new IndexToolVerificationResult(scan);
+            verificationResultList.add(perTaskVerificationResult);
+            addRebuildAndOrVerifyTask(tasks, mapList.get(i), mostRecentIndexRowKeys, perTaskVerificationResult);
+        }
+        submitTasks(tasks);
+        if (verify) {
+            for (IndexToolVerificationResult result : verificationResultList) {
+                verificationResult.add(result);
             }
-            parallelizeIndexVerify(verificationPhaseResult);
-            nextVerificationResult.getAfter().add(verificationPhaseResult);
         }
-        verificationResult.add(nextVerificationResult);
-    }
-
-    private boolean isColumnIncluded(Cell cell) {
-        byte[] family = CellUtil.cloneFamily(cell);
-        if (!familyMap.containsKey(family)) {
-            return false;
-        }
-        NavigableSet<byte[]> set = familyMap.get(family);
-        if (set == null || set.isEmpty()) {
-            return true;
-        }
-        byte[] qualifier = CellUtil.cloneQualifier(cell);
-        return set.contains(qualifier);
     }
 
     /**
@@ -1277,12 +1193,24 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
     }
 
     @VisibleForTesting
-    public int prepareIndexMutations(Put put, Delete del) throws IOException {
+    public int prepareIndexMutations(Put put, Delete del, Map<byte[], List<Mutation>> indexKeyToMutationMap,
+                                     Set<byte[]> mostRecentIndexRowKeys) throws IOException {
         List<Mutation> indexMutations = prepareIndexMutationsForRebuild(indexMaintainer, put, del);
+        boolean mostRecentDone = false;
+        // Do not populate mostRecentIndexRowKeys when verifyType != IndexTool.IndexVerifyType.ONLY
+        if (verifyType != IndexTool.IndexVerifyType.ONLY) {
+            mostRecentDone = true;
+        }
         for (Mutation mutation : indexMutations) {
             byte[] indexRowKey = mutation.getRow();
             List<Mutation> mutationList = indexKeyToMutationMap.get(indexRowKey);
             if (mutationList == null) {
+                if (!mostRecentDone) {
+                    if (mutation instanceof Put) {
+                        mostRecentIndexRowKeys.add(indexRowKey);
+                        mostRecentDone = true;
+                    }
+                }
                 mutationList = new ArrayList<>();
                 mutationList.add(mutation);
                 indexKeyToMutationMap.put(indexRowKey, mutationList);
@@ -1290,7 +1218,7 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
                 mutationList.add(mutation);
             }
         }
-        return 0;
+        return indexMutations.size();
     }
 
     @Override
@@ -1304,11 +1232,13 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
             results.add(aggKeyValue);
             return false;
         }
+        Map<byte[], List<Mutation>> indexKeyToMutationMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+        Set<byte[]> mostRecentIndexRowKeys = new TreeSet<>(Bytes.BYTES_COMPARATOR);
         Cell lastCell = null;
-        int rowCount = 0;
+        int dataRowCount = 0;
+        int indexMutationCount = 0;
         region.startRegionOperation();
         try {
-            byte[] uuidValue = ServerCacheClient.generateId();
             synchronized (innerScanner) {
                 if(!shouldVerify()) {
                     skipped = true;
@@ -1323,7 +1253,7 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
                         Delete del = null;
                         for (Cell cell : row) {
                             if (KeyValue.Type.codeToType(cell.getTypeByte()) == KeyValue.Type.Put) {
-                                if (!partialRebuild && familyMap != null && !isColumnIncluded(cell)) {
+                                if (familyMap != null && !isColumnIncluded(cell)) {
                                     continue;
                                 }
                                 if (put == null) {
@@ -1340,37 +1270,19 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
                         if (put == null && del == null) {
                             continue;
                         }
-                        // Always add the put first and then delete for a given row. This simplifies the logic in
-                        // IndexRegionObserver
-                        if (put != null) {
-                            mutations.add(put);
-                        }
-                        if (del != null) {
-                            mutations.add(del);
-                        }
-                        if (!verify) {
-                            if (put != null) {
-                                setMutationAttributes(put, uuidValue);
-                            }
-                            if (del != null) {
-                                setMutationAttributes(del, uuidValue);
-                            }
-                            uuidValue = commitIfReady(uuidValue, mutations);
-                        } else {
-                            byte[] dataKey = (put != null) ? put.getRow() : del.getRow();
-                            prepareIndexMutations(put, del);
-                            dataKeyToMutationMap.put(dataKey, new Pair<Put, Delete>(put, del));
-                        }
-                        rowCount++;
+                        indexMutationCount += prepareIndexMutations(put, del, indexKeyToMutationMap, mostRecentIndexRowKeys);
+                        dataRowCount++;
                     }
-                } while (hasMore && rowCount < pageSizeInRows);
-                if (!mutations.isEmpty()) {
-                    if (verify) {
-                        verifyAndOrRebuildIndex();
+                } while (hasMore && indexMutationCount < pageSizeInRows);
+                if (!indexKeyToMutationMap.isEmpty()) {
+                    if (indexRowKey != null) {
+                        rebuildIndexRows(indexKeyToMutationMap, verificationResult);
                     } else {
-                        ungroupedAggregateRegionObserver.checkForRegionClosing();
-                        ungroupedAggregateRegionObserver.commitBatchWithRetries(region, mutations, blockingMemstoreSize);
+                        verifyAndOrRebuildIndex(indexKeyToMutationMap, mostRecentIndexRowKeys);
                     }
+                }
+                if (verify) {
+                    verificationResult.setScannedDataRowCount(verificationResult.getScannedDataRowCount() + dataRowCount);
                 }
             }
         } catch (Throwable e) {
@@ -1379,16 +1291,11 @@ public class IndexRebuildRegionScanner extends GlobalIndexRegionScanner {
             throw e;
         } finally {
             region.closeRegionOperation();
-            mutations.clear();
-            if (verify) {
-                dataKeyToMutationMap.clear();
-                indexKeyToMutationMap.clear();
-            }
         }
         if (indexRowKey != null) {
-            rowCount = singleRowRebuildReturnCode;
+            dataRowCount = singleRowRebuildReturnCode;
         }
-        byte[] rowCountBytes = PLong.INSTANCE.toBytes(Long.valueOf(rowCount));
+        byte[] rowCountBytes = PLong.INSTANCE.toBytes(Long.valueOf(dataRowCount));
         final Cell aggKeyValue;
         if (lastCell == null) {
             aggKeyValue = KeyValueUtil.newKeyValue(UNGROUPED_AGG_ROW_KEY, SINGLE_COLUMN_FAMILY,

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/IndexerRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/IndexerRegionScanner.java
@@ -39,6 +39,9 @@ import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.KeyValue;
 
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -50,6 +53,7 @@ import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.Pair;
+import org.apache.phoenix.cache.ServerCacheClient;
 import org.apache.phoenix.compile.ScanRanges;
 import org.apache.phoenix.filter.SkipScanFilter;
 import org.apache.phoenix.hbase.index.ValueGetter;
@@ -58,6 +62,7 @@ import org.apache.phoenix.hbase.index.parallel.Task;
 import org.apache.phoenix.hbase.index.parallel.TaskBatch;
 import org.apache.phoenix.hbase.index.util.GenericKeyValueBuilder;
 
+import org.apache.phoenix.index.PhoenixIndexCodec;
 import org.apache.phoenix.mapreduce.index.IndexTool;
 import org.apache.phoenix.mapreduce.index.IndexVerificationResultRepository;
 import org.apache.phoenix.query.KeyRange;
@@ -75,14 +80,26 @@ public class IndexerRegionScanner extends GlobalIndexRegionScanner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexerRegionScanner.class);
     protected Map<byte[], Put> indexKeyToDataPutMap;
+    protected UngroupedAggregateRegionObserver.MutationList mutations;
+    private boolean partialRebuild = false;
+    private UngroupedAggregateRegionObserver ungroupedAggregateRegionObserver;
 
     IndexerRegionScanner (final RegionScanner innerScanner, final Region region, final Scan scan,
-            final RegionCoprocessorEnvironment env) throws IOException {
+                          final RegionCoprocessorEnvironment env,
+                          UngroupedAggregateRegionObserver ungroupedAggregateRegionObserver) throws IOException {
         super(innerScanner, region, scan, env);
-        indexKeyToDataPutMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-        verificationResult = new IndexToolVerificationResult(scan);
-        verificationResultRepository =
-                new IndexVerificationResultRepository(indexMaintainer.getIndexTableName(), hTableFactory);
+        this.ungroupedAggregateRegionObserver = ungroupedAggregateRegionObserver;
+        if (scan.getAttribute(BaseScannerRegionObserver.INDEX_REBUILD_PAGING) == null) {
+            partialRebuild = true;
+        }
+        if (verify) {
+            indexKeyToDataPutMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+            verificationResult = new IndexToolVerificationResult(scan);
+            verificationResultRepository =
+                    new IndexVerificationResultRepository(indexMaintainer.getIndexTableName(), hTableFactory);
+        } else {
+            mutations = new UngroupedAggregateRegionObserver.MutationList(maxBatchSize);
+        }
     }
 
     @Override
@@ -97,13 +114,17 @@ public class IndexerRegionScanner extends GlobalIndexRegionScanner {
     public void close() throws IOException {
         innerScanner.close();
         try {
-            verificationResultRepository.logToIndexToolResultTable(verificationResult,
-                    IndexTool.IndexVerifyType.ONLY, region.getRegionInfo().getRegionName());
+            if (verify) {
+                verificationResultRepository.logToIndexToolResultTable(verificationResult,
+                        IndexTool.IndexVerifyType.ONLY, region.getRegionInfo().getRegionName());
+            }
         } finally {
             this.pool.stop("IndexerRegionScanner is closing");
             hTableFactory.shutdown();
             indexHTable.close();
-            verificationResultRepository.close();
+            if (verify) {
+                verificationResultRepository.close();
+            }
         }
     }
 
@@ -222,7 +243,7 @@ public class IndexerRegionScanner extends GlobalIndexRegionScanner {
         }
     }
 
-    private void addVerifyTask(final List<KeyRange> keys, final Map<byte[], Put> perTaskDataKeyToDataPutMap,
+    private void addVerifyTask(TaskBatch<Boolean> tasks, final List<KeyRange> keys, final Map<byte[], Put> perTaskDataKeyToDataPutMap,
             final IndexToolVerificationResult.PhaseResult verificationPhaseResult) {
         tasks.add(new Task<Boolean>() {
             @Override
@@ -243,7 +264,7 @@ public class IndexerRegionScanner extends GlobalIndexRegionScanner {
 
     private void parallelizeIndexVerify(IndexToolVerificationResult.PhaseResult verificationPhaseResult) throws IOException {
         int taskCount = (indexKeyToDataPutMap.size() + rowCountPerTask - 1) / rowCountPerTask;
-        tasks = new TaskBatch<>(taskCount);
+        TaskBatch<Boolean> tasks = new TaskBatch<>(taskCount);
 
         List<Map<byte[], Put>> dataPutMapList = new ArrayList<>(taskCount);
         List<IndexToolVerificationResult.PhaseResult> verificationPhaseResultList = new ArrayList<>(taskCount);
@@ -260,7 +281,7 @@ public class IndexerRegionScanner extends GlobalIndexRegionScanner {
             keys.add(PVarbinary.INSTANCE.getKeyRange(entry.getKey()));
             perTaskDataKeyToDataPutMap.put(entry.getValue().getRow(), entry.getValue());
             if (keys.size() == rowCountPerTask) {
-                addVerifyTask(keys, perTaskDataKeyToDataPutMap, perTaskVerificationPhaseResult);
+                addVerifyTask(tasks, keys, perTaskDataKeyToDataPutMap, perTaskVerificationPhaseResult);
                 keys = new ArrayList<>(rowCountPerTask);
                 perTaskDataKeyToDataPutMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
                 dataPutMapList.add(perTaskDataKeyToDataPutMap);
@@ -269,7 +290,7 @@ public class IndexerRegionScanner extends GlobalIndexRegionScanner {
             }
         }
         if (keys.size() > 0) {
-            addVerifyTask(keys, perTaskDataKeyToDataPutMap, perTaskVerificationPhaseResult);
+            addVerifyTask(tasks, keys, perTaskDataKeyToDataPutMap, perTaskVerificationPhaseResult);
         }
         Pair<List<Boolean>, List<Future<Boolean>>> resultsAndFutures = null;
         try {
@@ -305,6 +326,26 @@ public class IndexerRegionScanner extends GlobalIndexRegionScanner {
         verificationResult.add(nextVerificationResult);
     }
 
+    private void setMutationAttributes(Mutation m, byte[] uuidValue) {
+        m.setAttribute(useProto ? PhoenixIndexCodec.INDEX_PROTO_MD : PhoenixIndexCodec.INDEX_MD, indexMetaData);
+        m.setAttribute(PhoenixIndexCodec.INDEX_UUID, uuidValue);
+        m.setAttribute(BaseScannerRegionObserver.REPLAY_WRITES,
+                BaseScannerRegionObserver.REPLAY_INDEX_REBUILD_WRITES);
+        m.setAttribute(BaseScannerRegionObserver.CLIENT_VERSION, clientVersionBytes);
+        // Since we're replaying existing mutations, it makes no sense to write them to the wal
+        m.setDurability(Durability.SKIP_WAL);
+    }
+
+    private byte[] commitIfReady(byte[] uuidValue, UngroupedAggregateRegionObserver.MutationList mutationList) throws IOException {
+        if (ServerUtil.readyToCommit(mutationList.size(), mutationList.byteSize(), maxBatchSize, maxBatchSizeBytes)) {
+            ungroupedAggregateRegionObserver.checkForRegionClosing();
+            ungroupedAggregateRegionObserver.commitBatchWithRetries(region, mutationList, blockingMemstoreSize);
+            uuidValue = ServerCacheClient.generateId();
+            mutationList.clear();
+        }
+        return uuidValue;
+    }
+
     @Override
     public boolean next(List<Cell> results) throws IOException {
         Cell lastCell = null;
@@ -312,35 +353,69 @@ public class IndexerRegionScanner extends GlobalIndexRegionScanner {
         region.startRegionOperation();
         try {
             synchronized (innerScanner) {
+                byte[] uuidValue = ServerCacheClient.generateId();
                 do {
                     List<Cell> row = new ArrayList<>();
                     hasMore = innerScanner.nextRaw(row);
                     if (!row.isEmpty()) {
-                        lastCell = row.get(0);
+                        lastCell = row.get(0); // lastCell is any cell from the last visited row
                         Put put = null;
+                        Delete del = null;
                         for (Cell cell : row) {
                             if (KeyValue.Type.codeToType(cell.getTypeByte()) == KeyValue.Type.Put) {
+                                if (!partialRebuild && familyMap != null && !isColumnIncluded(cell)) {
+                                    continue;
+                                }
                                 if (put == null) {
                                     put = new Put(CellUtil.cloneRow(cell));
                                 }
                                 put.add(cell);
                             } else {
-                                throw new DoNotRetryIOException("Scan without raw found a deleted cell");
+                                if (del == null) {
+                                    del = new Delete(CellUtil.cloneRow(cell));
+                                }
+                                del.addDeleteMarker(cell);
                             }
                         }
+                        if (put == null && del == null) {
+                            continue;
+                        }
+                        if (!verify) {
+                            if (put != null) {
+                                setMutationAttributes(put, uuidValue);
+                                mutations.add(put);
+                            }
+                            if (del != null) {
+                                setMutationAttributes(del, uuidValue);
+                                mutations.add(del);
+                            }
+                            uuidValue = commitIfReady(uuidValue, mutations);
+                        } else {
+                            indexKeyToDataPutMap
+                                    .put(getIndexRowKey(indexMaintainer, put), put);
+                        }
                         rowCount++;
-                        indexKeyToDataPutMap
-                                .put(getIndexRowKey(indexMaintainer, put), put);
+
                     }
                 } while (hasMore && rowCount < pageSizeInRows);
-                verifyIndex();
+                if (verify) {
+                    verifyIndex();
+                } else if (!mutations.isEmpty()) {
+                    ungroupedAggregateRegionObserver.checkForRegionClosing();
+                    ungroupedAggregateRegionObserver.commitBatchWithRetries(region, mutations, blockingMemstoreSize);
+                    mutations.clear();
+                }
             }
         } catch (IOException e) {
             LOGGER.error(String.format("IOException during rebuilding: %s", Throwables.getStackTraceAsString(e)));
             throw e;
         } finally {
             region.closeRegionOperation();
-            indexKeyToDataPutMap.clear();
+            if (verify) {
+                indexKeyToDataPutMap.clear();
+            } else {
+                mutations.clear();
+            }
         }
         byte[] rowCountBytes = PLong.INSTANCE.toBytes(Long.valueOf(rowCount));
         final Cell aggKeyValue;

--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/index/IndexVerificationResultRepository.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/index/IndexVerificationResultRepository.java
@@ -83,7 +83,7 @@ public class IndexVerificationResultRepository implements AutoCloseable {
             "BeforeRebuildUnknownIndexRowCount";
     public final static byte[] BEFORE_REBUILD_UNKNOWN_INDEX_ROW_COUNT_BYTES = Bytes.toBytes(BEFORE_REBUILD_UNKNOWN_INDEX_ROW_COUNT);
     public final static String AFTER_REBUILD_VALID_INDEX_ROW_COUNT =
-        "AfterValidExpiredIndexRowCount";
+        "AfterRebuildValidIndexRowCount";
     public final static byte[] AFTER_REBUILD_VALID_INDEX_ROW_COUNT_BYTES = Bytes.toBytes(AFTER_REBUILD_VALID_INDEX_ROW_COUNT);
     public final static String AFTER_REBUILD_EXPIRED_INDEX_ROW_COUNT =
         "AfterRebuildExpiredIndexRowCount";

--- a/phoenix-core/src/test/java/org/apache/phoenix/index/IndexRebuildRegionScannerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/index/IndexRebuildRegionScannerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.index;
+
+import com.google.common.collect.Maps;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+
+import static org.apache.phoenix.coprocessor.IndexRebuildRegionScanner.getPerTaskIndexKeyToMutationMaps;
+
+public class IndexRebuildRegionScannerTest{
+    private static final Random RAND = new Random(7);
+    @Test
+    public void testGetPerTaskIndexKeyToMutationMaps() {
+        TreeMap<byte[], List<Mutation>> indexKeyToMutationMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+        final int MAP_SIZE = 64*1024;
+        final int REPEAT = 16;
+        final int MAX_SPLIT_SIZE = 32;
+        for (int i = 0; i < MAP_SIZE; i++) {
+            byte[] indexKey = Bytes.toBytes(RAND.nextLong());
+            indexKeyToMutationMap.put(indexKey, null);
+        }
+        for (int i = 0; i < REPEAT; i++) {
+            byte[][] endKeys = new byte[i + 1][Long.SIZE / Byte.SIZE];
+            for (int j = 0; j < i; j++) {
+                endKeys[j] = Bytes.toBytes(RAND.nextLong());
+            }
+            // The last end key is always null
+            endKeys[i] = null;
+            List<Map<byte[], List<Mutation>>> mapList = getPerTaskIndexKeyToMutationMaps(indexKeyToMutationMap, endKeys, MAX_SPLIT_SIZE);
+            int regionIndex = 0;
+            int regionCount = i + 1;
+            for (Map<byte[], List<Mutation>> map : mapList) {
+                // Check map sizes
+                Assert.assertTrue(map.size() <= MAX_SPLIT_SIZE);
+                // Check map boundaries
+                TreeMap<byte[], List<Mutation>> treeMap = (TreeMap<byte[], List<Mutation>>) map;
+                byte[] firstKey = treeMap.firstKey();
+                // Find the region including the first key of the of the map
+                while (regionIndex < regionCount -1  && Bytes.compareTo(firstKey, endKeys[regionIndex]) != 1) {
+                    regionIndex++;
+                }
+                // The last key of the map also must fall into the same region
+                if (regionIndex != regionCount - 1) {
+                    Assert.assertTrue(Bytes.compareTo(treeMap.lastKey(), endKeys[regionIndex]) != 1);
+                }
+            }
+        }
+    }
+
+
+}

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
@@ -20,6 +20,7 @@ package org.apache.phoenix.query;
 import static org.apache.phoenix.hbase.index.write.ParallelWriterIndexCommitter.NUM_CONCURRENT_INDEX_WRITER_THREADS_CONF_KEY;
 import static org.apache.phoenix.query.QueryConstants.MILLIS_IN_DAY;
 import static org.apache.phoenix.query.QueryServices.DROP_METADATA_ATTRIB;
+import static org.apache.phoenix.query.QueryServices.GLOBAL_INDEX_ROW_AGE_THRESHOLD_TO_DELETE_MS_ATTRIB;
 import static org.apache.phoenix.util.PhoenixRuntime.CURRENT_SCN_ATTRIB;
 import static org.apache.phoenix.util.PhoenixRuntime.JDBC_PROTOCOL;
 import static org.apache.phoenix.util.PhoenixRuntime.JDBC_PROTOCOL_TERMINATOR;
@@ -626,6 +627,7 @@ public abstract class BaseTest {
         conf.setInt(QueryServices.TASK_HANDLING_INTERVAL_MS_ATTRIB, 10000);
         conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 2);
         conf.setInt(NUM_CONCURRENT_INDEX_WRITER_THREADS_CONF_KEY, 1);
+        conf.setInt(GLOBAL_INDEX_ROW_AGE_THRESHOLD_TO_DELETE_MS_ATTRIB, 0);
         return conf;
     }
 


### PR DESCRIPTION
This PR eliminates data tables in the rebuild write path by letting UngroupedAggregateRegionObserver directly write to index tables without going through IndexRegionObserver.  By doing so, this PR eliminates going through data table update path and its overhead (its interaction with flushes, row locking etc). This PR also applies the index table updates in the index table row key order. It is expected that this will reduce the number of RPC calls compared to the existing implementation which generates index table updates in the data table row key order. Finally, the PR makes index rebuild from a given table region multi-threaded. Thus, this PR improves the rebuild performance and efficiency. 