### PR TITLE
PHOENIX-6218 Rows deleted count is incorrect for immutable tables with indexes

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/ImmutableIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/ImmutableIndexIT.java
@@ -632,6 +632,36 @@ public class ImmutableIndexIT extends BaseUniqueNamesOwnClusterIT {
         }
     }
 
+    private void setupForDeleteCount(Connection conn, String schemaName, String dataTableName,
+            String indexTableName1, String indexTableName2) throws SQLException {
+
+        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
+
+        conn.createStatement().execute("CREATE TABLE " + dataTableFullName
+            + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
+            + this.tableDDLOptions);
+
+        if (indexTableName1 != null) {
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL1) INCLUDE (VAL2)", indexTableName1, dataTableFullName));
+        }
+
+        if (indexTableName2 != null) {
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL2) INCLUDE (VAL1)", indexTableName2, dataTableFullName));
+        }
+
+        PreparedStatement dataPreparedStatement =
+            conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
+        for (int i = 1; i <= 10; i++) {
+            dataPreparedStatement.setInt(1, i);
+            dataPreparedStatement.setInt(2, i + 1);
+            dataPreparedStatement.setInt(3, i * 2);
+            dataPreparedStatement.execute();
+        }
+        conn.commit();
+    }
+
     @Test
     public void testDeleteCount_PK() throws Exception {
         String schemaName = generateUniqueName();
@@ -640,23 +670,7 @@ public class ImmutableIndexIT extends BaseUniqueNamesOwnClusterIT {
         String indexTableName = "IND_" + generateUniqueName();
 
         try (Connection conn = DriverManager.getConnection(getUrl())) {
-
-            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
-                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
-                + this.tableDDLOptions);
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL1) INCLUDE (VAL2)", indexTableName, dataTableFullName));
-
-            PreparedStatement dataPreparedStatement =
-                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
-            for (int i = 1; i <= 10; i++) {
-                dataPreparedStatement.setInt(1, i);
-                dataPreparedStatement.setInt(2, i + 1);
-                dataPreparedStatement.setInt(3, i * 2);
-                dataPreparedStatement.execute();
-            }
-            conn.commit();
+            setupForDeleteCount(conn, schemaName, dataTableName, indexTableName, null);
 
             PreparedStatement deleteStmt =
                 conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE ID > 5");
@@ -670,30 +684,11 @@ public class ImmutableIndexIT extends BaseUniqueNamesOwnClusterIT {
         String schemaName = generateUniqueName();
         String dataTableName = "TBL_" + generateUniqueName();
         String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
-        String indexTableName = "IND_" + generateUniqueName();
+        String indexTableName1 = "IND_" + generateUniqueName();
         String indexTableName2 = "IND_" + generateUniqueName();
 
         try (Connection conn = DriverManager.getConnection(getUrl())) {
-
-            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
-                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
-                + this.tableDDLOptions);
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL1) INCLUDE (VAL2)", indexTableName, dataTableFullName));
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL2) INCLUDE (VAL1)", indexTableName2, dataTableFullName));
-
-            PreparedStatement dataPreparedStatement =
-                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
-            for (int i = 1; i <= 10; i++) {
-                dataPreparedStatement.setInt(1, i);
-                dataPreparedStatement.setInt(2, i + 1);
-                dataPreparedStatement.setInt(3, i * 2);
-                dataPreparedStatement.execute();
-            }
-            conn.commit();
+            setupForDeleteCount(conn, schemaName, dataTableName, indexTableName1, indexTableName2);
 
             PreparedStatement deleteStmt =
                 conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE VAL1 > 6");
