### PR TITLE
PHOENIX-6424 SELECT cf1.* FAILS with a WHERE clause including cf2.

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MultiCfQueryExecIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MultiCfQueryExecIT.java
@@ -342,6 +342,71 @@ public class MultiCfQueryExecIT extends ParallelStatsEnabledIT {
     }
 
     @Test
+    public void testCFWildcardProjection() throws Exception {
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            String tableName = generateUniqueName();
+            String ddl =
+                    "CREATE TABLE IF NOT EXISTS " + tableName + " (pk1 INTEGER NOT NULL PRIMARY KEY, x.v1 VARCHAR, y.v2 INTEGER)";
+            conn.createStatement().execute(ddl);
+            conn.createStatement().execute("UPSERT INTO " + tableName + " VALUES(1, 'test', 2)");
+            conn.commit();
+
+            ResultSet rs = conn.createStatement().executeQuery("SELECT x.* FROM "+tableName+" WHERE y.v2 = 2");
+            assertTrue(rs.next());
+            assertEquals("test", rs.getString(1));
+            rs.close();
+
+            // make sure this works with a local index as well (only the data plan needs to be adjusted)
+            conn.createStatement().execute("CREATE LOCAL INDEX " + tableName + "_IDX ON " + tableName + "(y.v2)");
+            conn.commit();
+
+            rs = conn.createStatement().executeQuery("SELECT x.* FROM "+tableName+" WHERE y.v2 = 2");
+            assertTrue(rs.next());
+            assertEquals("test", rs.getString(1));
+            rs.close();
+
+            rs = conn.createStatement().executeQuery("SELECT y.* FROM "+tableName+" WHERE x.v1 <> 'blah'");
+            assertTrue(rs.next());
+            assertEquals(2, rs.getInt(1));
+            rs.close();
+        }
+    }
+
+    @Test
+    public void testMultipleCFWildcardProjection() throws Exception {
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            String tableName = generateUniqueName();
+            String ddl =
+                    "CREATE TABLE IF NOT EXISTS " + tableName + " (pk1 INTEGER NOT NULL PRIMARY KEY, x.v1 VARCHAR, y.v2 INTEGER, z.v3 INTEGER)";
+            conn.createStatement().execute(ddl);
+            conn.createStatement().execute("UPSERT INTO " + tableName + " VALUES(1, 'test', 2, 3)");
+            conn.commit();
+
+            ResultSet rs = conn.createStatement().executeQuery("SELECT x.*, z.* FROM "+tableName+" WHERE y.v2 = 2");
+            assertTrue(rs.next());
+            assertEquals("test", rs.getString(1));
+            assertEquals(3, rs.getInt(2));
+            rs.close();
+
+            // make sure this works with a local index as well (only the data plan needs to be adjusted)
+            conn.createStatement().execute("CREATE LOCAL INDEX " + tableName + "_IDX ON " + tableName + "(y.v2)");
+            conn.commit();
+
+            rs = conn.createStatement().executeQuery("SELECT x.*, z.* FROM "+tableName+" WHERE y.v2 = 2");
+            assertTrue(rs.next());
+            assertEquals("test", rs.getString(1));
+            assertEquals(3, rs.getInt(2));
+            rs.close();
+
+            rs = conn.createStatement().executeQuery("SELECT x.*, y.* FROM "+tableName+" WHERE z.v3 = 3");
+            assertTrue(rs.next());
+            assertEquals("test", rs.getString(1));
+            assertEquals(2, rs.getInt(2));
+            rs.close();
+        }
+    }
+
+    @Test
     public void testMixedDefaultAndExplicitCFs() throws Exception {
         try (Connection conn = DriverManager.getConnection(getUrl())) {
             String tableName = generateUniqueName();

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
@@ -496,6 +496,10 @@ public abstract class BaseResultIterators extends ExplainTable implements Result
                         trackedColumnsBitset.set(qualifier);
                     }
                 }
+            } else {
+                // cannot use EncodedQualifiersColumnProjectionFilter in this case
+                // since there's an unknown set of qualifiers (cf.*)
+                trackedColumnsBitset = null;
             }
             columnsTracker.put(cf, cols);
         }

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/EncodedColumnsUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/EncodedColumnsUtil.java
@@ -133,7 +133,7 @@ public class EncodedColumnsUtil {
          * Disabling this optimization for tables with more than one column family.
          * See PHOENIX-3890.
          */
-        return !scan.isRaw() && table.getColumnFamilies().size() <= 1 && table.getImmutableStorageScheme() != null
+        return !scan.isRaw() && table.getColumnFamilies().size() == 1 && table.getImmutableStorageScheme() != null
                 && table.getImmutableStorageScheme() == ImmutableStorageScheme.ONE_CELL_PER_COLUMN
                 && usesEncodedColumnNames(table) && !table.isTransactional()
                 && !ScanUtil.hasDynamicColumns(table);


### PR DESCRIPTION
See Jira. In the SELECT CF1.* WHERE CF2.C ... cannot use the EncodedQualifiersColumnProjectionFilter since the number of qualifiers is not know (so the trackcolumns Bitset cannot be build ahead of time).