### PR TITLE
PHOENIX-6198 Add option to IndexTool to specify the source table for scan

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexToolIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexToolIT.java
@@ -641,14 +641,14 @@ public class IndexToolIT extends BaseUniqueNamesOwnClusterIT {
                                             IndexTool.IndexVerifyType verifyType, Long startTime,
                                             Long endTime, Long incrementalVerify) {
         return getArgList(directApi, useSnapshot, schemaName, dataTable, indxTable, tenantId,
-            verifyType, startTime, endTime, IndexTool.IndexDisableLoggingType.NONE, incrementalVerify);
+            verifyType, startTime, endTime, IndexTool.IndexDisableLoggingType.NONE, incrementalVerify, false);
     }
 
     private static List<String> getArgList (boolean directApi, boolean useSnapshot, String schemaName,
                             String dataTable, String indxTable, String tenantId,
                             IndexTool.IndexVerifyType verifyType, Long startTime, Long endTime,
                                             IndexTool.IndexDisableLoggingType disableLoggingType,
-                                            Long incrementalVerify) {
+                                            Long incrementalVerify, boolean useIndexTableAsSource) {
         List<String> args = Lists.newArrayList();
         if (schemaName != null) {
             args.add("-s");
@@ -692,6 +692,11 @@ public class IndexToolIT extends BaseUniqueNamesOwnClusterIT {
             args.add("-rv");
             args.add(String.valueOf(incrementalVerify));
         }
+
+        if (useIndexTableAsSource) {
+            args.add("-fi");
+        }
+
         args.add("-op");
         args.add("/tmp/" + UUID.randomUUID().toString());
         return args;
@@ -708,7 +713,7 @@ public class IndexToolIT extends BaseUniqueNamesOwnClusterIT {
                                         String dataTable, String indexTable, String tenantId, IndexTool.IndexVerifyType verifyType,
                                         IndexTool.IndexDisableLoggingType disableLoggingType) {
         List<String> args = getArgList(directApi, useSnapshot, schemaName, dataTable, indexTable,
-                tenantId, verifyType, null, null, disableLoggingType, null);
+                tenantId, verifyType, null, null, disableLoggingType, null, false);
         return args.toArray(new String[0]);
     }
 
@@ -727,7 +732,19 @@ public class IndexToolIT extends BaseUniqueNamesOwnClusterIT {
                                          IndexTool.IndexDisableLoggingType disableLoggingType,
                                          Long incrementalVerify ) {
         List<String> args = getArgList(directApi, useSnapshot, schemaName, dataTable, indexTable,
-            tenantId, verifyType, startTime, endTime, disableLoggingType, incrementalVerify);
+            tenantId, verifyType, startTime, endTime, disableLoggingType, incrementalVerify, false);
+        return args.toArray(new String[0]);
+    }
+
+    public static String [] getArgValues(boolean directApi, boolean useSnapshot, String schemaName,
+        String dataTable, String indexTable, String tenantId,
+        IndexTool.IndexVerifyType verifyType, Long startTime,
+        Long endTime,
+        IndexTool.IndexDisableLoggingType disableLoggingType,
+        Long incrementalVerify,
+        boolean useIndexTableAsSource) {
+        List<String> args = getArgList(directApi, useSnapshot, schemaName, dataTable, indexTable,
+            tenantId, verifyType, startTime, endTime, disableLoggingType, incrementalVerify, useIndexTableAsSource);
         return args.toArray(new String[0]);
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/PhoenixServerBuildIndexInputFormat.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/PhoenixServerBuildIndexInputFormat.java
@@ -20,10 +20,12 @@ package org.apache.phoenix.mapreduce;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.JobContext;
@@ -31,7 +33,12 @@ import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 import org.apache.phoenix.compile.*;
 import org.apache.phoenix.coprocessor.BaseScannerRegionObserver;
 import org.apache.phoenix.coprocessor.IndexRebuildRegionScanner;
+import org.apache.phoenix.coprocessor.MetaDataProtocol;
+import org.apache.phoenix.index.IndexMaintainer;
+import org.apache.phoenix.index.PhoenixIndexCodec;
 import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.jdbc.PhoenixStatement;
+import org.apache.phoenix.mapreduce.index.IndexScrutinyTool.SourceTable;
 import org.apache.phoenix.mapreduce.util.ConnectionUtil;
 import org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil;
 import org.apache.phoenix.query.QueryServices;
@@ -47,6 +54,7 @@ import static org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.getDisa
 import static org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.getIndexToolDataTableName;
 import static org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.getIndexToolIndexTableName;
 import static org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.getIndexToolLastVerifyTime;
+import static org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.getIndexToolSourceTable;
 import static org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.getIndexVerifyType;
 import static org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.getIndexToolStartTime;
 import static org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.setCurrentScnValue;
@@ -67,6 +75,46 @@ public class PhoenixServerBuildIndexInputFormat<T extends DBWritable> extends Ph
      */
     public PhoenixServerBuildIndexInputFormat() {
     }
+
+    private interface QueryPlanBuilder {
+        QueryPlan getQueryPlan(PhoenixConnection phoenixConnection, String dataTableFullName,
+            String indexTableFullName) throws SQLException;
+    }
+
+    private class DataTableQueryPlanBuilder implements QueryPlanBuilder {
+        @Override
+        public QueryPlan getQueryPlan(PhoenixConnection phoenixConnection, String dataTableFullName,
+            String indexTableFullName) throws SQLException {
+            PTable indexTable = PhoenixRuntime.getTableNoCache(phoenixConnection, indexTableFullName);
+            ServerBuildIndexCompiler compiler = new ServerBuildIndexCompiler(phoenixConnection, dataTableFullName);
+            MutationPlan plan = compiler.compile(indexTable);
+            return plan.getQueryPlan();
+        }
+    }
+
+    private class IndexTableQueryPlanBuilder implements QueryPlanBuilder {
+        @Override
+        public QueryPlan getQueryPlan(PhoenixConnection phoenixConnection, String dataTableFullName,
+            String indexTableFullName) throws SQLException {
+            QueryPlan plan;
+            try (final PhoenixStatement statement = new PhoenixStatement(phoenixConnection)) {
+                String query = "SELECT count(*) FROM " + indexTableFullName;
+                plan = statement.compileQuery(query);
+                TableRef tableRef = plan.getTableRef();
+                Scan scan = plan.getContext().getScan();
+                ImmutableBytesWritable ptr = new ImmutableBytesWritable();
+                PTable pIndexTable = tableRef.getTable();
+                PTable pDataTable = PhoenixRuntime.getTable(phoenixConnection, dataTableFullName);
+                IndexMaintainer.serialize(pDataTable, ptr, Collections.singletonList(pIndexTable), phoenixConnection);
+                scan.setAttribute(PhoenixIndexCodec.INDEX_PROTO_MD, ByteUtil.copyKeyBytesIfNecessary(ptr));
+                scan.setAttribute(BaseScannerRegionObserver.REBUILD_INDEXES, TRUE_BYTES);
+                ScanUtil.setClientVersion(scan, MetaDataProtocol.PHOENIX_VERSION);
+            }
+            return plan;
+        }
+    }
+
+    private QueryPlanBuilder queryPlanBuilder;
 
     @Override
     protected QueryPlan getQueryPlan(final JobContext context, final Configuration configuration)
@@ -90,6 +138,9 @@ public class PhoenixServerBuildIndexInputFormat<T extends DBWritable> extends Ph
         }
         String dataTableFullName = getIndexToolDataTableName(configuration);
         String indexTableFullName = getIndexToolIndexTableName(configuration);
