### PR TITLE
PHOENIX-5543: Implement SHOW TABLES/SCHEMAS sql commands

### DIFF
--- a/phoenix-core/src/main/antlr3/PhoenixSQL.g
+++ b/phoenix-core/src/main/antlr3/PhoenixSQL.g
@@ -73,6 +73,7 @@ tokens
     SESSION='session';
     TABLE='table';
     SCHEMA='schema';
+    SCHEMAS='schemas';
     ADD='add';
     SPLIT='split';
     EXPLAIN='explain';
@@ -147,6 +148,7 @@ tokens
     IMMUTABLE = 'immutable';
     GRANT = 'grant';
     REVOKE = 'revoke';
+    SHOW = 'show';
 }
 
 
@@ -425,6 +427,7 @@ oneStatement returns [BindableStatement ret]
     |   s=drop_index_node
     |   s=alter_index_node
     |   s=alter_table_node
+    |   s=show_node
     |   s=trace_node
     |   s=create_function_node
     |   s=drop_function_node
@@ -487,6 +490,12 @@ revoke_permission_node returns [ChangePermsStatement ret]
         }
     ;
 
+// Parse a show statement. SHOW TABLES, SHOW SCHEMAS ...
+show_node returns [ShowStatement ret]
+    :   SHOW TABLES (IN schema=identifier)? (LIKE pattern=string_literal)? { $ret = factory.showTablesStatement(schema, pattern); }
+    |   SHOW SCHEMAS (LIKE pattern=string_literal)? { $ret = factory.showSchemasStatement(pattern); }
+    ;
+
 // Parse a create view statement.
 create_view_node returns [CreateTableStatement ret]
     :   CREATE VIEW (IF NOT ex=EXISTS)? t=from_table_name 
@@ -524,6 +533,11 @@ create_sequence_node returns [CreateSequenceStatement ret]
 int_literal_or_bind returns [ParseNode ret]
     : n=int_or_long_literal { $ret = n; }
     | b=bind_expression { $ret = b; }
+    ;
+
+// Returns the normalized string literal
+string_literal returns [String ret]
+    :   s=STRING_LITERAL { ret = SchemaUtil.normalizeLiteral(factory.literal(s.getText())); }
     ;
 
 // Parse a drop sequence statement.

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -141,6 +142,8 @@ import org.apache.phoenix.parse.ParseNodeFactory;
 import org.apache.phoenix.parse.PrimaryKeyConstraint;
 import org.apache.phoenix.parse.SQLParser;
 import org.apache.phoenix.parse.SelectStatement;
+import org.apache.phoenix.parse.ShowSchemasStatement;
+import org.apache.phoenix.parse.ShowTablesStatement;
 import org.apache.phoenix.parse.TableName;
 import org.apache.phoenix.parse.TableNode;
 import org.apache.phoenix.parse.TraceStatement;
@@ -1100,6 +1103,35 @@ public class PhoenixStatement implements Statement, SQLCloseable {
         }
     }
 
