### PR TITLE
PHOENIX-6356 missing row.clear() for dummy row in GlobalIndexRegionScanner

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
@@ -1452,6 +1452,7 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
                     hasMoreIncr = scanner.nextRaw(row);
                     if (!row.isEmpty()) {
                         if (isDummy(row)) {
+                            row.clear();
                             continue;
                         }
                         keys.add(PVarbinary.INSTANCE.getKeyRange(CellUtil.cloneRow(row.get(0))));


### PR DESCRIPTION
If PagedScanFilter is set on the scan, a dummy row can be returned which needs to be skipped.