### PR TITLE
PHOENIX-5728 : ExplainPlan with plan as attributes object

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/iterate/MockResultIterator.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/iterate/MockResultIterator.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.execute.TupleProjector;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.tuple.ResultTuple;
@@ -54,6 +56,11 @@ public class MockResultIterator implements PeekingResultIterator {
 
     @Override
     public void explain(List<String> planSteps) {}
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+    }
 
     @Override
     public void close() throws SQLException {}

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -36,6 +36,8 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.cache.ServerCacheClient;
 import org.apache.phoenix.cache.ServerCacheClient.ServerCache;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.coprocessor.BaseScannerRegionObserver;
@@ -809,11 +811,18 @@ public class DeleteCompiler {
 
         @Override
         public ExplainPlan getExplainPlan() throws SQLException {
-            List<String> queryPlanSteps =  aggPlan.getExplainPlan().getPlanSteps();
-            List<String> planSteps = Lists.newArrayListWithExpectedSize(queryPlanSteps.size()+1);
+            ExplainPlan explainPlan = aggPlan.getExplainPlan();
+            List<String> queryPlanSteps = explainPlan.getPlanSteps();
+            ExplainPlanAttributes explainPlanAttributes =
+                explainPlan.getPlanStepsAsAttributes();
+            List<String> planSteps =
+                Lists.newArrayListWithExpectedSize(queryPlanSteps.size() + 1);
+            ExplainPlanAttributesBuilder newBuilder =
+                new ExplainPlanAttributesBuilder(explainPlanAttributes);
+            newBuilder.setAbstractExplainPlan("DELETE ROWS SERVER SELECT");
             planSteps.add("DELETE ROWS SERVER SELECT");
             planSteps.addAll(queryPlanSteps);
-            return new ExplainPlan(planSteps);
+            return new ExplainPlan(planSteps, newBuilder.build());
         }
 
         @Override
@@ -945,11 +954,17 @@ public class DeleteCompiler {
 
         @Override
         public ExplainPlan getExplainPlan() throws SQLException {
-            List<String> queryPlanSteps =  bestPlan.getExplainPlan().getPlanSteps();
+            ExplainPlan explainPlan = bestPlan.getExplainPlan();
+            List<String> queryPlanSteps = explainPlan.getPlanSteps();
+            ExplainPlanAttributes explainPlanAttributes =
+                explainPlan.getPlanStepsAsAttributes();
             List<String> planSteps = Lists.newArrayListWithExpectedSize(queryPlanSteps.size()+1);
+            ExplainPlanAttributesBuilder newBuilder =
+                new ExplainPlanAttributesBuilder(explainPlanAttributes);
+            newBuilder.setAbstractExplainPlan("DELETE ROWS CLIENT SELECT");
             planSteps.add("DELETE ROWS CLIENT SELECT");
             planSteps.addAll(queryPlanSteps);
-            return new ExplainPlan(planSteps);
+            return new ExplainPlan(planSteps, newBuilder.build());
         }
 
         @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlan.java
@@ -26,15 +26,28 @@ public class ExplainPlan {
     public static final ExplainPlan EMPTY_PLAN = new ExplainPlan(Collections.<String>emptyList());
 
     private final List<String> planSteps;
-    
+    private final ExplainPlanAttributes planStepsAsAttributes;
+
     public ExplainPlan(List<String> planSteps) {
         this.planSteps = ImmutableList.copyOf(planSteps);
+        this.planStepsAsAttributes =
+            ExplainPlanAttributes.getDefaultExplainPlan();
     }
-    
+
+    public ExplainPlan(List<String> planSteps,
+            ExplainPlanAttributes planStepsAsAttributes) {
+        this.planSteps = planSteps;
+        this.planStepsAsAttributes = planStepsAsAttributes;
+    }
+
     public List<String> getPlanSteps() {
         return planSteps;
     }
-    
+
+    public ExplainPlanAttributes getPlanStepsAsAttributes() {
+        return planStepsAsAttributes;
+    }
+
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlanAttributes.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlanAttributes.java
@@ -1,0 +1,598 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.compile;
+
+import org.apache.hadoop.hbase.client.Consistency;
+import org.apache.phoenix.parse.HintNode;
+import org.apache.phoenix.parse.HintNode.Hint;
+
+/**
+ * ExplainPlan attributes that contain individual attributes of ExplainPlan
+ * that we can assert against. This also makes attribute retrieval easier
+ * as an API rather than retrieving list of Strings containing entire plan.
+ */
+public class ExplainPlanAttributes {
+
+    private final String abstractExplainPlan;
+    private final Integer splitsChunk;
+    private final Long estimatedRows;
+    private final Long estimatedSizeInBytes;
+    private final String iteratorTypeAndScanSize;
+    private final Double samplingRate;
+    private final boolean useRoundRobinIterator;
+    private final String hexStringRVCOffset;
+    private final Consistency consistency;
+    private final Hint hint;
+    private final String serverSortedBy;
+    private final String explainScanType;
+    private final String tableName;
+    private final String keyRanges;
+    private final Long scanTimeRangeMin;
+    private final Long scanTimeRangeMax;
+    private final String serverWhereFilter;
+    private final String serverDistinctFilter;
+    private final Integer serverOffset;
+    private final Long serverRowLimit;
+    private final boolean serverArrayElementProjection;
+    private final String serverAggregate;
+    private final String clientFilterBy;
+    private final String clientAggregate;
+    private final String clientSortedBy;
+    private final String clientAfterAggregate;
+    private final String clientDistinctFilter;
+    private final Integer clientOffset;
+    private final Integer clientRowLimit;
+    private final Integer clientSequenceCount;
+    private final String clientCursorName;
+    private final String clientSortAlgo;
+    // This object represents PlanAttributes object for rhs query
+    // to be used only by Join queries. In case of Join query, lhs plan is
+    // represented by 'this' object and rhs plan is represented by
+    // 'rhsJoinQueryExplainPlan' object (which in turn should
+    // have null rhsJoinQueryExplainPlan)
+    // For non-Join queries related Plans, rhsJoinQueryExplainPlan will always
+    // be null
+    private final ExplainPlanAttributes rhsJoinQueryExplainPlan;
+
+    private static final ExplainPlanAttributes EXPLAIN_PLAN_INSTANCE =
+        new ExplainPlanAttributes();
+
+    private ExplainPlanAttributes() {
+        this.abstractExplainPlan = null;
+        this.splitsChunk = null;
+        this.estimatedRows = null;
+        this.estimatedSizeInBytes = null;
+        this.iteratorTypeAndScanSize = null;
+        this.samplingRate = null;
+        this.useRoundRobinIterator = false;
+        this.hexStringRVCOffset = null;
+        this.consistency = null;
+        this.hint = null;
+        this.serverSortedBy = null;
+        this.explainScanType = null;
+        this.tableName = null;
+        this.keyRanges = null;
+        this.scanTimeRangeMin = null;
+        this.scanTimeRangeMax = null;
+        this.serverWhereFilter = null;
+        this.serverDistinctFilter = null;
+        this.serverOffset = null;
+        this.serverRowLimit = null;
+        this.serverArrayElementProjection = false;
+        this.serverAggregate = null;
+        this.clientFilterBy = null;
+        this.clientAggregate = null;
+        this.clientSortedBy = null;
+        this.clientAfterAggregate = null;
+        this.clientDistinctFilter = null;
+        this.clientOffset = null;
+        this.clientRowLimit = null;
+        this.clientSequenceCount = null;
+        this.clientCursorName = null;
+        this.clientSortAlgo = null;
+        this.rhsJoinQueryExplainPlan = null;
+    }
+
+    public ExplainPlanAttributes(String abstractExplainPlan,
+            Integer splitsChunk, Long estimatedRows, Long estimatedSizeInBytes,
+            String iteratorTypeAndScanSize, Double samplingRate,
+            boolean useRoundRobinIterator,
+            String hexStringRVCOffset, Consistency consistency,
+            Hint hint, String serverSortedBy, String explainScanType,
+            String tableName, String keyRanges, Long scanTimeRangeMin,
+            Long scanTimeRangeMax, String serverWhereFilter,
+            String serverDistinctFilter,
+            Integer serverOffset, Long serverRowLimit,
+            boolean serverArrayElementProjection, String serverAggregate,
+            String clientFilterBy, String clientAggregate,
+            String clientSortedBy,
+            String clientAfterAggregate, String clientDistinctFilter,
+            Integer clientOffset, Integer clientRowLimit,
+            Integer clientSequenceCount, String clientCursorName,
+            String clientSortAlgo,
+            ExplainPlanAttributes rhsJoinQueryExplainPlan) {
+        this.abstractExplainPlan = abstractExplainPlan;
+        this.splitsChunk = splitsChunk;
+        this.estimatedRows = estimatedRows;
+        this.estimatedSizeInBytes = estimatedSizeInBytes;
+        this.iteratorTypeAndScanSize = iteratorTypeAndScanSize;
+        this.samplingRate = samplingRate;
+        this.useRoundRobinIterator = useRoundRobinIterator;
+        this.hexStringRVCOffset = hexStringRVCOffset;
+        this.consistency = consistency;
+        this.hint = hint;
+        this.serverSortedBy = serverSortedBy;
+        this.explainScanType = explainScanType;
+        this.tableName = tableName;
+        this.keyRanges = keyRanges;
+        this.scanTimeRangeMin = scanTimeRangeMin;
+        this.scanTimeRangeMax = scanTimeRangeMax;
+        this.serverWhereFilter = serverWhereFilter;
+        this.serverDistinctFilter = serverDistinctFilter;
+        this.serverOffset = serverOffset;
+        this.serverRowLimit = serverRowLimit;
+        this.serverArrayElementProjection = serverArrayElementProjection;
+        this.serverAggregate = serverAggregate;
+        this.clientFilterBy = clientFilterBy;
+        this.clientAggregate = clientAggregate;
+        this.clientSortedBy = clientSortedBy;
+        this.clientAfterAggregate = clientAfterAggregate;
+        this.clientDistinctFilter = clientDistinctFilter;
+        this.clientOffset = clientOffset;
+        this.clientRowLimit = clientRowLimit;
+        this.clientSequenceCount = clientSequenceCount;
+        this.clientCursorName = clientCursorName;
+        this.clientSortAlgo = clientSortAlgo;
+        this.rhsJoinQueryExplainPlan = rhsJoinQueryExplainPlan;
+    }
+
+    public String getAbstractExplainPlan() {
+        return abstractExplainPlan;
+    }
+
+    public Integer getSplitsChunk() {
+        return splitsChunk;
+    }
+
+    public Long getEstimatedRows() {
+        return estimatedRows;
+    }
+
+    public Long getEstimatedSizeInBytes() {
+        return estimatedSizeInBytes;
+    }
+
+    public String getIteratorTypeAndScanSize() {
+        return iteratorTypeAndScanSize;
+    }
+
+    public Double getSamplingRate() {
+        return samplingRate;
+    }
+
+    public boolean isUseRoundRobinIterator() {
+        return useRoundRobinIterator;
+    }
+
+    public String getHexStringRVCOffset() {
+        return hexStringRVCOffset;
+    }
+
+    public Consistency getConsistency() {
+        return consistency;
+    }
+
+    public Hint getHint() {
+        return hint;
+    }
+
+    public String getServerSortedBy() {
+        return serverSortedBy;
+    }
+
+    public String getExplainScanType() {
+        return explainScanType;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getKeyRanges() {
+        return keyRanges;
+    }
+
+    public Long getScanTimeRangeMin() {
+        return scanTimeRangeMin;
+    }
+
+    public Long getScanTimeRangeMax() {
+        return scanTimeRangeMax;
+    }
+
+    public String getServerWhereFilter() {
+        return serverWhereFilter;
+    }
+
+    public String getServerDistinctFilter() {
+        return serverDistinctFilter;
+    }
+
+    public Integer getServerOffset() {
+        return serverOffset;
+    }
+
+    public Long getServerRowLimit() {
+        return serverRowLimit;
+    }
+
+    public boolean isServerArrayElementProjection() {
+        return serverArrayElementProjection;
+    }
+
+    public String getServerAggregate() {
+        return serverAggregate;
+    }
+
+    public String getClientFilterBy() {
+        return clientFilterBy;
+    }
+
+    public String getClientAggregate() {
+        return clientAggregate;
+    }
+
+    public String getClientSortedBy() {
+        return clientSortedBy;
+    }
+
+    public String getClientAfterAggregate() {
+        return clientAfterAggregate;
+    }
+
+    public String getClientDistinctFilter() {
+        return clientDistinctFilter;
+    }
+
+    public Integer getClientOffset() {
+        return clientOffset;
+    }
+
+    public Integer getClientRowLimit() {
+        return clientRowLimit;
+    }
+
+    public Integer getClientSequenceCount() {
+        return clientSequenceCount;
+    }
+
+    public String getClientCursorName() {
+        return clientCursorName;
+    }
+
+    public String getClientSortAlgo() {
+        return clientSortAlgo;
+    }
+
+    public ExplainPlanAttributes getRhsJoinQueryExplainPlan() {
+        return rhsJoinQueryExplainPlan;
+    }
+
+    public static ExplainPlanAttributes getDefaultExplainPlan() {
+        return EXPLAIN_PLAN_INSTANCE;
+    }
+
+    public static class ExplainPlanAttributesBuilder {
+        private String abstractExplainPlan;
+        private Integer splitsChunk;
+        private Long estimatedRows;
+        private Long estimatedSizeInBytes;
+        private String iteratorTypeAndScanSize;
+        private Double samplingRate;
+        private boolean useRoundRobinIterator;
+        private String hexStringRVCOffset;
+        private Consistency consistency;
+        private HintNode.Hint hint;
+        private String serverSortedBy;
+        private String explainScanType;
+        private String tableName;
+        private String keyRanges;
+        private Long scanTimeRangeMin;
+        private Long scanTimeRangeMax;
+        private String serverWhereFilter;
+        private String serverDistinctFilter;
+        private Integer serverOffset;
+        private Long serverRowLimit;
+        private boolean serverArrayElementProjection;
+        private String serverAggregate;
+        private String clientFilterBy;
+        private String clientAggregate;
+        private String clientSortedBy;
+        private String clientAfterAggregate;
+        private String clientDistinctFilter;
+        private Integer clientOffset;
+        private Integer clientRowLimit;
+        private Integer clientSequenceCount;
+        private String clientCursorName;
+        private String clientSortAlgo;
+        private ExplainPlanAttributes rhsJoinQueryExplainPlan;
+
+        public ExplainPlanAttributesBuilder() {
+            // default
+        }
+
+        public ExplainPlanAttributesBuilder(
+                ExplainPlanAttributes explainPlanAttributes) {
+            this.abstractExplainPlan =
+                explainPlanAttributes.getAbstractExplainPlan();
+            this.splitsChunk = explainPlanAttributes.getSplitsChunk();
+            this.estimatedRows = explainPlanAttributes.getEstimatedRows();
+            this.estimatedSizeInBytes =
+                explainPlanAttributes.getEstimatedSizeInBytes();
+            this.iteratorTypeAndScanSize = explainPlanAttributes.getIteratorTypeAndScanSize();
+            this.samplingRate = explainPlanAttributes.getSamplingRate();
+            this.useRoundRobinIterator =
+                explainPlanAttributes.isUseRoundRobinIterator();
+            this.hexStringRVCOffset =
+                explainPlanAttributes.getHexStringRVCOffset();
+            this.consistency = explainPlanAttributes.getConsistency();
+            this.hint = explainPlanAttributes.getHint();
+            this.serverSortedBy = explainPlanAttributes.getServerSortedBy();
+            this.explainScanType = explainPlanAttributes.getExplainScanType();
+            this.tableName = explainPlanAttributes.getTableName();
+            this.keyRanges = explainPlanAttributes.getKeyRanges();
+            this.scanTimeRangeMin = explainPlanAttributes.getScanTimeRangeMin();
+            this.scanTimeRangeMax = explainPlanAttributes.getScanTimeRangeMax();
+            this.serverWhereFilter =
+                explainPlanAttributes.getServerWhereFilter();
+            this.serverDistinctFilter =
+                explainPlanAttributes.getServerDistinctFilter();
+            this.serverOffset = explainPlanAttributes.getServerOffset();
+            this.serverRowLimit = explainPlanAttributes.getServerRowLimit();
+            this.serverArrayElementProjection =
+                explainPlanAttributes.isServerArrayElementProjection();
+            this.serverAggregate = explainPlanAttributes.getServerAggregate();
+            this.clientFilterBy = explainPlanAttributes.getClientFilterBy();
+            this.clientAggregate = explainPlanAttributes.getClientAggregate();
+            this.clientSortedBy = explainPlanAttributes.getClientSortedBy();
+            this.clientAfterAggregate =
+                explainPlanAttributes.getClientAfterAggregate();
+            this.clientDistinctFilter =
+                explainPlanAttributes.getClientDistinctFilter();
+            this.clientOffset = explainPlanAttributes.getClientOffset();
+            this.clientRowLimit = explainPlanAttributes.getClientRowLimit();
+            this.clientSequenceCount =
+                explainPlanAttributes.getClientSequenceCount();
+            this.clientCursorName = explainPlanAttributes.getClientCursorName();
+            this.clientSortAlgo = explainPlanAttributes.getClientSortAlgo();
+            this.rhsJoinQueryExplainPlan =
+                explainPlanAttributes.getRhsJoinQueryExplainPlan();
+        }
+
+        public ExplainPlanAttributesBuilder setAbstractExplainPlan(
+                String abstractExplainPlan) {
+            this.abstractExplainPlan = abstractExplainPlan;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setSplitsChunk(
+                Integer splitsChunk) {
+            this.splitsChunk = splitsChunk;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setEstimatedRows(
+                Long estimatedRows) {
+            this.estimatedRows = estimatedRows;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setEstimatedSizeInBytes(
+                Long estimatedSizeInBytes) {
+            this.estimatedSizeInBytes = estimatedSizeInBytes;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setIteratorTypeAndScanSize(
+                String iteratorTypeAndScanSize) {
+            this.iteratorTypeAndScanSize = iteratorTypeAndScanSize;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setSamplingRate(
+                Double samplingRate) {
+            this.samplingRate = samplingRate;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setUseRoundRobinIterator(
+                boolean useRoundRobinIterator) {
+            this.useRoundRobinIterator = useRoundRobinIterator;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setHexStringRVCOffset(
+                String hexStringRVCOffset) {
+            this.hexStringRVCOffset = hexStringRVCOffset;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setConsistency(
+                Consistency consistency) {
+            this.consistency = consistency;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setHint(HintNode.Hint hint) {
+            this.hint = hint;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setServerSortedBy(
+                String serverSortedBy) {
+            this.serverSortedBy = serverSortedBy;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setExplainScanType(
+                String explainScanType) {
+            this.explainScanType = explainScanType;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setTableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setKeyRanges(String keyRanges) {
+            this.keyRanges = keyRanges;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setScanTimeRangeMin(
+                Long scanTimeRangeMin) {
+            this.scanTimeRangeMin = scanTimeRangeMin;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setScanTimeRangeMax(
+                Long scanTimeRangeMax) {
+            this.scanTimeRangeMax = scanTimeRangeMax;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setServerWhereFilter(
+                String serverWhereFilter) {
+            this.serverWhereFilter = serverWhereFilter;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setServerDistinctFilter(
+                String serverDistinctFilter) {
+            this.serverDistinctFilter = serverDistinctFilter;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setServerOffset(
+                Integer serverOffset) {
+            this.serverOffset = serverOffset;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setServerRowLimit(
+                Long serverRowLimit) {
+            this.serverRowLimit = serverRowLimit;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setServerArrayElementProjection(
+                boolean serverArrayElementProjection) {
+            this.serverArrayElementProjection = serverArrayElementProjection;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setServerAggregate(
+                String serverAggregate) {
+            this.serverAggregate = serverAggregate;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientFilterBy(
+                String clientFilterBy) {
+            this.clientFilterBy = clientFilterBy;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientAggregate(
+                String clientAggregate) {
+            this.clientAggregate = clientAggregate;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientSortedBy(
+                String clientSortedBy) {
+            this.clientSortedBy = clientSortedBy;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientAfterAggregate(
+                String clientAfterAggregate) {
+            this.clientAfterAggregate = clientAfterAggregate;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientDistinctFilter(
+                String clientDistinctFilter) {
+            this.clientDistinctFilter = clientDistinctFilter;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientOffset(
+                Integer clientOffset) {
+            this.clientOffset = clientOffset;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientRowLimit(
+                Integer clientRowLimit) {
+            this.clientRowLimit = clientRowLimit;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientSequenceCount(
+                Integer clientSequenceCount) {
+            this.clientSequenceCount = clientSequenceCount;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientCursorName(
+                String clientCursorName) {
+            this.clientCursorName = clientCursorName;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setClientSortAlgo(
+                String clientSortAlgo) {
+            this.clientSortAlgo = clientSortAlgo;
+            return this;
+        }
+
+        public ExplainPlanAttributesBuilder setRhsJoinQueryExplainPlan(
+                ExplainPlanAttributes rhsJoinQueryExplainPlan) {
+            this.rhsJoinQueryExplainPlan = rhsJoinQueryExplainPlan;
+            return this;
+        }
+
+        public ExplainPlanAttributes build() {
+            return new ExplainPlanAttributes(abstractExplainPlan, splitsChunk,
+                estimatedRows, estimatedSizeInBytes, iteratorTypeAndScanSize,
+                samplingRate, useRoundRobinIterator, hexStringRVCOffset,
+                consistency, hint, serverSortedBy, explainScanType, tableName,
+                keyRanges, scanTimeRangeMin, scanTimeRangeMax,
+                serverWhereFilter, serverDistinctFilter,
+                serverOffset, serverRowLimit,
+                serverArrayElementProjection, serverAggregate,
+                clientFilterBy, clientAggregate, clientSortedBy,
+                clientAfterAggregate, clientDistinctFilter, clientOffset,
+                clientRowLimit, clientSequenceCount, clientCursorName,
+                clientSortAlgo, rhsJoinQueryExplainPlan);
+        }
+    }
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ListJarsQueryPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ListJarsQueryPlan.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+  .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.execute.visitor.QueryPlanVisitor;
@@ -177,6 +179,11 @@ public class ListJarsQueryPlan implements QueryPlan {
             
             @Override
             public void explain(List<String> planSteps) {
+            }
+
+            @Override
+            public void explain(List<String> planSteps,
+                    ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
             }
         };
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/MutatingParallelIteratorFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/MutatingParallelIteratorFactory.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.execute.MutationState;
 import org.apache.phoenix.iterate.ParallelIteratorFactory;
 import org.apache.phoenix.iterate.PeekingResultIterator;
@@ -94,6 +96,11 @@ public abstract class MutatingParallelIteratorFactory implements ParallelIterato
 
                 @Override
                 public void explain(List<String> planSteps) {
+                }
+
+                @Override
+                public void explain(List<String> planSteps,
+                    ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
                 }
 
                 @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/TraceQueryPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/TraceQueryPlan.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.htrace.Sampler;
 import org.apache.htrace.TraceScope;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.execute.visitor.QueryPlanVisitor;
@@ -306,6 +308,11 @@ public class TraceQueryPlan implements QueryPlan {
 
         @Override
         public void explain(List<String> planSteps) {
+        }
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
         }
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/UpsertCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/UpsertCompiler.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.cache.ServerCacheClient;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.coprocessor.BaseScannerRegionObserver;
@@ -1138,11 +1140,18 @@ public class UpsertCompiler {
 
         @Override
         public ExplainPlan getExplainPlan() throws SQLException {
-            List<String> queryPlanSteps =  aggPlan.getExplainPlan().getPlanSteps();
-            List<String> planSteps = Lists.newArrayListWithExpectedSize(queryPlanSteps.size()+1);
+            ExplainPlan explainPlan = aggPlan.getExplainPlan();
+            List<String> queryPlanSteps = explainPlan.getPlanSteps();
+            ExplainPlanAttributes explainPlanAttributes =
+                explainPlan.getPlanStepsAsAttributes();
+            List<String> planSteps =
+                Lists.newArrayListWithExpectedSize(queryPlanSteps.size() + 1);
+            ExplainPlanAttributesBuilder newBuilder =
+                new ExplainPlanAttributesBuilder(explainPlanAttributes);
+            newBuilder.setAbstractExplainPlan("UPSERT ROWS");
             planSteps.add("UPSERT ROWS");
             planSteps.addAll(queryPlanSteps);
-            return new ExplainPlan(planSteps);
+            return new ExplainPlan(planSteps, newBuilder.build());
         }
 
         @Override
@@ -1418,11 +1427,18 @@ public class UpsertCompiler {
 
         @Override
         public ExplainPlan getExplainPlan() throws SQLException {
-            List<String> queryPlanSteps =  queryPlan.getExplainPlan().getPlanSteps();
-            List<String> planSteps = Lists.newArrayListWithExpectedSize(queryPlanSteps.size()+1);
+            ExplainPlan explainPlan = queryPlan.getExplainPlan();
+            List<String> queryPlanSteps = explainPlan.getPlanSteps();
+            ExplainPlanAttributes explainPlanAttributes =
+                explainPlan.getPlanStepsAsAttributes();
+            List<String> planSteps =
+                Lists.newArrayListWithExpectedSize(queryPlanSteps.size() + 1);
+            ExplainPlanAttributesBuilder newBuilder =
+                new ExplainPlanAttributesBuilder(explainPlanAttributes);
+            newBuilder.setAbstractExplainPlan("UPSERT SELECT");
             planSteps.add("UPSERT SELECT");
             planSteps.addAll(queryPlanSteps);
-            return new ExplainPlan(planSteps);
+            return new ExplainPlan(planSteps, newBuilder.build());
         }
 
         @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/BaseQueryPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/BaseQueryPlan.java
@@ -27,6 +27,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.phoenix.compile.ExplainPlanAttributes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.thirdparty.com.google.common.base.Optional;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Scan;
@@ -516,7 +520,10 @@ public abstract class BaseQueryPlan implements QueryPlan {
         }
 
         ResultIterator iterator = iterator();
-        ExplainPlan explainPlan = new ExplainPlan(getPlanSteps(iterator));
+        Pair<List<String>, ExplainPlanAttributes> planSteps =
+            getPlanStepsV2(iterator);
+        ExplainPlan explainPlan = new ExplainPlan(planSteps.getLeft(),
+            planSteps.getRight());
         iterator.close();
         return explainPlan;
     }
@@ -525,6 +532,15 @@ public abstract class BaseQueryPlan implements QueryPlan {
         List<String> planSteps = Lists.newArrayListWithExpectedSize(5);
         iterator.explain(planSteps);
         return planSteps;
+    }
+
+    private Pair<List<String>, ExplainPlanAttributes> getPlanStepsV2(
+            ResultIterator iterator) {
+        List<String> planSteps = Lists.newArrayListWithExpectedSize(5);
+        ExplainPlanAttributesBuilder builder =
+            new ExplainPlanAttributesBuilder();
+        iterator.explain(planSteps, builder);
+        return Pair.of(planSteps, builder.build());
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/HashJoinPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/HashJoinPlan.java
@@ -295,6 +295,7 @@ public class HashJoinPlan extends DelegateQueryPlan {
 
     @Override
     public ExplainPlan getExplainPlan() throws SQLException {
+        // TODO : Support ExplainPlanAttributes for HashJoinPlan
         List<String> planSteps = Lists.newArrayList(delegate.getExplainPlan().getPlanSteps());
         int count = subPlans.length;
         for (int i = 0; i < count; i++) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/LiteralResultIterationPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/LiteralResultIterationPlan.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.phoenix.cache.ServerCacheClient.ServerCache;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.compile.RowProjector;
@@ -118,7 +120,12 @@ public class LiteralResultIterationPlan extends BaseQueryPlan {
             @Override
             public void explain(List<String> planSteps) {
             }
-            
+
+            @Override
+            public void explain(List<String> planSteps,
+                    ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+            }
+
         };
         
         if (context.getSequenceManager().getSequenceCount() > 0) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/SortMergeJoinPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/SortMergeJoinPlan.java
@@ -39,6 +39,9 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.compile.ColumnResolver;
 import org.apache.phoenix.compile.ExplainPlan;
+import org.apache.phoenix.compile.ExplainPlanAttributes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.compile.QueryCompiler;
@@ -197,14 +200,33 @@ public class SortMergeJoinPlan implements QueryPlan {
     public ExplainPlan getExplainPlan() throws SQLException {
         List<String> steps = Lists.newArrayList();
         steps.add("SORT-MERGE-JOIN (" + joinType.toString().toUpperCase() + ") TABLES");
-        for (String step : lhsPlan.getExplainPlan().getPlanSteps()) {
-            steps.add("    " + step);            
+        ExplainPlan lhsExplainPlan = lhsPlan.getExplainPlan();
+        List<String> lhsPlanSteps = lhsExplainPlan.getPlanSteps();
+        ExplainPlanAttributes lhsPlanAttributes =
+          lhsExplainPlan.getPlanStepsAsAttributes();
+        ExplainPlanAttributesBuilder lhsPlanBuilder =
+          new ExplainPlanAttributesBuilder(lhsPlanAttributes);
+        lhsPlanBuilder.setAbstractExplainPlan("SORT-MERGE-JOIN ("
+          + joinType.toString().toUpperCase() + ")");
+
+        for (String step : lhsPlanSteps) {
+            steps.add("    " + step);
         }
         steps.add("AND" + (rhsSchema.getFieldCount() == 0 ? " (SKIP MERGE)" : ""));
-        for (String step : rhsPlan.getExplainPlan().getPlanSteps()) {
-            steps.add("    " + step);            
+
+        ExplainPlan rhsExplainPlan = rhsPlan.getExplainPlan();
+        List<String> rhsPlanSteps = rhsExplainPlan.getPlanSteps();
+        ExplainPlanAttributes rhsPlanAttributes =
+          rhsExplainPlan.getPlanStepsAsAttributes();
+        ExplainPlanAttributesBuilder rhsPlanBuilder =
+          new ExplainPlanAttributesBuilder(rhsPlanAttributes);
+
+        lhsPlanBuilder.setRhsJoinQueryExplainPlan(rhsPlanBuilder.build());
+
+        for (String step : rhsPlanSteps) {
+            steps.add("    " + step);
         }
-        return new ExplainPlan(steps);
+        return new ExplainPlan(steps, lhsPlanBuilder.build());
     }
 
     @Override
@@ -481,6 +503,11 @@ public class SortMergeJoinPlan implements QueryPlan {
         public void explain(List<String> planSteps) {
         }
 
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        }
+
         private void doInit(boolean lhs) throws SQLException {
             if(lhs) {
                 nextLhsTuple = lhsIterator.next();
@@ -745,7 +772,12 @@ public class SortMergeJoinPlan implements QueryPlan {
         @Override
         public void explain(List<String> planSteps) {
         }
-        
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        }
+
         private void advance(boolean lhs) throws SQLException {
             if (lhs) {
                 lhsTuple = lhsIterator.next();

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/TupleProjectionPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/TupleProjectionPlan.java
@@ -27,6 +27,9 @@ import java.util.Map;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.phoenix.compile.ColumnResolver;
 import org.apache.phoenix.compile.ExplainPlan;
+import org.apache.phoenix.compile.ExplainPlanAttributes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.OrderPreservingTracker;
 import org.apache.phoenix.compile.OrderPreservingTracker.Info;
 import org.apache.phoenix.compile.QueryPlan;
@@ -151,12 +154,19 @@ public class TupleProjectionPlan extends DelegateQueryPlan {
 
     @Override
     public ExplainPlan getExplainPlan() throws SQLException {
-        List<String> planSteps = Lists.newArrayList(delegate.getExplainPlan().getPlanSteps());
+        ExplainPlan explainPlan = delegate.getExplainPlan();
+        List<String> planSteps = Lists.newArrayList(explainPlan.getPlanSteps());
+        ExplainPlanAttributes explainPlanAttributes =
+            explainPlan.getPlanStepsAsAttributes();
         if (postFilter != null) {
             planSteps.add("CLIENT FILTER BY " + postFilter.toString());
+            ExplainPlanAttributesBuilder newBuilder =
+                new ExplainPlanAttributesBuilder(explainPlanAttributes);
+            newBuilder.setClientFilterBy(postFilter.toString());
+            explainPlanAttributes = newBuilder.build();
         }
 
-        return new ExplainPlan(planSteps);
+        return new ExplainPlan(planSteps, explainPlanAttributes);
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/UnnestArrayPlan.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/UnnestArrayPlan.java
@@ -24,6 +24,9 @@ import java.util.List;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.phoenix.compile.ExplainPlan;
+import org.apache.phoenix.compile.ExplainPlanAttributes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.execute.visitor.QueryPlanVisitor;
@@ -57,9 +60,15 @@ public class UnnestArrayPlan extends DelegateQueryPlan {
 
     @Override
     public ExplainPlan getExplainPlan() throws SQLException {
-        List<String> planSteps = delegate.getExplainPlan().getPlanSteps();
+        ExplainPlan explainPlan = delegate.getExplainPlan();
+        List<String> planSteps = explainPlan.getPlanSteps();
+        ExplainPlanAttributes explainPlanAttributes =
+            explainPlan.getPlanStepsAsAttributes();
+        ExplainPlanAttributesBuilder newBuilder =
+            new ExplainPlanAttributesBuilder(explainPlanAttributes);
         planSteps.add("UNNEST");
-        return new ExplainPlan(planSteps);
+        newBuilder.setAbstractExplainPlan("UNNEST");
+        return new ExplainPlan(planSteps, newBuilder.build());
     }
     
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseGroupedAggregatingResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseGroupedAggregatingResultIterator.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.expression.aggregator.Aggregator;
 import org.apache.phoenix.expression.aggregator.Aggregators;
 import org.apache.phoenix.schema.tuple.Tuple;
@@ -103,4 +105,9 @@ public abstract class BaseGroupedAggregatingResultIterator implements
         resultIterator.explain(planSteps);
     }
 
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        resultIterator.explain(planSteps, explainPlanAttributesBuilder);
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterator.java
@@ -17,6 +17,9 @@
  */
 package org.apache.phoenix.iterate;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
+
 import java.sql.SQLException;
 import java.util.List;
 
@@ -38,4 +41,8 @@ public abstract class BaseResultIterator implements ResultIterator {
     public void explain(List<String> planSteps) {
     }
 
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ChunkedResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ChunkedResultIterator.java
@@ -26,6 +26,8 @@ import java.util.List;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.execute.MutationState;
@@ -132,6 +134,12 @@ public class ChunkedResultIterator implements PeekingResultIterator {
     }
 
     @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        resultIterator.explain(planSteps, explainPlanAttributesBuilder);
+    }
+
+    @Override
     public void close() throws SQLException {
         resultIterator.close();
     }
@@ -207,6 +215,12 @@ public class ChunkedResultIterator implements PeekingResultIterator {
         @Override
         public void explain(List<String> planSteps) {
             delegate.explain(planSteps);
+        }
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+            delegate.explain(planSteps, explainPlanAttributesBuilder);
         }
 
         @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ClientHashAggregatingResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ClientHashAggregatingResultIterator.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.expression.Expression;
@@ -141,6 +143,12 @@ public class ClientHashAggregatingResultIterator
     @Override
     public void explain(List<String> planSteps) {
         resultIterator.explain(planSteps);
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        resultIterator.explain(planSteps, explainPlanAttributesBuilder);
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ConcatResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ConcatResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.util.ServerUtil;
 
@@ -90,6 +92,14 @@ public class ConcatResultIterator implements PeekingResultIterator {
     public void explain(List<String> planSteps) {
         if (resultIterators != null) {
             resultIterators.explain(planSteps);
+        }
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        if (resultIterators != null) {
+            resultIterators.explain(planSteps, explainPlanAttributesBuilder);
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/CursorResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/CursorResultIterator.java
@@ -17,6 +17,8 @@
  */
 package org.apache.phoenix.iterate;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.util.CursorUtil;
 
@@ -51,6 +53,14 @@ public class CursorResultIterator implements ResultIterator {
     @Override
     public void explain(List<String> planSteps) {
         delegate.explain(planSteps);
+        planSteps.add("CLIENT CURSOR " + cursorName);
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        delegate.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientCursorName(cursorName);
         planSteps.add("CLIENT CURSOR " + cursorName);
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/DelegateResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/DelegateResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 
 
@@ -47,6 +49,12 @@ public class DelegateResultIterator implements ResultIterator {
     @Override
     public void explain(List<String> planSteps) {
         delegate.explain(planSteps);
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        delegate.explain(planSteps, explainPlanAttributesBuilder);
     }
 
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/DistinctAggregatingResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/DistinctAggregatingResultIterator.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.phoenix.compile.ColumnProjector;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.RowProjector;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.aggregator.Aggregator;
@@ -154,6 +156,15 @@ public class DistinctAggregatingResultIterator implements AggregatingResultItera
     @Override
     public void explain(List<String> planSteps) {
         delegate.explain(planSteps);
+        planSteps.add("CLIENT DISTINCT ON " + rowProjector.toString());
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        delegate.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientDistinctFilter(
+            rowProjector.toString());
         planSteps.add("CLIENT DISTINCT ON " + rowProjector.toString());
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/FilterAggregatingResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/FilterAggregatingResultIterator.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.aggregator.Aggregator;
 import org.apache.phoenix.schema.tuple.Tuple;
@@ -76,9 +78,17 @@ public class FilterAggregatingResultIterator  implements AggregatingResultIterat
         planSteps.add("CLIENT FILTER BY " + expression.toString());
     }
 
-	@Override
-	public String toString() {
-		return "FilterAggregatingResultIterator [delegate=" + delegate
-				+ ", expression=" + expression + ", ptr=" + ptr + "]";
-	}
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        delegate.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientFilterBy(expression.toString());
+        planSteps.add("CLIENT FILTER BY " + expression.toString());
+    }
+
+    @Override
+    public String toString() {
+        return "FilterAggregatingResultIterator [delegate=" + delegate
+            + ", expression=" + expression + ", ptr=" + ptr + "]";
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/FilterResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/FilterResultIterator.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PBoolean;
@@ -74,9 +76,17 @@ public class FilterResultIterator  extends LookAheadResultIterator {
         planSteps.add("CLIENT FILTER BY " + expression.toString());
     }
 
-	@Override
-	public String toString() {
-		return "FilterResultIterator [delegate=" + delegate + ", expression="
-				+ expression + ", ptr=" + ptr + "]";
-	}
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        delegate.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientFilterBy(expression.toString());
+        planSteps.add("CLIENT FILTER BY " + expression.toString());
+    }
+
+    @Override
+    public String toString() {
+        return "FilterResultIterator [delegate=" + delegate + ", expression="
+            + expression + ", ptr=" + ptr + "]";
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/LimitingResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/LimitingResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 
 /**
@@ -50,12 +52,20 @@ public class LimitingResultIterator extends DelegateResultIterator {
     @Override
     public void explain(List<String> planSteps) {
         super.explain(planSteps);
-            planSteps.add("CLIENT " + limit + " ROW LIMIT");
+        planSteps.add("CLIENT " + limit + " ROW LIMIT");
     }
 
-	@Override
-	public String toString() {
-		return "LimitingResultIterator [rowCount=" + rowCount + ", limit="
-				+ limit + "]";
-	}
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        super.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientRowLimit(limit);
+        planSteps.add("CLIENT " + limit + " ROW LIMIT");
+    }
+
+    @Override
+    public String toString() {
+        return "LimitingResultIterator [rowCount=" + rowCount + ", limit="
+            + limit + "]";
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/LookAheadResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/LookAheadResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.ResultTuple;
 import org.apache.phoenix.schema.tuple.Tuple;
 
@@ -35,6 +37,12 @@ abstract public class LookAheadResultIterator implements PeekingResultIterator {
             @Override
             public void explain(List<String> planSteps) {
                 iterator.explain(planSteps);
+            }
+
+            @Override
+            public void explain(List<String> planSteps,
+                    ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+                iterator.explain(planSteps, explainPlanAttributesBuilder);
             }
 
             @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/MaterializedComparableResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/MaterializedComparableResultIterator.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import java.util.Comparator;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 
 /**
@@ -71,5 +73,11 @@ public class MaterializedComparableResultIterator
     @Override
     public void explain(List<String> planSteps) {
         delegate.explain(planSteps);
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        delegate.explain(planSteps, explainPlanAttributesBuilder);
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/MaterializedResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/MaterializedResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.*;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 
 
@@ -106,5 +108,10 @@ public class MaterializedResultIterator implements PeekingResultIterator {
 
     @Override
     public void explain(List<String> planSteps) {
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/MergeSortRowKeyResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/MergeSortRowKeyResultIterator.java
@@ -19,6 +19,8 @@ package org.apache.phoenix.iterate;
 
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.util.TupleUtil;
 
@@ -57,9 +59,17 @@ public class MergeSortRowKeyResultIterator extends MergeSortResultIterator {
         planSteps.add("CLIENT MERGE SORT");
     }
 
-	@Override
-	public String toString() {
-		return "MergeSortRowKeyResultIterator [keyOffset=" + keyOffset
-				+ ", factor=" + factor + "]";
-	}
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        resultIterators.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientSortAlgo("CLIENT MERGE SORT");
+        planSteps.add("CLIENT MERGE SORT");
+    }
+
+    @Override
+    public String toString() {
+        return "MergeSortRowKeyResultIterator [keyOffset=" + keyOffset
+            + ", factor=" + factor + "]";
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/MergeSortTopNResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/MergeSortTopNResultIterator.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.OrderByExpression;
 import org.apache.phoenix.schema.tuple.Tuple;
@@ -108,10 +110,26 @@ public class MergeSortTopNResultIterator extends MergeSortResultIterator {
         }
     }
 
-	@Override
-	public String toString() {
-		return "MergeSortTopNResultIterator [limit=" + limit + ", count="
-				+ count + ", orderByColumns=" + orderByColumns + ", ptr1="
-				+ ptr1 + ", ptr2=" + ptr2 + ",offset=" + offset + "]";
-	}
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        resultIterators.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientSortAlgo("CLIENT MERGE SORT");
+        planSteps.add("CLIENT MERGE SORT");
+        if (offset > 0) {
+            explainPlanAttributesBuilder.setClientOffset(offset);
+            planSteps.add("CLIENT OFFSET " + offset);
+        }
+        if (limit > 0) {
+            explainPlanAttributesBuilder.setClientRowLimit(limit);
+            planSteps.add("CLIENT LIMIT " + limit);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MergeSortTopNResultIterator [limit=" + limit + ", count="
+            + count + ", orderByColumns=" + orderByColumns + ", ptr1="
+            + ptr1 + ", ptr2=" + ptr2 + ",offset=" + offset + "]";
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/OffsetResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/OffsetResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 
 /**
@@ -48,6 +50,14 @@ public class OffsetResultIterator extends DelegateResultIterator {
     @Override
     public void explain(List<String> planSteps) {
         super.explain(planSteps);
+        planSteps.add("CLIENT OFFSET " + offset);
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        super.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientOffset(offset);
         planSteps.add("CLIENT OFFSET " + offset);
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/OrderedResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/OrderedResultIterator.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.execute.DescVarLengthFastByteComparisons;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.OrderByExpression;
@@ -304,6 +306,19 @@ public class OrderedResultIterator implements PeekingResultIterator {
     }
 
     @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        delegate.explain(planSteps, explainPlanAttributesBuilder);
+        explainPlanAttributesBuilder.setClientOffset(offset);
+        explainPlanAttributesBuilder.setClientRowLimit(limit);
+        explainPlanAttributesBuilder.setClientSortedBy(
+            orderByExpressions.toString());
+        planSteps.add("CLIENT" + (offset == null || offset == 0 ? "" : " OFFSET " + offset)
+            + (limit == null ? "" : " TOP " + limit + " ROW" + (limit == 1 ? "" : "S"))
+            + " SORTED BY " + orderByExpressions.toString());
+    }
+
+    @Override
     public String toString() {
         return "OrderedResultIterator [thresholdBytes=" + thresholdBytes
                 + ", limit=" + limit + ", offset=" + offset + ", delegate=" + delegate
@@ -354,6 +369,11 @@ public class OrderedResultIterator implements PeekingResultIterator {
 
         @Override
         public void explain(List<String> planSteps) {
+        }
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
         }
 
         @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/PeekingResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/PeekingResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 
 
@@ -50,6 +52,11 @@ public interface PeekingResultIterator extends ResultIterator {
 
         @Override
         public void explain(List<String> planSteps) {
+        }
+
+        @Override
+        public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
         }
     };
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.util.SQLCloseable;
 
@@ -38,6 +40,11 @@ public interface ResultIterator extends SQLCloseable {
         @Override
         public void explain(List<String> planSteps) {
         }
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        }
     };
 
     /**
@@ -49,4 +56,21 @@ public interface ResultIterator extends SQLCloseable {
     public Tuple next() throws SQLException;
     
     public void explain(List<String> planSteps);
+
+    /**
+     * Generate ExplainPlan steps and add steps as list of Strings in
+     * planSteps argument as readable statement as well as add same generated
+     * steps in explainPlanAttributesBuilder so that we prepare ExplainPlan
+     * result as an attribute object useful to retrieve individual plan step
+     * attributes.
+     *
+     * @param planSteps Add generated plan in list of planSteps. This argument
+     *     is used to provide planSteps as whole statement consisting of
+     *     list of Strings.
+     * @param explainPlanAttributesBuilder Add generated plan in attributes
+     *     object. Having an API to provide planSteps as an object is easier
+     *     while comparing individual attributes of ExplainPlan.
+     */
+    void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder);
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ResultIterators.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.util.SQLCloseable;
 
@@ -30,4 +32,22 @@ public interface ResultIterators extends SQLCloseable {
     public List<List<Scan>> getScans();
     public void explain(List<String> planSteps);
     public List<PeekingResultIterator> getIterators() throws SQLException;
+
+    /**
+     * Generate ExplainPlan steps and add steps as list of Strings in
+     * planSteps argument as readable statement as well as add same generated
+     * steps in explainPlanAttributesBuilder so that we prepare ExplainPlan
+     * result as an attribute object useful to retrieve individual plan step
+     * attributes.
+     *
+     * @param planSteps Add generated plan in list of planSteps. This argument
+     *     is used to provide planSteps as whole statement consisting of
+     *     list of Strings.
+     * @param explainPlanAttributesBuilder Add generated plan in attributes
+     *     object. Having an API to provide planSteps as an object is easier
+     *     while comparing individual attributes of ExplainPlan.
+     */
+    void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder);
+
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/RoundRobinResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/RoundRobinResultIterator.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.query.ConnectionQueryServices;
@@ -151,6 +153,14 @@ public class RoundRobinResultIterator implements ResultIterator {
     public void explain(List<String> planSteps) {
         if (resultIterators != null) {
             resultIterators.explain(planSteps);
+        }
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        if (resultIterators != null) {
+            resultIterators.explain(planSteps, explainPlanAttributesBuilder);
         }
     }
 
@@ -312,6 +322,12 @@ public class RoundRobinResultIterator implements ResultIterator {
         @Override
         public void explain(List<String> planSteps) {
             delegate.explain(planSteps);
+        }
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+            delegate.explain(planSteps, explainPlanAttributesBuilder);
         }
 
         @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/RowKeyOrderedAggregateResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/RowKeyOrderedAggregateResultIterator.java
@@ -25,6 +25,8 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.expression.aggregator.Aggregator;
 import org.apache.phoenix.expression.aggregator.Aggregators;
 import org.apache.phoenix.schema.tuple.SingleKeyValueTuple;
@@ -101,6 +103,14 @@ public class RowKeyOrderedAggregateResultIterator extends LookAheadResultIterato
     public void explain(List<String> planSteps) {
         if (resultIterators != null) {
             resultIterators.explain(planSteps);
+        }
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        if (resultIterators != null) {
+            resultIterators.explain(planSteps, explainPlanAttributesBuilder);
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ScanningResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ScanningResultIterator.java
@@ -51,6 +51,8 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.monitoring.CombinableMetric;
 import org.apache.phoenix.monitoring.GlobalClientMetrics;
 import org.apache.phoenix.monitoring.ScanMetricsHolder;
@@ -171,6 +173,11 @@ public class ScanningResultIterator implements ResultIterator {
 
     @Override
     public void explain(List<String> planSteps) {
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/SequenceResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/SequenceResultIterator.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.iterate;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.SequenceManager;
 import org.apache.phoenix.schema.tuple.Tuple;
 
@@ -55,9 +57,19 @@ public class SequenceResultIterator extends DelegateResultIterator {
         planSteps.add("CLIENT RESERVE VALUES FROM " + nSequences + " SEQUENCE" + (nSequences == 1 ? "" : "S"));
     }
 
-	@Override
-	public String toString() {
-		return "SequenceResultIterator [sequenceManager=" + sequenceManager
-				+ "]";
-	}
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        super.explain(planSteps, explainPlanAttributesBuilder);
+        int nSequences = sequenceManager.getSequenceCount();
+        explainPlanAttributesBuilder.setClientSequenceCount(nSequences);
+        planSteps.add("CLIENT RESERVE VALUES FROM " + nSequences
+            + " SEQUENCE" + (nSequences == 1 ? "" : "S"));
+    }
+
+    @Override
+    public String toString() {
+        return "SequenceResultIterator [sequenceManager=" + sequenceManager
+            + "]";
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/SerialIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/SerialIterators.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.cache.ServerCacheClient.ServerCache;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.coprocessor.BaseScannerRegionObserver;
 import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
@@ -205,6 +207,11 @@ public class SerialIterators extends BaseResultIterators {
 
         @Override
         public void explain(List<String> planSteps) {}
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        }
 
         @Override
         public void close() throws SQLException {

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/SpoolingResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/SpoolingResultIterator.java
@@ -36,6 +36,8 @@ import org.apache.commons.io.output.DeferredFileOutputStream;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.io.WritableUtils;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.memory.MemoryManager;
@@ -253,6 +255,11 @@ public class SpoolingResultIterator implements PeekingResultIterator {
         @Override
         public void explain(List<String> planSteps) {
         }
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        }
     }
 
     /**
@@ -354,9 +361,19 @@ public class SpoolingResultIterator implements PeekingResultIterator {
         @Override
         public void explain(List<String> planSteps) {
         }
+
+        @Override
+        public void explain(List<String> planSteps,
+                ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        }
     }
 
     @Override
     public void explain(List<String> planSteps) {
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableResultIterator.java
@@ -44,6 +44,8 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.cache.ServerCacheClient.ServerCache;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.coprocessor.BaseScannerRegionObserver;
 import org.apache.phoenix.coprocessor.HashJoinCacheNotFoundException;
@@ -295,6 +297,12 @@ public class TableResultIterator implements ResultIterator {
     @Override
     public void explain(List<String> planSteps) {
         scanIterator.explain(planSteps);
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+        scanIterator.explain(planSteps, explainPlanAttributesBuilder);
     }
 
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableSnapshotResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableSnapshotResultIterator.java
@@ -34,6 +34,8 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotHelper;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil;
 import org.apache.phoenix.monitoring.ScanMetricsHolder;
 import org.apache.phoenix.schema.tuple.Tuple;
@@ -170,9 +172,14 @@ public class TableSnapshotResultIterator implements ResultIterator {
     }
   }
 
-  @Override
-  public void explain(List<String> planSteps) {
-    // noop
-  }
+    @Override
+    public void explain(List<String> planSteps) {
+      // noop
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+    }
 
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/iterate/ConcatResultIteratorTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/iterate/ConcatResultIteratorTest.java
@@ -29,6 +29,8 @@ import java.util.List;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.schema.tuple.SingleKeyValueTuple;
 import org.apache.phoenix.schema.tuple.Tuple;
@@ -95,6 +97,12 @@ public class ConcatResultIteratorTest {
             @Override
             public List<PeekingResultIterator> getIterators() throws SQLException {
                 return results;
+            }
+
+            @Override
+            public void explain(List<String> planSteps,
+                    ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+
             }
 
             @Override

--- a/phoenix-core/src/test/java/org/apache/phoenix/iterate/MaterializedResultIterators.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/iterate/MaterializedResultIterators.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.query.KeyRange;
 
 /**
@@ -39,6 +41,11 @@ public class MaterializedResultIterators implements ResultIterators {
     @Override
     public List<PeekingResultIterator> getIterators() throws SQLException {
         return results;
+    }
+
+    @Override
+    public void explain(List<String> planSteps,
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
     }
 
     @Override

--- a/phoenix-core/src/test/java/org/apache/phoenix/iterate/MergeSortResultIteratorTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/iterate/MergeSortResultIteratorTest.java
@@ -29,6 +29,8 @@ import java.util.List;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compile.ExplainPlanAttributes
+    .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.schema.tuple.SingleKeyValueTuple;
 import org.apache.phoenix.schema.tuple.Tuple;
@@ -79,6 +81,11 @@ public class MergeSortResultIteratorTest {
             }
 
             @Override
+            public void explain(List<String> planSteps,
+                    ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+            }
+
+            @Override
             public int size() {
                 return results.size();
             }
@@ -106,6 +113,11 @@ public class MergeSortResultIteratorTest {
             @Override
             public List<PeekingResultIterator> getIterators() throws SQLException {
                 return results;
+            }
+
+            @Override
+            public void explain(List<String> planSteps,
+                    ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
             }
 
             @Override
@@ -169,6 +181,11 @@ public class MergeSortResultIteratorTest {
             @Override
             public List<PeekingResultIterator> getIterators() throws SQLException {
                 return results;
+            }
+
+            @Override
+            public void explain(List<String> planSteps,
+                    ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
             }
 
             @Override


### PR DESCRIPTION
* ExplainPlan can provide plan as attributes object for simplified assertion of individual plan attributes
* Provide an additional API to get plan object
* Explain queries can still continue to provide output as String / list of String, object based approach is just an additional parameter for better comparison
* Utilizes object based comparison in BaseStatsCollectorIT as per Jira, the plan is to extend object based comparison to maximum tests with further sub-tasks of [PHOENIX-5265](https://issues.apache.org/jira/browse/PHOENIX-5265)
* Support HashJoinPlan as part of separate Jira