### PR TITLE
[PHOENIX-6213] Extend Cell Tags to Delete object to store source of operation.

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DeleteIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DeleteIT.java
@@ -18,12 +18,13 @@
 package org.apache.phoenix.end2end;
 
 import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
-import static org.apache.phoenix.util.TestUtil.printResultSet;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
@@ -32,14 +33,31 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.PhoenixTagType;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.Tag;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compile.DeleteCompiler;
+import org.apache.phoenix.compile.MutationPlan;
+import org.apache.phoenix.jdbc.PhoenixStatement;
+import org.apache.phoenix.parse.DeleteStatement;
+import org.apache.phoenix.parse.SQLParser;
+import org.apache.phoenix.query.ConnectionQueryServices;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.util.PropertiesUtil;
 import org.apache.phoenix.util.QueryUtil;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -943,6 +961,162 @@ public class DeleteIT extends ParallelStatsDisabledIT {
             }
         }
     }
+
+    /*
+        Tests whether we have cell tags in delete marker for
+        ClientSelectDeleteMutationPlan.
+     */
+    @Test
+    public void testDeleteClientDeleteMutationPlan() throws Exception {
+        String tableName = generateUniqueName();
+        String indexName = generateUniqueName();
+        String tagValue = "customer-delete";
+        String delete = "DELETE FROM " + tableName + " WHERE v1 = 'foo'";
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        // Add tag "customer-delete" to delete marker.
+        props.setProperty(ConnectionQueryServices.SOURCE_OPERATION_ATTRIB, tagValue);
+
+        createAndUpsertTable(tableName, indexName, props);
+        // Make sure that the plan creates is of ClientSelectDeleteMutationPlan
+        verifyDeletePlan(delete, DeleteCompiler.ClientSelectDeleteMutationPlan.class, props);
+        executeDelete(delete, props, 1);
+        String startRowKeyForBaseTable = "1";
+        String startRowKeyForIndexTable = "foo";
+        // Make sure that Delete Marker has cell tag for base table
+        // and has no cell tag for index table.
+        checkTagPresentInDeleteMarker(tableName, startRowKeyForBaseTable, true, tagValue);
+        checkTagPresentInDeleteMarker(indexName, startRowKeyForIndexTable, false, null);
+    }
+
+    /*
+        Tests whether we have cell tags in delete marker for
+        ServerSelectDeleteMutationPlan.
+     */
+    @Test
+    public void testDeleteServerDeleteMutationPlan() throws Exception {
+        String tableName = generateUniqueName();
+        String indexName = generateUniqueName();
+        String tagValue = "customer-delete";
+        String delete = "DELETE FROM " + tableName;
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        props.setProperty(ConnectionQueryServices.SOURCE_OPERATION_ATTRIB, tagValue);
+
+        createAndUpsertTable(tableName, indexName, props);
+        // Make sure that the plan creates is of ServerSelectDeleteMutationPlan
+        verifyDeletePlan(delete, DeleteCompiler.ServerSelectDeleteMutationPlan.class, props);
+        executeDelete(delete, props, 2);
+
+        String startRowKeyForBaseTable = "1";
+        String startRowKeyForIndexTable = "foo";
+        // Make sure that Delete Marker has cell tag for base table
+        // and has no cell tag for index table.
+        checkTagPresentInDeleteMarker(tableName, startRowKeyForBaseTable, true, tagValue);
+        checkTagPresentInDeleteMarker(indexName, startRowKeyForIndexTable, false, null);
+    }
+
+    /*
+        Tests whether we have cell tags in delete marker for
+        MultiRowDeleteMutationPlan.
+    */
+    @Test
+    public void testDeleteMultiRowDeleteMutationPlan() throws Exception {
+        String tableName = generateUniqueName();
+        String tagValue = "customer-delete";
+        String delete = "DELETE FROM " + tableName + " WHERE k = 1";
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        props.setProperty(ConnectionQueryServices.SOURCE_OPERATION_ATTRIB, tagValue);
+        // Don't create index table. We will use MultiRowDeleteMutationPlan
+        // if there is no index present for a table.
+        createAndUpsertTable(tableName, null, props);
+        // Make sure that the plan creates is of MultiRowDeleteMutationPlan
+        verifyDeletePlan(delete, DeleteCompiler.MultiRowDeleteMutationPlan.class, props);
+        executeDelete(delete, props, 1);
+        String startRowKeyForBaseTable = "1";
+        // Make sure that Delete Marker has cell tag for base table.
+        // We haven't created index table for this test case.
+        checkTagPresentInDeleteMarker(tableName, startRowKeyForBaseTable, true, tagValue);
+    }
+
+    /*
+        Verify whether plan that we create for delete statement is of planClass
+     */
+    private void verifyDeletePlan(String delete, Class<? extends MutationPlan> planClass,
+            Properties props) throws SQLException {
+        try(Connection conn = DriverManager.getConnection(getUrl(), props)) {
+            conn.setAutoCommit(true);
+            PhoenixStatement stmt = conn.createStatement().unwrap(PhoenixStatement.class);
+            SQLParser parser = new SQLParser(delete);
+            DeleteStatement deleteStmt = (DeleteStatement) parser.parseStatement();
+            DeleteCompiler compiler = new DeleteCompiler(stmt, null);
+            MutationPlan plan = compiler.compile(deleteStmt);
+            assertEquals(plan.getClass(), planClass);
+        }
+    }
+    private void createAndUpsertTable(String tableName, String indexName, Properties props)
+            throws SQLException {
+        String ddl = "CREATE TABLE " + tableName +
+                " (k INTEGER NOT NULL PRIMARY KEY, v1 VARCHAR, v2 VARCHAR)";
+        try(Connection conn = DriverManager.getConnection(getUrl(), props)) {
+            conn.setAutoCommit(true);
+            try (Statement statement = conn.createStatement()) {
+                statement.execute(ddl);
+                if (indexName != null) {
+                    String indexDdl1 = "CREATE INDEX " + indexName + " ON " + tableName + "(v1,v2)";
+                    statement.execute(indexDdl1);
+                }
+                statement.execute(
+                        "upsert into " + tableName + " values (1, 'foo', 'foo1')");
+                statement.execute(
+                        "upsert into " + tableName + " values (2, 'bar', 'bar1')");
+                conn.commit();
+            }
+        }
+    }
+
+    private void executeDelete(String delete, Properties props, int deleteRowCount)
+            throws SQLException {
+        try(Connection conn = DriverManager.getConnection(getUrl(), props)) {
+            conn.setAutoCommit(true);
+            try (Statement statement = conn.createStatement()) {
+                int rs = statement.executeUpdate(delete);
+                assertEquals( deleteRowCount, rs);
+            }
+        }
+    }
+
+    /*
+        Verify whether we have tags present for base table and not present for
+        index tables.
+     */
+    private void checkTagPresentInDeleteMarker(String tableName, String startRowKey,
+            boolean tagPresent, String tagValue) throws IOException {
+        List<Cell> values = new ArrayList<>();
+        TableName table = TableName.valueOf(tableName);
+        // Scan table with specified startRowKey
+        for (HRegion region : getUtility().getHBaseCluster().getRegions(table)) {
+            Scan scan = new Scan();
+            // Make sure to set rawScan to true so that we will get Delete Markers.
+            scan.setRaw(true);
+            scan.setStartRow(Bytes.toBytes(startRowKey));
+            RegionScanner scanner = region.getScanner(scan);
+            scanner.next(values);
+            if (!values.isEmpty()) {
+                break;
+            }
+        }
+        assertFalse("Values shouldn't be empty", values.isEmpty());
+        Cell first = values.get(0);
+        assertTrue("First cell should be delete marker ", CellUtil.isDelete(first));
+        List<Tag> tags = Tag.asList(first.getTagsArray(),
+                first.getTagsOffset(), first.getTagsLength());
+        if (tagPresent) {
+            assertEquals(1, tags.size());
+            Tag sourceOfOperationTag = Tag.getTag(first.getTagsArray(), first.getTagsOffset(),
+                    first.getTagsLength(), PhoenixTagType.SOURCE_OPERATION_TAG_TYPE);
+            Assert.assertNotNull(sourceOfOperationTag);
+            assertEquals(tagValue, Bytes.toString(sourceOfOperationTag.getValue()));
+        } else {
+            assertEquals(0, tags.size());
+        }
+    }
 }