@@ -707,67 +702,11 @@ public class ImmutableIndexIT extends BaseUniqueNamesOwnClusterIT {
         String schemaName = generateUniqueName();
         String dataTableName = "TBL_" + generateUniqueName();
         String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
-        String indexTableName = "IND_" + generateUniqueName();
+        String indexTableName1 = "IND_" + generateUniqueName();
         String indexTableName2 = "IND_" + generateUniqueName();
 
         try (Connection conn = DriverManager.getConnection(getUrl())) {
-
-            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
-                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
-                + this.tableDDLOptions);
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL1) INCLUDE (VAL2)", indexTableName, dataTableFullName));
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL2) INCLUDE (VAL1)", indexTableName2, dataTableFullName));
-
-            PreparedStatement dataPreparedStatement =
-                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
-            for (int i = 1; i <= 10; i++) {
-                dataPreparedStatement.setInt(1, i);
-                dataPreparedStatement.setInt(2, i + 1);
-                dataPreparedStatement.setInt(3, i * 2);
-                dataPreparedStatement.execute();
-            }
-            conn.commit();
-
-            PreparedStatement deleteStmt =
-                conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE VAL1 > 6 LIMIT 3");
-            assertEquals(3, deleteStmt.executeUpdate());
-            conn.commit();
-        }
-    }
-
-    @Test
-    public void testDeleteCount_noCoveredColumn() throws Exception {
-        String schemaName = generateUniqueName();
-        String dataTableName = "TBL_" + generateUniqueName();
-        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
-        String indexTableName = "IND_" + generateUniqueName();
-        String indexTableName2 = "IND_" + generateUniqueName();
-
-        try (Connection conn = DriverManager.getConnection(getUrl())) {
-
-            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
-                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
-                + this.tableDDLOptions);
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL1)", indexTableName, dataTableFullName));
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL2)", indexTableName2, dataTableFullName));
-
-            PreparedStatement dataPreparedStatement =
-                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
-            for (int i = 1; i <= 10; i++) {
-                dataPreparedStatement.setInt(1, i);
-                dataPreparedStatement.setInt(2, i + 1);
-                dataPreparedStatement.setInt(3, i * 2);
-                dataPreparedStatement.execute();
-            }
-            conn.commit();
+            setupForDeleteCount(conn, schemaName, dataTableName, indexTableName1, indexTableName2);
 
             PreparedStatement deleteStmt =
                 conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE VAL1 > 6 LIMIT 3");
@@ -780,28 +719,11 @@ public class ImmutableIndexIT extends BaseUniqueNamesOwnClusterIT {
     public void testDeleteCount_index() throws Exception {
         String schemaName = generateUniqueName();
         String dataTableName = "TBL_" + generateUniqueName();
-        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
         String indexTableName = "IND_" + generateUniqueName();
         String indexTableFullName = SchemaUtil.getTableName(schemaName, indexTableName);
 
         try (Connection conn = DriverManager.getConnection(getUrl())) {
-
-            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
-                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
-                + this.tableDDLOptions);
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL1)", indexTableName, dataTableFullName));
-
-            PreparedStatement dataPreparedStatement =
-                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
-            for (int i = 1; i <= 10; i++) {
-                dataPreparedStatement.setInt(1, i);
-                dataPreparedStatement.setInt(2, i + 1);
-                dataPreparedStatement.setInt(3, i * 2);
-                dataPreparedStatement.execute();
-            }
-            conn.commit();
+            setupForDeleteCount(conn, schemaName, dataTableName, indexTableName, null);
 
             PreparedStatement deleteStmt =
                 conn.prepareStatement("DELETE FROM " + indexTableFullName + " WHERE \"0:VAL1\" > 6");

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/ImmutableIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/ImmutableIndexIT.java
@@ -634,9 +634,6 @@ public class ImmutableIndexIT extends BaseUniqueNamesOwnClusterIT {
 
     @Test
     public void testDeleteCount_PK() throws Exception {
-        if (transactionProvider != null) {
-            return;
-        }
         String schemaName = generateUniqueName();
         String dataTableName = "TBL_" + generateUniqueName();
         String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
@@ -670,9 +667,6 @@ public class ImmutableIndexIT extends BaseUniqueNamesOwnClusterIT {
 
     @Test
     public void testDeleteCount_nonPK() throws Exception {
-        if (transactionProvider != null) {
-            return;
-        }
         String schemaName = generateUniqueName();
         String dataTableName = "TBL_" + generateUniqueName();
         String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
@@ -703,6 +697,114 @@ public class ImmutableIndexIT extends BaseUniqueNamesOwnClusterIT {
 
             PreparedStatement deleteStmt =
                 conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE VAL1 > 6");
+            assertEquals(5, deleteStmt.executeUpdate());
+            conn.commit();
+        }
+    }
+
+    @Test
+    public void testDeleteCount_limit() throws Exception {
+        String schemaName = generateUniqueName();
+        String dataTableName = "TBL_" + generateUniqueName();
+        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
+        String indexTableName = "IND_" + generateUniqueName();
+        String indexTableName2 = "IND_" + generateUniqueName();
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+
+            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
+                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
+                + this.tableDDLOptions);
+
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL1) INCLUDE (VAL2)", indexTableName, dataTableFullName));
+
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL2) INCLUDE (VAL1)", indexTableName2, dataTableFullName));
+
+            PreparedStatement dataPreparedStatement =
+                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
+            for (int i = 1; i <= 10; i++) {
+                dataPreparedStatement.setInt(1, i);
+                dataPreparedStatement.setInt(2, i + 1);
+                dataPreparedStatement.setInt(3, i * 2);
+                dataPreparedStatement.execute();
+            }
+            conn.commit();
+
+            PreparedStatement deleteStmt =
+                conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE VAL1 > 6 LIMIT 3");
+            assertEquals(3, deleteStmt.executeUpdate());
+            conn.commit();
+        }
+    }
+
+    @Test
+    public void testDeleteCount_noCoveredColumn() throws Exception {
+        String schemaName = generateUniqueName();
+        String dataTableName = "TBL_" + generateUniqueName();
+        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
+        String indexTableName = "IND_" + generateUniqueName();
+        String indexTableName2 = "IND_" + generateUniqueName();
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+
+            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
+                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
+                + this.tableDDLOptions);
+
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL1)", indexTableName, dataTableFullName));
+
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL2)", indexTableName2, dataTableFullName));
+
+            PreparedStatement dataPreparedStatement =
+                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
+            for (int i = 1; i <= 10; i++) {
+                dataPreparedStatement.setInt(1, i);
+                dataPreparedStatement.setInt(2, i + 1);
+                dataPreparedStatement.setInt(3, i * 2);
+                dataPreparedStatement.execute();
+            }
+            conn.commit();
+
+            PreparedStatement deleteStmt =
+                conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE VAL1 > 6 LIMIT 3");
+            assertEquals(3, deleteStmt.executeUpdate());
+            conn.commit();
+        }
+    }
+
+    @Test
+    public void testDeleteCount_index() throws Exception {
+        String schemaName = generateUniqueName();
+        String dataTableName = "TBL_" + generateUniqueName();
+        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
+        String indexTableName = "IND_" + generateUniqueName();
+        String indexTableFullName = SchemaUtil.getTableName(schemaName, indexTableName);
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+
+            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
+                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
+                + this.tableDDLOptions);
+
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL1)", indexTableName, dataTableFullName));
+
+            PreparedStatement dataPreparedStatement =
+                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
+            for (int i = 1; i <= 10; i++) {
+                dataPreparedStatement.setInt(1, i);
+                dataPreparedStatement.setInt(2, i + 1);
+                dataPreparedStatement.setInt(3, i * 2);
+                dataPreparedStatement.execute();
+            }
+            conn.commit();
+
+            PreparedStatement deleteStmt =
+                conn.prepareStatement("DELETE FROM " + indexTableFullName + " WHERE \"0:VAL1\" > 6");
             assertEquals(5, deleteStmt.executeUpdate());
             conn.commit();
         }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/MutableIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/MutableIndexIT.java
