### PR TITLE
PHOENIX-6423 Wildcard queries fail with mixed default and explicit column families.

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ProjectionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ProjectionCompiler.java
@@ -159,6 +159,11 @@ public class ProjectionCompiler {
                         String schemaName = table.getSchemaName().getString();
                         ref = resolver.resolveColumn(schemaName.length() == 0 ? null : schemaName, table.getTableName().getString(), colName);
                     }
+                    // The freshly revolved column's family better be the same as the original one.
+                    // If not, trigger the disambiguation logic. Also see PTableImpl.getColumnForColumnName(...)
+                    if (column.getFamilyName() != null && !column.getFamilyName().equals(ref.getColumn().getFamilyName())) {
+                        throw new AmbiguousColumnException();
+                    }
                 } catch (AmbiguousColumnException e) {
                     if (column.getFamilyName() != null) {
                         ref = resolver.resolveColumn(tableAlias != null ? tableAlias : table.getTableName().getString(), column.getFamilyName().getString(), colName);


### PR DESCRIPTION
See Jira.

SELECT * is generally broken with any table table mixes C and CF.C. (i.e. the same column name in the default and an explicit column family).

After spending a lot of time debugging, turns out the fix is pretty simple.