-
-

--- a/phoenix-core/src/main/java/org/apache/hadoop/hbase/PhoenixTagType.java
+++ b/phoenix-core/src/main/java/org/apache/hadoop/hbase/PhoenixTagType.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+/**
+    Used to persist the TagType in HBase Cell Tags.
+    All the type present here should be more than @{@link Tag#CUSTOM_TAG_TYPE_RANGE} which is 64.
+ **/
+public final class PhoenixTagType {
+    /**
+     * Indicates the source of operation.
+     */
+    public static final byte SOURCE_OPERATION_TAG_TYPE = (byte) 65;
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/call/CallRunner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/call/CallRunner.java
@@ -62,5 +62,4 @@ public class CallRunner {
             }
         }
     }
-
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -22,7 +22,6 @@ import static org.apache.phoenix.util.NumberUtil.add;
 import java.io.IOException;
 import java.sql.ParameterMetaData;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -33,6 +32,7 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.cache.ServerCacheClient;
 import org.apache.phoenix.cache.ServerCacheClient.ServerCache;
@@ -351,7 +351,7 @@ public class DeleteCompiler {
         return Collections.emptyList();
     }
     
-    private class MultiRowDeleteMutationPlan implements MutationPlan {
+    public class MultiRowDeleteMutationPlan implements MutationPlan {
         private final List<MutationPlan> plans;
         private final MutationPlan firstPlan;
         private final QueryPlan dataPlan;
@@ -621,7 +621,7 @@ public class DeleteCompiler {
             final int offset = table.getBucketNum() == null ? 0 : 1;
             Iterator<PColumn> projectedColsItr = projectedColumns.iterator();
             int i = 0;
-            while(projectedColsItr.hasNext()) {
+            while (projectedColsItr.hasNext()) {
                 final int position = i++;
                 adjustedProjectedColumns.add(new DelegateColumn(projectedColsItr.next()) {
                     @Override
@@ -742,7 +742,7 @@ public class DeleteCompiler {
         }
     }
 
-    private class ServerSelectDeleteMutationPlan implements MutationPlan {
+    public class ServerSelectDeleteMutationPlan implements MutationPlan {
         private final StatementContext context;
         private final QueryPlan dataPlan;
         private final PhoenixConnection connection;
@@ -802,6 +802,11 @@ public class DeleteCompiler {
                     context.getScan().setAttribute(PhoenixIndexCodec.INDEX_PROTO_MD, ptr.get());
                     context.getScan().setAttribute(BaseScannerRegionObserver.TX_STATE, txState);
                     ScanUtil.setClientVersion(context.getScan(), MetaDataProtocol.PHOENIX_VERSION);
+                    String sourceOfDelete = statement.getConnection().getSourceOfOperation();
+                    if (sourceOfDelete != null) {
+                        context.getScan().setAttribute(QueryServices.SOURCE_OPERATION_ATTRIB,
+                                Bytes.toBytes(sourceOfDelete));
+                    }
                 }
                 ResultIterator iterator = aggPlan.iterator();
                 try {
@@ -860,7 +865,7 @@ public class DeleteCompiler {
         }
     }
 
-    private class ClientSelectDeleteMutationPlan implements MutationPlan {
+    public class ClientSelectDeleteMutationPlan implements MutationPlan {
         private final StatementContext context;
         private final TableRef targetTableRef;
         private final QueryPlan dataPlan;

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/UngroupedAggregateRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/UngroupedAggregateRegionScanner.java
@@ -31,6 +31,7 @@ import static org.apache.phoenix.query.QueryConstants.SINGLE_COLUMN;
 import static org.apache.phoenix.query.QueryConstants.SINGLE_COLUMN_FAMILY;
 import static org.apache.phoenix.query.QueryServices.MUTATE_BATCH_SIZE_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MUTATE_BATCH_SIZE_BYTES_ATTRIB;
+import static org.apache.phoenix.query.QueryServices.SOURCE_OPERATION_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.UNGROUPED_AGGREGATE_PAGE_SIZE_IN_MS;
 import static org.apache.phoenix.schema.PTableImpl.getColumnsToClone;
 
@@ -430,6 +431,12 @@ public class UngroupedAggregateRegionScanner extends BaseRegionScanner {
         if (replayMutations != null) {
             delete.setAttribute(REPLAY_WRITES, replayMutations);
         }
+        byte[] sourceOperationBytes =
+                scan.getAttribute(SOURCE_OPERATION_ATTRIB);
+        if (sourceOperationBytes != null) {
+            delete.setAttribute(SOURCE_OPERATION_ATTRIB, sourceOperationBytes);
+        }
+
         mutations.add(delete);
         // force tephra to ignore this deletes
         delete.setAttribute(PhoenixTransactionContext.TX_ROLLBACK_ATTRIBUTE_KEY, new byte[0]);
@@ -446,6 +453,10 @@ public class UngroupedAggregateRegionScanner extends BaseRegionScanner {
             delete.deleteColumns(deleteCF,  deleteCQ, ts);
             // force tephra to ignore this deletes
             delete.setAttribute(PhoenixTransactionContext.TX_ROLLBACK_ATTRIBUTE_KEY, new byte[0]);
+            // TODO: We need to set SOURCE_OPERATION_ATTRIB here also. The control will come here if
+            // TODO: we drop a column. We also delete metadata from SYSCAT table for the dropped column
+            // TODO: and delete the column. In short, we need to set this attribute for the DM for SYSCAT metadata
+            // TODO: and for data table rows.
             mutations.add(delete);
         }
     }
@@ -469,7 +480,7 @@ public class UngroupedAggregateRegionScanner extends BaseRegionScanner {
                     SortOrder.invert(values[i], 0, values[i], 0,
                             values[i].length);
                 }
-            }else{
+            } else {
                 values[i] = ByteUtil.EMPTY_BYTE_ARRAY;
             }
         }

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
@@ -173,6 +173,7 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
     private boolean isRunningUpgrade;
     private LogLevel logLevel;
     private Double logSamplingRate;
+    private String sourceOfOperation;
 
     private Object queueCreationLock = new Object(); // lock for the lazy init path of childConnections structure
     private ConcurrentLinkedQueue<PhoenixConnection> childConnections = null;
@@ -403,6 +404,8 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
         } else {
             GLOBAL_OPEN_PHOENIX_CONNECTIONS.increment();
         }
+        this.sourceOfOperation =
+                this.services.getProps().get(QueryServices.SOURCE_OPERATION_ATTRIB, null);
     }
 
     private static void checkScn(Long scnParam) throws SQLException {
@@ -1360,4 +1363,11 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
         return this.logSamplingRate;
     }
 
+    /**
+     *
+     * @return source of operation
+     */
+    public String getSourceOfOperation() {
+        return sourceOfOperation;
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -363,6 +363,13 @@ public interface QueryServices extends SQLCloseable {
     public static final String GUIDE_POSTS_CACHE_FACTORY_CLASS = "phoenix.guide.posts.cache.factory.class";
 
     public static final String PENDING_MUTATIONS_DDL_THROW_ATTRIB = "phoenix.pending.mutations.before.ddl.throw";
+
+    /**
+     * Parameter to indicate the source of operation attribute.
+     * It can include metadata about the customer, service, etc.
+     */
+    String SOURCE_OPERATION_ATTRIB = "phoenix.source.operation";
+
     /**
      * Get executor service used for parallel scans
      */

--- a/phoenix-core/src/test/java/org/apache/phoenix/compile/QueryOptimizerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/compile/QueryOptimizerTest.java
@@ -370,12 +370,12 @@ public class QueryOptimizerTest extends BaseConnectionlessQueryTest {
         DeleteCompiler compiler = new DeleteCompiler(stmt, null);
         MutationPlan plan = compiler.compile(delete);
         assertEquals("T", plan.getQueryPlan().getTableRef().getTable().getTableName().getString());
-        assertTrue(plan.getClass().getName().contains("ServerSelectDeleteMutationPlan"));
+        assertEquals(plan.getClass(), DeleteCompiler.ServerSelectDeleteMutationPlan.class);
         parser = new SQLParser("DELETE FROM t WHERE v1 = 'foo'");
         delete = (DeleteStatement) parser.parseStatement();
         plan = compiler.compile(delete);
         assertEquals("IDX", plan.getQueryPlan().getTableRef().getTable().getTableName().getString());
-        assertTrue(plan.getClass().getName().contains("ClientSelectDeleteMutationPlan"));
+        assertEquals(plan.getClass(), DeleteCompiler.ClientSelectDeleteMutationPlan.class);
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick of https://github.com/apache/phoenix/pull/978
Hbase api for adding tags are different in branch-1 otherwise remaining logic is the same.