### PR TITLE
[PHOENIX-6213] Extend Cell Tags to Delete object to store source of operation.

### DIFF
--- a/phoenix-core/src/main/java/org/apache/hadoop/hbase/PhoenixTagType.java
+++ b/phoenix-core/src/main/java/org/apache/hadoop/hbase/PhoenixTagType.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+/**
+    Used to persist the TagType in HBase Cell Tags.
+    All the type present here should be more than @{@link Tag#CUSTOM_TAG_TYPE_RANGE} which is 64.
+ **/
+public final class PhoenixTagType {
+    /**
+     * Indicates the source of operation.
+     */
+    public static final byte SOURCE_OPERATION_TAG_TYPE = (byte) 65;
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/call/CallRunner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/call/CallRunner.java
@@ -62,5 +62,4 @@ public class CallRunner {
             }
         }
     }
-
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -22,7 +22,6 @@ import static org.apache.phoenix.util.NumberUtil.add;
 import java.io.IOException;
 import java.sql.ParameterMetaData;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -33,6 +32,7 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.cache.ServerCacheClient;
 import org.apache.phoenix.cache.ServerCacheClient.ServerCache;
@@ -335,7 +335,7 @@ public class DeleteCompiler {
         return Collections.emptyList();
     }
     
-    private class MultiRowDeleteMutationPlan implements MutationPlan {
+    public class MultiRowDeleteMutationPlan implements MutationPlan {
         private final List<MutationPlan> plans;
         private final MutationPlan firstPlan;
         private final QueryPlan dataPlan;
@@ -605,7 +605,7 @@ public class DeleteCompiler {
             final int offset = table.getBucketNum() == null ? 0 : 1;
             Iterator<PColumn> projectedColsItr = projectedColumns.iterator();
             int i = 0;
-            while(projectedColsItr.hasNext()) {
+            while (projectedColsItr.hasNext()) {
                 final int position = i++;
                 adjustedProjectedColumns.add(new DelegateColumn(projectedColsItr.next()) {
                     @Override
@@ -726,7 +726,7 @@ public class DeleteCompiler {
         }
     }
 
-    private class ServerSelectDeleteMutationPlan implements MutationPlan {
+    public class ServerSelectDeleteMutationPlan implements MutationPlan {
         private final StatementContext context;
         private final QueryPlan dataPlan;
         private final PhoenixConnection connection;
@@ -786,6 +786,11 @@ public class DeleteCompiler {
                     context.getScan().setAttribute(PhoenixIndexCodec.INDEX_PROTO_MD, ptr.get());
                     context.getScan().setAttribute(BaseScannerRegionObserver.TX_STATE, txState);
                     ScanUtil.setClientVersion(context.getScan(), MetaDataProtocol.PHOENIX_VERSION);
+                    String sourceOfDelete = statement.getConnection().getSourceOfOperation();
+                    if (sourceOfDelete != null) {
+                        context.getScan().setAttribute(QueryServices.SOURCE_OPERATION_ATTRIB,
+                                Bytes.toBytes(sourceOfDelete));
+                    }
                 }
                 ResultIterator iterator = aggPlan.iterator();
                 try {
@@ -837,7 +842,7 @@ public class DeleteCompiler {
         }
     }
 
-    private class ClientSelectDeleteMutationPlan implements MutationPlan {
+    public class ClientSelectDeleteMutationPlan implements MutationPlan {
         private final StatementContext context;
         private final TableRef targetTableRef;
         private final QueryPlan dataPlan;

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -17,6 +17,7 @@
  */
 package org.apache.phoenix.execute;
 
+import static org.apache.phoenix.query.QueryServices.SOURCE_OPERATION_ATTRIB;
 import static org.apache.phoenix.thirdparty.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.phoenix.monitoring.GlobalClientMetrics.GLOBAL_MUTATION_BATCH_FAILED_COUNT;
 import static org.apache.phoenix.monitoring.GlobalClientMetrics.GLOBAL_MUTATION_BATCH_SIZE;
@@ -648,6 +649,14 @@ public class MutationState implements SQLCloseable {
             if (rowEntry.getValue().getColumnValues() == PRow.DELETE_MARKER) { // means delete
                 row.delete();
                 rowMutations = row.toRowMutations();
+                String sourceOfDelete = getConnection().getSourceOfOperation();
+                if (sourceOfDelete != null) {
+                    byte[] sourceOfDeleteBytes = Bytes.toBytes(sourceOfDelete);
+                    // Set the source of operation attribute.
+                    for (Mutation mutation: rowMutations) {
+                        mutation.setAttribute(SOURCE_OPERATION_ATTRIB, sourceOfDeleteBytes);
+                    }
+                }
                 // The DeleteCompiler already generates the deletes for indexes, so no need to do it again
                 rowMutationsPertainingToIndex = Collections.emptyList();
             } else {

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
@@ -171,6 +171,7 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
     private boolean isRunningUpgrade;
     private LogLevel logLevel;
     private Double logSamplingRate;
+    private String sourceOfOperation;
 
     static {
         Tracing.addTraceMetricsSource();
@@ -388,6 +389,8 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
         
         this.logSamplingRate = Double.parseDouble(this.services.getProps().get(QueryServices.LOG_SAMPLE_RATE,
                 QueryServicesOptions.DEFAULT_LOG_SAMPLE_RATE));
+        this.sourceOfOperation =
+                this.services.getProps().get(QueryServices.SOURCE_OPERATION_ATTRIB, null);
         GLOBAL_OPEN_PHOENIX_CONNECTIONS.increment();
     }
 
@@ -1293,4 +1296,11 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
         return this.logSamplingRate;
     }
 
+    /**
+     *
+     * @return source of operation
+     */
+    public String getSourceOfOperation() {
+        return sourceOfOperation;
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -360,6 +360,13 @@ public interface QueryServices extends SQLCloseable {
     public static final String GUIDE_POSTS_CACHE_FACTORY_CLASS = "phoenix.guide.posts.cache.factory.class";
 
     public static final String PENDING_MUTATIONS_DDL_THROW_ATTRIB = "phoenix.pending.mutations.before.ddl.throw";
+
+    /**
+     * Parameter to indicate the source of operation attribute.
+     * It can include metadata about the customer, service, etc.
+     */
+    String SOURCE_OPERATION_ATTRIB = "phoenix.source.operation";
+
     /**
      * Get executor service used for parallel scans
      */

--- a/phoenix-core/src/test/java/org/apache/phoenix/compile/QueryOptimizerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/compile/QueryOptimizerTest.java
@@ -370,12 +370,12 @@ public class QueryOptimizerTest extends BaseConnectionlessQueryTest {
         DeleteCompiler compiler = new DeleteCompiler(stmt, null);
         MutationPlan plan = compiler.compile(delete);
         assertEquals("T", plan.getQueryPlan().getTableRef().getTable().getTableName().getString());
-        assertTrue(plan.getClass().getName().contains("ServerSelectDeleteMutationPlan"));
+        assertEquals(plan.getClass(), DeleteCompiler.ServerSelectDeleteMutationPlan.class);
         parser = new SQLParser("DELETE FROM t WHERE v1 = 'foo'");
         delete = (DeleteStatement) parser.parseStatement();
         plan = compiler.compile(delete);
         assertEquals("IDX", plan.getQueryPlan().getTableRef().getTable().getTableName().getString());
-        assertTrue(plan.getClass().getName().contains("ClientSelectDeleteMutationPlan"));
+        assertEquals(plan.getClass(), DeleteCompiler.ClientSelectDeleteMutationPlan.class);
     }
 
     @Test


### PR DESCRIPTION
Changes done in this PR: 
1. Added a new property in ConnectionQueryServices` phoenix.source.operation` The client will set this in Properties object to create the connection. This indicates the metadata about what is the source of the operation. for e.g. customer-delete, internal-service-delete, etc.
2. Changed MutationState and UngroupedAggregateRegionScanner to propagate the attribute from PhoenixConnection to mutation object
3. Added a method in  IndexRegionObserver to add the attribute from mutation object to cell as tags.