### PR TITLE
PHOENIX-6330 SystemCatalogRegionObserver isn't added when cluster is …

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/SystemCatalogRegionObserverIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/SystemCatalogRegionObserverIT.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.end2end;
+
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.phoenix.coprocessor.SystemCatalogRegionObserver;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
+import org.apache.phoenix.util.PropertiesUtil;
+import org.apache.phoenix.util.ReadOnlyProps;
+import org.apache.phoenix.util.SchemaUtil;
+import org.apache.phoenix.util.TestUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SystemCatalogRegionObserverIT extends BaseUniqueNamesOwnClusterIT {
+
+    public SystemCatalogRegionObserverIT() {
+    }
+
+    @BeforeClass
+    public static synchronized void doSetup() throws Exception {
+        Map<String, String> serverProps = Maps.newHashMapWithExpectedSize(7);
+        serverProps.put(QueryServices.IS_NAMESPACE_MAPPING_ENABLED, "true");
+        Map<String, String> clientProps = Maps.newHashMapWithExpectedSize(1);
+        clientProps.put(QueryServices.IS_NAMESPACE_MAPPING_ENABLED, "true");
+        setUpTestDriver(new ReadOnlyProps(serverProps.entrySet().iterator()), new ReadOnlyProps(clientProps.entrySet().iterator()));
+    }
+
+    protected Connection getConnection() throws SQLException{
+        Properties props = PropertiesUtil.deepCopy(TestUtil.TEST_PROPERTIES);
+        props.setProperty(QueryServices.IS_NAMESPACE_MAPPING_ENABLED, Boolean.toString(true));
+        return DriverManager.getConnection(getUrl(),props);
+    }
+
+    @Test
+    public void testSystemCatalogRegionObserverWasAdded() throws Exception {
+        try (Connection conn = getConnection()){
+            PhoenixConnection phoenixConn = conn.unwrap(PhoenixConnection.class);
+            Table syscatTable = phoenixConn.getQueryServices().getTable(
+                SchemaUtil.getPhysicalTableName(PhoenixDatabaseMetaData.SYSTEM_CATALOG_NAME_BYTES, true).getName());
+            assertTrue("SystemCatalogRegionObserver was not added to SYSTEM.CATALOG",
+                syscatTable.getTableDescriptor().getCoprocessors().contains(
+                SystemCatalogRegionObserver.class.getName()));
+        }
+    }
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -1152,8 +1152,7 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                             PhoenixTTLRegionObserver.class.getName(), null, priority-2, null);
                 }
             }
-
-            if (Arrays.equals(tableName, SYSTEM_CATALOG_NAME_BYTES)) {
+            if (Arrays.equals(tableName, SchemaUtil.getPhysicalName(SYSTEM_CATALOG_NAME_BYTES, props).getName())) {
                 if (!descriptor.hasCoprocessor(SystemCatalogRegionObserver.class.getName())) {
                     descriptor.addCoprocessor(
                             SystemCatalogRegionObserver.class.getName(), null, priority, null);


### PR DESCRIPTION
…initialized with isNamespaceMappingEnabled=true