### PR TITLE
Remove duplicate entry of commons-io dependency in phoenix-pherf

### DIFF
--- a/phoenix-pherf/pom.xml
+++ b/phoenix-pherf/pom.xml
@@ -134,10 +134,6 @@
       <artifactId>phoenix-shaded-commons-cli</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
     </dependency>


### PR DESCRIPTION
Resolves the following warning in Maven logs:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.phoenix:phoenix-pherf:jar:5.2.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: commons-io:commons-io:jar -> duplicate declaration of version (?) @ line 136, column 17
[WARNING] 
```