@@ -898,35 +898,101 @@ public class MutableIndexIT extends ParallelStatsDisabledIT {
           IndexScrutiny.scrutinizeIndex(conn, fullTableName, fullIndexName);
       }
   }
+    private void setupForDeleteCount(Connection conn, String schemaName, String dataTableName,
+        String indexTableName1, String indexTableName2) throws SQLException {
+
+        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
+
+        conn.createStatement().execute("CREATE TABLE " + dataTableFullName
+            + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
+            + this.tableDDLOptions);
+
+        if (indexTableName1 != null) {
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL1) INCLUDE (VAL2)", indexTableName1, dataTableFullName));
+        }
+
+        if (indexTableName2 != null) {
+            conn.createStatement().execute(String.format(
+                "CREATE INDEX %s ON %s (VAL2) INCLUDE (VAL1)", indexTableName2, dataTableFullName));
+        }
+
+        PreparedStatement dataPreparedStatement =
+            conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
+        for (int i = 1; i <= 10; i++) {
+            dataPreparedStatement.setInt(1, i);
+            dataPreparedStatement.setInt(2, i + 1);
+            dataPreparedStatement.setInt(3, i * 2);
+            dataPreparedStatement.execute();
+        }
+        conn.commit();
+    }
 
     @Test
-    public void testDeleteCount_nonPK() throws Exception {
+    public void testDeleteCount_PK() throws Exception {
         String schemaName = generateUniqueName();
         String dataTableName = "TBL_" + generateUniqueName();
         String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
         String indexTableName = "IND_" + generateUniqueName();
 
         try (Connection conn = DriverManager.getConnection(getUrl())) {
+            setupForDeleteCount(conn, schemaName, dataTableName, indexTableName, null);
 
-            conn.createStatement().execute("CREATE TABLE " + dataTableFullName
-                + " (ID INTEGER NOT NULL PRIMARY KEY, VAL1 INTEGER, VAL2 INTEGER) "
-                + this.tableDDLOptions);
-
-            conn.createStatement().execute(String.format(
-                "CREATE INDEX %s ON %s (VAL1) INCLUDE (VAL2)", indexTableName, dataTableFullName));
-
-            PreparedStatement dataPreparedStatement =
-                conn.prepareStatement("UPSERT INTO " + dataTableFullName + " VALUES(?,?,?)");
-            for (int i = 1; i <= 10; i++) {
-                dataPreparedStatement.setInt(1, i);
-                dataPreparedStatement.setInt(2, i + 1);
-                dataPreparedStatement.setInt(3, i * 2);
-                dataPreparedStatement.execute();
-            }
+            PreparedStatement deleteStmt =
+                conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE ID > 5");
+            assertEquals(5, deleteStmt.executeUpdate());
             conn.commit();
+        }
+    }
+
+    @Test
+    public void testDeleteCount_nonPK() throws Exception {
+        String schemaName = generateUniqueName();
+        String dataTableName = "TBL_" + generateUniqueName();
+        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
+        String indexTableName1 = "IND_" + generateUniqueName();
+        String indexTableName2 = "IND_" + generateUniqueName();
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            setupForDeleteCount(conn, schemaName, dataTableName, indexTableName1, indexTableName2);
 
             PreparedStatement deleteStmt =
                 conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE VAL1 > 6");
+            assertEquals(5, deleteStmt.executeUpdate());
+            conn.commit();
+        }
+    }
+
+    @Test
+    public void testDeleteCount_limit() throws Exception {
+        String schemaName = generateUniqueName();
+        String dataTableName = "TBL_" + generateUniqueName();
+        String dataTableFullName = SchemaUtil.getTableName(schemaName, dataTableName);
+        String indexTableName1 = "IND_" + generateUniqueName();
+        String indexTableName2 = "IND_" + generateUniqueName();
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            setupForDeleteCount(conn, schemaName, dataTableName, indexTableName1, indexTableName2);
+
+            PreparedStatement deleteStmt =
+                conn.prepareStatement("DELETE FROM " + dataTableFullName + " WHERE VAL1 > 6 LIMIT 3");
+            assertEquals(3, deleteStmt.executeUpdate());
+            conn.commit();
+        }
+    }
+
+    @Test
+    public void testDeleteCount_index() throws Exception {
+        String schemaName = generateUniqueName();
+        String dataTableName = "TBL_" + generateUniqueName();
+        String indexTableName = "IND_" + generateUniqueName();
+        String indexTableFullName = SchemaUtil.getTableName(schemaName, indexTableName);
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            setupForDeleteCount(conn, schemaName, dataTableName, indexTableName, null);
+
+            PreparedStatement deleteStmt =
+                conn.prepareStatement("DELETE FROM " + indexTableFullName + " WHERE \"0:VAL1\" > 6");
             assertEquals(5, deleteStmt.executeUpdate());
             conn.commit();
         }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -913,18 +913,13 @@ public class DeleteCompiler {
                     // Return total number of rows that have been deleted from the table. In the case of auto commit being off
                     // the mutations will all be in the mutation state of the current connection. We need to divide by the
                     // total number of tables we updated as otherwise the client will get an inflated result.
+                    // MutationState.join() ignores index rows in row count so totalRowCount calculated above will
+                    // reflect data table always and index table only if the bestPlan uses index table.
                     int totalTablesUpdateClientSide = 1; // data table is always updated
                     PTable bestTable = bestPlan.getTableRef().getTable();
                     // global immutable tables are also updated client side (but don't double count the data table)
                     if (bestPlan != dataPlan && isMaintainedOnClient(bestTable)) {
                         totalTablesUpdateClientSide++;
-                    }
-                    for (TableRef otherTableRef : otherTableRefs) {
-                        PTable otherTable = otherTableRef.getTable();
-                        // Don't double count the data table here (which morphs when it becomes a projected table, hence this check)
-                        if (projectedTableRef != otherTableRef && isMaintainedOnClient(otherTable)) {
-                            totalTablesUpdateClientSide++;
-                        }
                     }
                     MutationState state = new MutationState(maxSize, maxSizeBytes, connection, totalRowCount/totalTablesUpdateClientSide);
 


### PR DESCRIPTION
MutationState.join() ignores index rows in row count so totalRowCount calculated
will reflect the data table always and the index table only if the bestPlan
uses the index table. So ignore the other index tables when determining
the number of tables updated.