+        SourceTable sourceTable = getIndexToolSourceTable(configuration);
+        queryPlanBuilder = sourceTable.equals(SourceTable.DATA_TABLE_SOURCE) ?
+            new DataTableQueryPlanBuilder() : new IndexTableQueryPlanBuilder();
 
         try (final Connection connection = ConnectionUtil.getInputConnection(configuration, overridingProps)) {
             PhoenixConnection phoenixConnection = connection.unwrap(PhoenixConnection.class);
@@ -97,11 +148,10 @@ public class PhoenixServerBuildIndexInputFormat<T extends DBWritable> extends Ph
             setCurrentScnValue(configuration, scn);
 
             Long startTime = (startTimeValue == null) ? 0L : Long.valueOf(startTimeValue);
-            PTable indexTable = PhoenixRuntime.getTableNoCache(phoenixConnection, indexTableFullName);
-            ServerBuildIndexCompiler compiler =
-                    new ServerBuildIndexCompiler(phoenixConnection, dataTableFullName);
-            MutationPlan plan = compiler.compile(indexTable);
-            Scan scan = plan.getContext().getScan();
+
+            queryPlan = queryPlanBuilder.getQueryPlan(phoenixConnection, dataTableFullName, indexTableFullName);
+            Scan scan = queryPlan.getContext().getScan();
+
             Long lastVerifyTimeValue = lastVerifyTime == null ? 0L : Long.valueOf(lastVerifyTime);
             try {
                 scan.setTimeRange(startTime, scn);
@@ -126,7 +176,6 @@ public class PhoenixServerBuildIndexInputFormat<T extends DBWritable> extends Ph
             } catch (IOException e) {
                 throw new SQLException(e);
             }
-            queryPlan = plan.getQueryPlan();
             // since we can't set a scn on connections with txn set TX_SCN attribute so that the max time range is set by BaseScannerRegionObserver
             if (txnScnValue != null) {
                 scan.setAttribute(BaseScannerRegionObserver.TX_SCN, Bytes.toBytes(Long.valueOf(txnScnValue)));

--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/util/PhoenixConfigurationUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/util/PhoenixConfigurationUtil.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.mapreduce.FormatToBytesWritableMapper;
 import org.apache.phoenix.mapreduce.ImportPreUpsertKeyValueProcessor;
+import org.apache.phoenix.mapreduce.index.IndexScrutinyTool;
 import org.apache.phoenix.mapreduce.index.IndexScrutinyTool.OutputFormat;
 import org.apache.phoenix.mapreduce.index.IndexScrutinyTool.SourceTable;
 import org.apache.phoenix.mapreduce.index.IndexTool;
@@ -663,16 +664,16 @@ public final class PhoenixConfigurationUtil {
     }
 
     public static void setIndexToolSourceTable(Configuration configuration,
-            IndexTool.SourceTable sourceTable) {
+            IndexScrutinyTool.SourceTable sourceTable) {
         Preconditions.checkNotNull(configuration);
         Preconditions.checkNotNull(sourceTable);
         configuration.set(INDEX_TOOL_SOURCE_TABLE, sourceTable.name());
     }
 
-    public static IndexTool.SourceTable getIndexToolSourceTable(Configuration configuration) {
+    public static IndexScrutinyTool.SourceTable getIndexToolSourceTable(Configuration configuration) {
         Preconditions.checkNotNull(configuration);
-        return IndexTool.SourceTable.valueOf(configuration.get(INDEX_TOOL_SOURCE_TABLE,
-            IndexTool.SourceTable.DATA_TABLE_SOURCE.name()));
+        return IndexScrutinyTool.SourceTable.valueOf(configuration.get(INDEX_TOOL_SOURCE_TABLE,
+            IndexScrutinyTool.SourceTable.DATA_TABLE_SOURCE.name()));
     }
 
     public static void setScrutinySourceTable(Configuration configuration,

--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/util/PhoenixConfigurationUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/util/PhoenixConfigurationUtil.java
@@ -125,6 +125,8 @@ public final class PhoenixConfigurationUtil {
 
     public static final String INDEX_TOOL_INDEX_TABLE_NAME = "phoenix.mr.index_tool.index.table.name";
 
+    public static final String INDEX_TOOL_SOURCE_TABLE = "phoenix.mr.index_tool.source.table";
+
     public static final String SCRUTINY_SOURCE_TABLE = "phoenix.mr.scrutiny.source.table";
 
     public static final String SCRUTINY_BATCH_SIZE = "phoenix.mr.scrutiny.batch.size";
@@ -658,6 +660,19 @@ public final class PhoenixConfigurationUtil {
     public static String getIndexToolIndexTableName(Configuration configuration) {
         Preconditions.checkNotNull(configuration);
         return configuration.get(INDEX_TOOL_INDEX_TABLE_NAME);
+    }
+
+    public static void setIndexToolSourceTable(Configuration configuration,
+            IndexTool.SourceTable sourceTable) {
+        Preconditions.checkNotNull(configuration);
+        Preconditions.checkNotNull(sourceTable);
+        configuration.set(INDEX_TOOL_SOURCE_TABLE, sourceTable.name());
+    }
+
+    public static IndexTool.SourceTable getIndexToolSourceTable(Configuration configuration) {
+        Preconditions.checkNotNull(configuration);
+        return IndexTool.SourceTable.valueOf(configuration.get(INDEX_TOOL_SOURCE_TABLE,
+            IndexTool.SourceTable.DATA_TABLE_SOURCE.name()));
     }
 
     public static void setScrutinySourceTable(Configuration configuration,

--- a/phoenix-core/src/test/java/org/apache/phoenix/index/IndexToolTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/index/IndexToolTest.java
@@ -19,10 +19,12 @@ package org.apache.phoenix.index;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.phoenix.end2end.IndexToolIT;
+import org.apache.phoenix.mapreduce.index.IndexScrutinyTool;
 import org.apache.phoenix.mapreduce.index.IndexTool;
 import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.util.EnvironmentEdgeManager;
+import org.apache.phoenix.util.IndexScrutiny;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -344,31 +346,13 @@ public class IndexToolTest extends BaseTest {
                 startTime , endTime);
         CommandLine cmdLine = it.parseOptions(args);
         it.populateIndexToolAttributes(cmdLine);
-        assertEquals(IndexTool.SourceTable.DATA_TABLE_SOURCE, it.getSourceTable());
+        assertEquals(IndexScrutinyTool.SourceTable.DATA_TABLE_SOURCE, it.getSourceTable());
     }
 
     @Test
     public void testIndexToolFromIndexSource() throws Exception {
         verifyFromIndexOption(IndexTool.IndexVerifyType.ONLY);
         verifyFromIndexOption(IndexTool.IndexVerifyType.BEFORE);
-    }
-
-    @Test
-    public void testIndexToolFromIndexSourceWith_Wrong_VerifyOption() throws Exception {
-        verifyFromIndexException(IndexTool.IndexVerifyType.NONE);
-        verifyFromIndexException(IndexTool.IndexVerifyType.AFTER);
-        verifyFromIndexException(IndexTool.IndexVerifyType.BOTH);
-    }
-
-    private void verifyFromIndexException(IndexTool.IndexVerifyType verifyType) {
-        Long startTime = 1L;
-        Long endTime = 10L;
-        String[] args =
-            IndexToolIT.getArgValues(true, true, schema,
-                dataTable, indexTable, tenantId, verifyType,
-                startTime, endTime, IndexTool.IndexDisableLoggingType.NONE, null, true);
-        exceptionRule.expect(IllegalStateException.class);
-        CommandLine cmdLine = it.parseOptions(args);
     }
 
     private void verifyFromIndexOption(IndexTool.IndexVerifyType verifyType) throws Exception {
@@ -380,7 +364,7 @@ public class IndexToolTest extends BaseTest {
                 startTime, endTime, IndexTool.IndexDisableLoggingType.BEFORE, null, true);
         CommandLine cmdLine = it.parseOptions(args);
         it.populateIndexToolAttributes(cmdLine);
-        assertEquals(IndexTool.SourceTable.INDEX_TABLE_SOURCE, it.getSourceTable());
+        assertEquals(IndexScrutinyTool.SourceTable.INDEX_TABLE_SOURCE, it.getSourceTable());
     }
 
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/index/IndexToolTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/index/IndexToolTest.java
@@ -34,9 +34,8 @@ import org.mockito.MockitoAnnotations;
 
 import static org.apache.phoenix.mapreduce.index.IndexTool.FEATURE_NOT_APPLICABLE;
 import static org.apache.phoenix.mapreduce.index.IndexTool.INVALID_TIME_RANGE_EXCEPTION_MESSAGE;
-import static org.junit.Assert.assertEquals;
 import static org.apache.phoenix.mapreduce.index.IndexTool.RETRY_VERIFY_NOT_APPLICABLE;
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 public class IndexToolTest extends BaseTest {
@@ -333,6 +332,55 @@ public class IndexToolTest extends BaseTest {
                 startTime, endTime, disableType, null);
         exceptionRule.expect(IllegalStateException.class);
         CommandLine cmdLine = it.parseOptions(args);
+    }
+
+    @Test
+    public void testIndexToolDefaultSource() throws Exception {
+        Long startTime = 1L;
+        Long endTime = 10L;
+        String [] args =
+            IndexToolIT.getArgValues(true, true, schema,
+                dataTable, indexTable, tenantId, IndexTool.IndexVerifyType.NONE,
+                startTime , endTime);
+        CommandLine cmdLine = it.parseOptions(args);
+        it.populateIndexToolAttributes(cmdLine);
+        assertEquals(IndexTool.SourceTable.DATA_TABLE_SOURCE, it.getSourceTable());
+    }
+
+    @Test
+    public void testIndexToolFromIndexSource() throws Exception {
+        verifyFromIndexOption(IndexTool.IndexVerifyType.ONLY);
+        verifyFromIndexOption(IndexTool.IndexVerifyType.BEFORE);
+    }
+
+    @Test
+    public void testIndexToolFromIndexSourceWith_Wrong_VerifyOption() throws Exception {
+        verifyFromIndexException(IndexTool.IndexVerifyType.NONE);
+        verifyFromIndexException(IndexTool.IndexVerifyType.AFTER);
+        verifyFromIndexException(IndexTool.IndexVerifyType.BOTH);
+    }
+
+    private void verifyFromIndexException(IndexTool.IndexVerifyType verifyType) {
+        Long startTime = 1L;
+        Long endTime = 10L;
+        String[] args =
+            IndexToolIT.getArgValues(true, true, schema,
+                dataTable, indexTable, tenantId, verifyType,
+                startTime, endTime, IndexTool.IndexDisableLoggingType.NONE, null, true);
+        exceptionRule.expect(IllegalStateException.class);
+        CommandLine cmdLine = it.parseOptions(args);
+    }
+
+    private void verifyFromIndexOption(IndexTool.IndexVerifyType verifyType) throws Exception {
+        Long startTime = 1L;
+        Long endTime = 10L;
+        String[] args =
+            IndexToolIT.getArgValues(true, true, schema,
+                dataTable, indexTable, tenantId, verifyType,
+                startTime, endTime, IndexTool.IndexDisableLoggingType.BEFORE, null, true);
+        CommandLine cmdLine = it.parseOptions(args);
+        it.populateIndexToolAttributes(cmdLine);
+        assertEquals(IndexTool.SourceTable.INDEX_TABLE_SOURCE, it.getSourceTable());
     }
 
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/mapreduce/util/PhoenixConfigurationUtilTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/mapreduce/util/PhoenixConfigurationUtilTest.java
@@ -25,6 +25,7 @@ import java.sql.DriverManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.phoenix.mapreduce.index.IndexTool.SourceTable;
 import org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.MRJobType;
 import org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.SchemaType;
 import org.apache.phoenix.query.BaseConnectionlessQueryTest;
@@ -311,5 +312,22 @@ public class PhoenixConfigurationUtilTest extends BaseConnectionlessQueryTest {
         Assert.assertEquals(lastVerifyTime.longValue(),
                 Long.parseLong(PhoenixConfigurationUtil.getIndexToolLastVerifyTime(configuration)));
 
+    }
+
+    @Test
+    public void testIndexToolSourceConfig() {
+        final Configuration conf = new Configuration();
+
+        // by default source is data table
+        SourceTable sourceTable = PhoenixConfigurationUtil.getIndexToolSourceTable(conf);
+        Assert.assertEquals(sourceTable, SourceTable.DATA_TABLE_SOURCE);
+
+        PhoenixConfigurationUtil.setIndexToolSourceTable(conf, SourceTable.INDEX_TABLE_SOURCE);
+        sourceTable = PhoenixConfigurationUtil.getIndexToolSourceTable(conf);
+        Assert.assertEquals(sourceTable, SourceTable.INDEX_TABLE_SOURCE);
+
+        PhoenixConfigurationUtil.setIndexToolSourceTable(conf, SourceTable.DATA_TABLE_SOURCE);
+        sourceTable = PhoenixConfigurationUtil.getIndexToolSourceTable(conf);
+        Assert.assertEquals(sourceTable, SourceTable.DATA_TABLE_SOURCE);
     }
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/mapreduce/util/PhoenixConfigurationUtilTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/mapreduce/util/PhoenixConfigurationUtilTest.java
@@ -25,7 +25,7 @@ import java.sql.DriverManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.mapreduce.Job;
-import org.apache.phoenix.mapreduce.index.IndexTool.SourceTable;
+import org.apache.phoenix.mapreduce.index.IndexScrutinyTool.SourceTable;
 import org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.MRJobType;
 import org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil.SchemaType;
 import org.apache.phoenix.query.BaseConnectionlessQueryTest;


### PR DESCRIPTION
Part of PHOENIX-6182

New option `-fi` or `--from-index` added. When specified, use the index table as the source for verification. Inly works with `-vBEFORE` and `-vONLY` options. 