### PR TITLE
PHOENIX-6436 OrderedResultIterator overestimates memory requirements.

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/OrderedResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/OrderedResultIterator.java
@@ -197,7 +197,8 @@ public class OrderedResultIterator implements PeekingResultIterator {
         // Make sure we don't overflow Long, though this is really unlikely to happen.
         assert(limit == null || Long.MAX_VALUE / estimatedEntrySize >= limit + this.offset);
 
-        this.estimatedByteSize = limit == null ? 0 : (limit + this.offset) * estimatedEntrySize;
+        // Both BufferedSortedQueue and SizeBoundQueue won't allocate more than thresholdBytes.
+        this.estimatedByteSize = limit == null ? 0 : Math.min((limit + this.offset) * estimatedEntrySize, thresholdBytes);
         this.pageSizeMs = pageSizeMs;
     }
 


### PR DESCRIPTION
See Jira.

the OrderedResultIterator will store topN values in either a BufferedQueue or a SizeBoundQueue. Each limit the memory used to the passed thresholdBytes (default is 20MB), the BufferQueue will spool to disk when reaching that size, SizeBoundQueue will fail.

Hence we additionally limit the worst case memory consumption to thresholdBytes.

I noticed this when implementing limit and topN pushdown for the Trino Phoenix connector: https://github.com/trinodb/trino/pull/7490