+    private static class ExecutableShowTablesStatement extends ShowTablesStatement
+        implements CompilableStatement {
+
+        public ExecutableShowTablesStatement(String schema, String pattern) {
+          super(schema, pattern);
+        }
+
+        @Override
+        public QueryPlan compilePlan(final PhoenixStatement stmt, Sequence.ValueOp seqAction)
+            throws SQLException {
+            PreparedStatement delegateStmt = QueryUtil.getTablesStmt(stmt.getConnection(), null,
+                getTargetSchema(), getDbPattern(), null);
+            return ((PhoenixPreparedStatement) delegateStmt).compileQuery();
+        }
+    }
+
+    // Delegates to a SELECT query against SYSCAT.
+    private static class ExecutableShowSchemasStatement extends ShowSchemasStatement implements CompilableStatement {
+
+        public ExecutableShowSchemasStatement(String pattern) { super(pattern); }
+
+        @Override
+        public QueryPlan compilePlan(final PhoenixStatement stmt, Sequence.ValueOp seqAction) throws SQLException {
+            PreparedStatement delegateStmt =
+                QueryUtil.getSchemasStmt(stmt.getConnection(), null, getSchemaPattern());
+            return ((PhoenixPreparedStatement) delegateStmt).compileQuery();
+        }
+    }
+
     private static class ExecutableCreateIndexStatement extends CreateIndexStatement implements CompilableStatement {
 
         public ExecutableCreateIndexStatement(NamedNode indexName, NamedTableNode dataTable, IndexKeyConstraint ikConstraint, List<ColumnName> includeColumns, List<ParseNode> splits,
@@ -1675,6 +1707,16 @@ public class PhoenixStatement implements Statement, SQLCloseable {
         public ExecutableChangePermsStatement changePermsStatement(String permsString, boolean isSchemaName, TableName tableName,
                                                          String schemaName, boolean isGroupName, LiteralParseNode userOrGroup, boolean isGrantStatement) {
             return new ExecutableChangePermsStatement(permsString, isSchemaName, tableName, schemaName, isGroupName, userOrGroup,isGrantStatement);
+        }
+
+        @Override
+        public ShowTablesStatement showTablesStatement(String schema, String pattern) {
+            return new ExecutableShowTablesStatement(schema, pattern);
+        }
+
+        @Override
+        public ShowSchemasStatement showSchemasStatement(String pattern) {
+            return new ExecutableShowSchemasStatement(pattern);
         }
 
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
@@ -945,4 +945,11 @@ public class ParseNodeFactory {
         return new ChangePermsStatement(permsString, isSchemaName, tableName, schemaName, isGroupName, userOrGroup, isGrantStatement);
     }
 
+    public ShowTablesStatement showTablesStatement(String schema, String pattern) {
+        return new ShowTablesStatement(schema, pattern);
+    }
+
+    public ShowSchemasStatement showSchemasStatement(String pattern) {
+        return new ShowSchemasStatement(pattern);
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ShowSchemasStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ShowSchemasStatement.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.parse;
+
+import com.google.common.base.Preconditions;
+import org.apache.phoenix.compile.ColumnResolver;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * ParseNode implementation for SHOW SCHEMAS sql.
+ */
+public class ShowSchemasStatement extends ShowStatement {
+    @Nullable
+    private final String schemaPattern;
+
+    public ShowSchemasStatement(String pattern) {
+        schemaPattern = pattern;
+    };
+
+    @Nullable
+    protected String getSchemaPattern() {
+        return schemaPattern;
+    }
+
+    public void toSQL(ColumnResolver resolver, StringBuilder buf) {
+        Preconditions.checkNotNull(buf);
+        buf.append("SHOW SCHEMAS");
+        if (schemaPattern != null) {
+            buf.append(" LIKE ");
+            buf.append("'").append(schemaPattern).append("'");
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder();
+        toSQL(null, buf);
+        return buf.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ShowSchemasStatement)) return false;
+        ShowSchemasStatement stmt = (ShowSchemasStatement) other;
+        return Objects.equals(schemaPattern, stmt.getSchemaPattern());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(schemaPattern);
+    }
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ShowStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ShowStatement.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.parse;
+
+import org.apache.phoenix.jdbc.PhoenixStatement;
+
+/**
+ * Parent class for all SHOW statements. SHOW SCHEMAS, SHOW TABLES etc.
+ */
+public class ShowStatement implements BindableStatement {
+    @Override
+    public int getBindCount() {
+        return 0;
+    }
+
+    @Override
+    public PhoenixStatement.Operation getOperation() {
+        return PhoenixStatement.Operation.QUERY;
+    }
+
+    public ShowStatement () {}
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ShowTablesStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ShowTablesStatement.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.parse;
+
+import com.google.common.base.Preconditions;
+import org.apache.phoenix.compile.ColumnResolver;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * ParseNode implementation for SHOW TABLES [IN <schema>].
+ */
+public class ShowTablesStatement extends ShowStatement {
+    // Schema for table listing. null implies the the db for this connection is used.
+    @Nullable
+    private String targetSchema;
+
+    // Pattern to be matched while looking up for tables in 'targetSchema'.
+    // null implies everything is returned.
+    @Nullable
+    private String dbPattern;
+
+    public  ShowTablesStatement() {
+        this(null, null);
+    }
+
+    public ShowTablesStatement(@Nullable String schema, @Nullable String pattern) {
+        targetSchema = schema;
+        dbPattern = pattern;
+    }
+
+    @Nullable
+    public String getTargetSchema() {
+        return targetSchema;
+    }
+
+    @Nullable
+    public String getDbPattern() {
+        return dbPattern;
+    }
+
+    public void toSQL(ColumnResolver resolver, StringBuilder buf) {
+        Preconditions.checkNotNull(buf);
+        buf.append("SHOW TABLES");
+        if (targetSchema != null) {
+            buf.append(" IN ");
+            buf.append(targetSchema);
+            buf.append(" ");
+        }
+        if (dbPattern != null) {
+            buf.append(" LIKE ");
+            buf.append("'").append(dbPattern).append("'");
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder();
+        toSQL(null, buf);
+        return buf.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ShowTablesStatement)) return false;
+        ShowTablesStatement stmt = (ShowTablesStatement) other;
+        return Objects.equals(targetSchema, stmt.getTargetSchema()) && Objects.equals(dbPattern,
+            stmt.getDbPattern());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(targetSchema, dbPattern);
+    }
+}

--- a/phoenix-core/src/test/java/org/apache/phoenix/parse/QueryParserTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/parse/QueryParserTest.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.hbase.util.Pair;
@@ -893,7 +891,25 @@ public class QueryParserTest {
 
     @Test
     public void testLimitRVCOffsetQuery() throws Exception {
-        String sql = "SELECT * FROM T LIMIT 10 OFFSET (A,B,C)=('a','b','c')";
-        parseQuery(sql);
+      String sql = "SELECT * FROM T LIMIT 10 OFFSET (A,B,C)=('a','b','c')";
+      parseQuery(sql);
+    }
+
+    @Test
+    public void testShowStmt() throws Exception {
+        // Happy paths
+        parseQuery("show schemas");
+        parseQuery("show schemas like 'foo%'");
+        parseQuery("show tables");
+        parseQuery("show tables in foo");
+        parseQuery("show tables in foo like 'bar%'");
+        parseQuery("show tables like 'bar%'");
+
+        // Expected failures.
+        parseQueryThatShouldFail("show schemas like foo");
+        parseQueryThatShouldFail("show schemas in foo");
+        parseQueryThatShouldFail("show tables 'foo'");
+        parseQueryThatShouldFail("show tables in 'foo'");
+        parseQueryThatShouldFail("show tables like foo");
     }
 }

--- a/phoenix-pherf/src/main/java/org/apache/phoenix/pherf/util/PhoenixUtil.java
+++ b/phoenix-pherf/src/main/java/org/apache/phoenix/pherf/util/PhoenixUtil.java
@@ -18,20 +18,15 @@
 
 package org.apache.phoenix.pherf.util;
 
-import org.apache.phoenix.mapreduce.index.IndexTool;
 import org.apache.phoenix.mapreduce.index.automation.PhoenixMRJobSubmitter;
 import org.apache.phoenix.pherf.PherfConstants;
 import org.apache.phoenix.pherf.configuration.*;
-import org.apache.phoenix.pherf.jmx.MonitorManager;
-import org.apache.phoenix.pherf.result.DataLoadThreadTime;
 import org.apache.phoenix.pherf.result.DataLoadTimeSummary;
 import org.apache.phoenix.pherf.rules.RulesApplier;
-import org.apache.phoenix.pherf.util.GoogleChartGenerator.Node;
 import org.apache.phoenix.util.EnvironmentEdgeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
This patch adds new SQL grammar like following

- SHOW SCHEMAS [like '<pattern>']
- SHOW TABLES [IN <schema>] [like '<pattern']

Example invocations:

- show schemas
- show scemas like 'SYS%'
- show tables
- show tables in SYSTEM
- show tables in SYSTEM like 'CAT%'

The current way of fetching this information is by using
!tables and !schemas via sqlline JDBC support but that is
not flexible enough for the end users to add more fitlers.
This approach is more inline with what other databases do.

Added test coverage in parser tests and core e2e tests.