### PR TITLE
PHOENIX-6458 Using global indexes for queries with uncovered columns

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/FromCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/FromCompiler.java
@@ -103,6 +103,7 @@ import org.apache.phoenix.thirdparty.com.google.common.collect.ListMultimap;
 import org.apache.phoenix.thirdparty.com.google.common.collect.Lists;
 
 import static org.apache.phoenix.monitoring.MetricType.NUM_METADATA_LOOKUP_FAILURES;
+import static org.apache.phoenix.util.IndexUtil.isHintedGlobalIndex;
 
 /**
  * Validates FROM clause and builds a ColumnResolver for resolving column references
@@ -1157,13 +1158,14 @@ public class FromCompiler {
     }
     
     private static class ProjectedTableColumnResolver extends MultiTableColumnResolver {
-        private final boolean isLocalIndex;
+        private final boolean isIndex;
         private final List<TableRef> theTableRefs;
         private final Map<ColumnRef, Integer> columnRefMap;
         private ProjectedTableColumnResolver(PTable projectedTable, PhoenixConnection conn, Map<String, UDFParseNode> udfParseNodes) throws SQLException {
             super(conn, 0, udfParseNodes, null);
             Preconditions.checkArgument(projectedTable.getType() == PTableType.PROJECTED);
-            this.isLocalIndex = projectedTable.getIndexType() == IndexType.LOCAL;
+            this.isIndex = projectedTable.getIndexType() == IndexType.LOCAL
+                    || projectedTable.getIndexType() == IndexType.GLOBAL;
             this.columnRefMap = new HashMap<ColumnRef, Integer>();
             long ts = Long.MAX_VALUE;
             for (int i = projectedTable.getBucketNum() == null ? 0 : 1; i < projectedTable.getColumns().size(); i++) {
@@ -1201,9 +1203,11 @@ public class FromCompiler {
             try {
                 colRef = super.resolveColumn(schemaName, tableName, colName);
             } catch (ColumnNotFoundException e) {
-                // This could be a ColumnRef for local index data column.
-                TableRef tableRef = isLocalIndex ? super.getTables().get(0) : super.resolveTable(schemaName, tableName);
-                if (tableRef.getTable().getIndexType() == IndexType.LOCAL) {
+                // This could be a ColumnRef for index data column.
+                TableRef tableRef = isIndex ? super.getTables().get(0)
+                        : super.resolveTable(schemaName, tableName);
+                if (tableRef.getTable().getIndexType() == IndexType.LOCAL
+                        || isHintedGlobalIndex(tableRef)) {
                     try {
                         TableRef parentTableRef = super.resolveTable(
                                 tableRef.getTable().getSchemaName().getString(),

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/StatementContext.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/StatementContext.java
@@ -87,6 +87,7 @@ public class StatementContext {
     private final OverAllQueryMetrics overAllQueryMetrics;
     private QueryLogger queryLogger;
     private boolean isClientSideUpsertSelect;
+    private boolean isUncoveredIndex;
     
     public StatementContext(PhoenixStatement statement) {
         this(statement, new Scan());
@@ -332,6 +333,14 @@ public class StatementContext {
 
     public void setClientSideUpsertSelect(boolean isClientSideUpsertSelect) {
         this.isClientSideUpsertSelect = isClientSideUpsertSelect;
+    }
+
+    public boolean isUncoveredIndex() {
+        return isUncoveredIndex;
+    }
+
+    public void setUncoveredIndex(boolean isUncoveredIndex) {
+        this.isUncoveredIndex = isUncoveredIndex;
     }
 
     /*

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/TupleProjectionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/TupleProjectionCompiler.java
@@ -18,6 +18,7 @@
 package org.apache.phoenix.compile;
 import static org.apache.phoenix.query.QueryConstants.VALUE_COLUMN_FAMILY;
 import static org.apache.phoenix.query.QueryConstants.BASE_TABLE_BASE_COLUMN_COUNT;
+import static org.apache.phoenix.util.IndexUtil.isHintedGlobalIndex;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -41,13 +42,12 @@ import org.apache.phoenix.parse.WildcardParseNode;
 import org.apache.phoenix.schema.ColumnFamilyNotFoundException;
 import org.apache.phoenix.schema.ColumnNotFoundException;
 import org.apache.phoenix.schema.ColumnRef;
-import org.apache.phoenix.schema.LocalIndexDataColumnRef;
+import org.apache.phoenix.schema.IndexDataColumnRef;
 import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PName;
 import org.apache.phoenix.schema.PNameFactory;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTable.EncodedCQCounter;
-import org.apache.phoenix.schema.PTable.IndexType;
 import org.apache.phoenix.schema.PTableImpl;
 import org.apache.phoenix.schema.PTableType;
 import org.apache.phoenix.schema.ProjectedColumn;
@@ -159,13 +159,17 @@ public class TupleProjectionCompiler {
             	EncodedColumnsUtil.setColumns(column, table, context.getScan());
             }
         }
-        // add LocalIndexDataColumnRef
+        // add IndexDataColumnRef
         position = projectedColumns.size();
-        for (LocalIndexDataColumnRef sourceColumnRef : visitor.localIndexColumnRefSet) {
+        for (IndexDataColumnRef sourceColumnRef : visitor.indexColumnRefSet) {
             PColumn column = new ProjectedColumn(sourceColumnRef.getColumn().getName(), 
                     sourceColumnRef.getColumn().getFamilyName(), position++, 
                     sourceColumnRef.getColumn().isNullable(), sourceColumnRef, sourceColumnRef.getColumn().getColumnQualifierBytes());
             projectedColumns.add(column);
+        }
+        if (!visitor.indexColumnRefSet.isEmpty()
+                && tableRef.isHinted()) {
+            context.setUncoveredIndex(true);
         }
         return PTableImpl.builderWithColumns(table, projectedColumns)
                 .setType(PTableType.PROJECTED)
@@ -235,12 +239,12 @@ public class TupleProjectionCompiler {
     private static class ColumnRefVisitor extends StatelessTraverseAllParseNodeVisitor {
         private final StatementContext context;
         private final LinkedHashSet<ColumnRef> nonPkColumnRefSet;
-        private final LinkedHashSet<LocalIndexDataColumnRef> localIndexColumnRefSet;
+        private final LinkedHashSet<IndexDataColumnRef> indexColumnRefSet;
         
         private ColumnRefVisitor(StatementContext context) {
             this.context = context;
             this.nonPkColumnRefSet = new LinkedHashSet<ColumnRef>();
-            this.localIndexColumnRefSet = new LinkedHashSet<LocalIndexDataColumnRef>();
+            this.indexColumnRefSet = new LinkedHashSet<IndexDataColumnRef>();
         }
 
         @Override
@@ -252,9 +256,12 @@ public class TupleProjectionCompiler {
                     nonPkColumnRefSet.add(resolveColumn);
                 }
             } catch (ColumnNotFoundException e) {
-                if (context.getCurrentTable().getTable().getIndexType() == IndexType.LOCAL) {
+                if (context.getCurrentTable().getTable().getIndexType() == PTable.IndexType.LOCAL
+                        || isHintedGlobalIndex(context.getCurrentTable())) {
                     try {
-                        localIndexColumnRefSet.add(new LocalIndexDataColumnRef(context, context.getCurrentTable(), node.getName()));
+                        context.setUncoveredIndex(true);
+                        indexColumnRefSet.add(new IndexDataColumnRef(context,
+                                context.getCurrentTable(), node.getName()));
                     } catch (ColumnFamilyNotFoundException c) {
                         throw e;
                     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
@@ -69,6 +69,7 @@ abstract public class BaseScannerRegionObserver extends CompatBaseScannerRegionO
     public static final String GROUP_BY_LIMIT = "_GroupByLimit";
     public static final String LOCAL_INDEX = "_LocalIndex";
     public static final String LOCAL_INDEX_BUILD = "_LocalIndexBuild";
+    public static final String UNCOVERED_GLOBAL_INDEX = "_UncoveredGlobalIndex";
     public static final String INDEX_REBUILD_PAGING = "_IndexRebuildPaging";
     // The number of index rows to be rebuild in one RPC call
     public static final String INDEX_REBUILD_PAGE_ROWS = "_IndexRebuildPageRows";
@@ -80,9 +81,15 @@ abstract public class BaseScannerRegionObserver extends CompatBaseScannerRegionO
         "_IndexRebuildDisableLoggingVerifyType";
     public static final String INDEX_REBUILD_DISABLE_LOGGING_BEYOND_MAXLOOKBACK_AGE =
         "_IndexRebuildDisableLoggingBeyondMaxLookbackAge";
+    @Deprecated
     public static final String LOCAL_INDEX_FILTER = "_LocalIndexFilter";
+    @Deprecated
     public static final String LOCAL_INDEX_LIMIT = "_LocalIndexLimit";
+    @Deprecated
     public static final String LOCAL_INDEX_FILTER_STR = "_LocalIndexFilterStr";
+    public static final String INDEX_FILTER = "_IndexFilter";
+    public static final String INDEX_LIMIT = "_IndexLimit";
+    public static final String INDEX_FILTER_STR = "_IndexFilterStr";
 
     /* 
     * Attribute to denote that the index maintainer has been serialized using its proto-buf presentation.

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/GroupedAggregateRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/GroupedAggregateRegionObserver.java
@@ -144,13 +144,8 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver im
                             .getEnvironment().getConfiguration(), em);
     
             RegionScanner innerScanner = s;
-            boolean useProto = false;
-            byte[] localIndexBytes = scan.getAttribute(LOCAL_INDEX_BUILD_PROTO);
-            useProto = localIndexBytes != null;
-            if (localIndexBytes == null) {
-                localIndexBytes = scan.getAttribute(LOCAL_INDEX_BUILD);
-            }
-            List<IndexMaintainer> indexMaintainers = localIndexBytes == null ? null : IndexMaintainer.deserialize(localIndexBytes, useProto);
+            List<IndexMaintainer> indexMaintainers =
+                    IndexUtil.deSerializeIndexMaintainersFromScan(scan);
             TupleProjector tupleProjector = null;
             byte[][] viewConstants = null;
             ColumnReference[] dataColumns = IndexUtil.deserializeDataTableColumnsToJoin(scan);
@@ -158,7 +153,8 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver im
             final TupleProjector p = TupleProjector.deserializeProjectorFromScan(scan);
             final HashJoinInfo j = HashJoinInfo.deserializeHashJoinFromScan(scan);
             boolean useQualifierAsIndex = EncodedColumnsUtil.useQualifierAsIndex(EncodedColumnsUtil.getMinMaxQualifiersFromScan(scan));
-            if (ScanUtil.isLocalIndex(scan) || (j == null && p != null)) {
+            if (ScanUtil.isLocalOrUncoveredGlobalIndex(scan)
+                    || (j == null && p != null)) {
                 if (dataColumns != null) {
                     tupleProjector = IndexUtil.getTupleProjector(scan, dataColumns);
                     viewConstants = IndexUtil.deserializeViewConstantsFromScan(scan);

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
@@ -281,13 +281,14 @@ public abstract class BaseResultIterators extends ExplainTable implements Result
             }
 
             if (perScanLimit != null) {
-                if (scan.getAttribute(BaseScannerRegionObserver.LOCAL_INDEX_FILTER) == null) {
+                if (scan.getAttribute(BaseScannerRegionObserver.INDEX_FILTER) == null) {
                     ScanUtil.andFilterAtEnd(scan, new PageFilter(perScanLimit));
                 } else {
-                    // if we have a local index filter and a limit, handle the limit after the filter
+                    // if we have an index filter and a limit, handle the limit after the filter
                     // we cast the limit to a long even though it passed as an Integer so that
                     // if we need extend this in the future the serialization is unchanged
-                    scan.setAttribute(BaseScannerRegionObserver.LOCAL_INDEX_LIMIT, Bytes.toBytes((long)perScanLimit));
+                    scan.setAttribute(BaseScannerRegionObserver.INDEX_LIMIT,
+                            Bytes.toBytes((long) perScanLimit));
                 }
             }
             

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
@@ -191,7 +191,11 @@ public abstract class ExplainTable {
         if (whereFilter != null) {
             whereFilterStr = whereFilter.toString();
         } else {
-            byte[] expBytes = scan.getAttribute(BaseScannerRegionObserver.LOCAL_INDEX_FILTER_STR);
+            byte[] expBytes = scan.getAttribute(BaseScannerRegionObserver.INDEX_FILTER_STR);
+            if (expBytes == null) {
+                // For older clients
+                expBytes = scan.getAttribute(BaseScannerRegionObserver.LOCAL_INDEX_FILTER_STR);
+            }
             if (expBytes != null) {
                 whereFilterStr = Bytes.toString(expBytes);
             }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/NonAggregateRegionScannerFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/NonAggregateRegionScannerFactory.java
@@ -128,21 +128,15 @@ public class NonAggregateRegionScannerFactory extends RegionScannerFactory {
     PhoenixTransactionContext tx = null;
     ColumnReference[] dataColumns = IndexUtil.deserializeDataTableColumnsToJoin(scan);
     if (dataColumns != null) {
-      tupleProjector = IndexUtil.getTupleProjector(scan, dataColumns);
-      dataRegion = env.getRegion();
-      boolean useProto = false;
-      byte[] localIndexBytes = scan.getAttribute(BaseScannerRegionObserver.LOCAL_INDEX_BUILD_PROTO);
-      useProto = localIndexBytes != null;
-      if (localIndexBytes == null) {
-        localIndexBytes = scan.getAttribute(BaseScannerRegionObserver.LOCAL_INDEX_BUILD);
-      }
-      int clientVersion = ScanUtil.getClientVersion(scan);
-      List<IndexMaintainer> indexMaintainers =
-              IndexMaintainer.deserialize(localIndexBytes, useProto);
-      indexMaintainer = indexMaintainers.get(0);
-      viewConstants = IndexUtil.deserializeViewConstantsFromScan(scan);
-      byte[] txState = scan.getAttribute(BaseScannerRegionObserver.TX_STATE);
-      tx = TransactionFactory.getTransactionContext(txState, clientVersion);
+        tupleProjector = IndexUtil.getTupleProjector(scan, dataColumns);
+        dataRegion = env.getRegion();
+        int clientVersion = ScanUtil.getClientVersion(scan);
+        List<IndexMaintainer> indexMaintainers =
+                IndexUtil.deSerializeIndexMaintainersFromScan(scan);
+        indexMaintainer = indexMaintainers.get(0);
+        viewConstants = IndexUtil.deserializeViewConstantsFromScan(scan);
+        byte[] txState = scan.getAttribute(BaseScannerRegionObserver.TX_STATE);
+        tx = TransactionFactory.getTransactionContext(txState, clientVersion);
     }
 
     final TupleProjector p = TupleProjector.deserializeProjectorFromScan(scan);

--- a/phoenix-core/src/main/java/org/apache/phoenix/optimize/QueryOptimizer.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/optimize/QueryOptimizer.java
@@ -334,6 +334,7 @@ public class QueryOptimizer {
         boolean isProjected = dataPlan.getContext().getResolver().getTables().get(0).getTable().getType() == PTableType.PROJECTED;
         // Check index state of now potentially updated index table to make sure it's active
         TableRef indexTableRef = resolver.getTables().get(0);
+        indexTableRef.setHinted(isHinted);
         Map<TableRef, QueryPlan> dataPlans = Collections.singletonMap(indexTableRef, dataPlan);
         PTable indexTable = indexTableRef.getTable();
         PIndexState indexState = indexTable.getIndexState();

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/TableRef.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/TableRef.java
@@ -38,6 +38,7 @@ public class TableRef {
     private final long lowerBoundTimeStamp;
     private final boolean hasDynamicCols;
     private final long currentTime;
+    private boolean hinted;
 
     private static TableRef createEmptyTableRef() {
         try {
@@ -53,15 +54,18 @@ public class TableRef {
     }
 
     public TableRef(TableRef tableRef) {
-        this(tableRef.alias, tableRef.table, tableRef.upperBoundTimeStamp, tableRef.lowerBoundTimeStamp, tableRef.hasDynamicCols);
+        this(tableRef.alias, tableRef.table, tableRef.upperBoundTimeStamp,
+                tableRef.lowerBoundTimeStamp, tableRef.hasDynamicCols, tableRef.hinted);
     }
     
     public TableRef(TableRef tableRef, long timeStamp) {
-        this(tableRef.alias, tableRef.table, timeStamp, tableRef.lowerBoundTimeStamp, tableRef.hasDynamicCols);
+        this(tableRef.alias, tableRef.table, timeStamp, tableRef.lowerBoundTimeStamp,
+                tableRef.hasDynamicCols, tableRef.hinted);
     }
     
     public TableRef(TableRef tableRef, String alias) {
-        this(alias, tableRef.table, tableRef.upperBoundTimeStamp, tableRef.lowerBoundTimeStamp, tableRef.hasDynamicCols);
+        this(alias, tableRef.table, tableRef.upperBoundTimeStamp, tableRef.lowerBoundTimeStamp,
+                tableRef.hasDynamicCols, tableRef.hinted);
     }
     
     public TableRef(PTable table) {
@@ -69,15 +73,20 @@ public class TableRef {
     }
     
     public TableRef(PTable table, long upperBoundTimeStamp, long lowerBoundTimeStamp) {
-        this(null, table, upperBoundTimeStamp, lowerBoundTimeStamp, false);
+        this(null, table, upperBoundTimeStamp, lowerBoundTimeStamp, false, false);
     }
 
     public TableRef(String alias, PTable table, long upperBoundTimeStamp, boolean hasDynamicCols) {
-        this(alias, table, upperBoundTimeStamp, 0, hasDynamicCols);
+        this(alias, table, upperBoundTimeStamp, 0, hasDynamicCols, false);
+    }
+
+    public TableRef(String alias, PTable table, long upperBoundTimeStamp, long lowerBoundTimeStamp,
+                    boolean hasDynamicCols) {
+        this(alias, table, upperBoundTimeStamp, lowerBoundTimeStamp, hasDynamicCols, false);
     }
     
-    public TableRef(String alias, PTable table, long upperBoundTimeStamp, long lowerBoundTimeStamp, 
-        boolean hasDynamicCols) {
+    public TableRef(String alias, PTable table, long upperBoundTimeStamp, long lowerBoundTimeStamp,
+        boolean hasDynamicCols, boolean hinted) {
         this.alias = alias;
         this.table = table;
         // if UPDATE_CACHE_FREQUENCY is set, always let the server set timestamps
@@ -85,6 +94,7 @@ public class TableRef {
         this.currentTime = this.upperBoundTimeStamp;
         this.lowerBoundTimeStamp = lowerBoundTimeStamp;
         this.hasDynamicCols = hasDynamicCols;
+        this.hinted = hinted;
     }
     
     public PTable getTable() {
@@ -101,6 +111,14 @@ public class TableRef {
 
     public String getTableAlias() {
         return alias;
+    }
+
+    public boolean isHinted() {
+        return hinted;
+    }
+
+    public void setHinted(boolean hinted) {
+        this.hinted = hinted;
     }
 
     public String getColumnDisplayName(ColumnRef ref, boolean cfCaseSensitive, boolean cqCaseSensitive) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
@@ -133,8 +133,19 @@ public class ScanUtil {
         scan.setAttribute(BaseScannerRegionObserver.LOCAL_INDEX, PDataType.TRUE_BYTES);
     }
 
+    public static void setUncoveredGlobalIndex(Scan scan) {
+        scan.setAttribute(BaseScannerRegionObserver.UNCOVERED_GLOBAL_INDEX, PDataType.TRUE_BYTES);
+    }
+
     public static boolean isLocalIndex(Scan scan) {
         return scan.getAttribute(BaseScannerRegionObserver.LOCAL_INDEX) != null;
+    }
+    public static boolean isUncoveredGlobalIndex(Scan scan) {
+        return scan.getAttribute(BaseScannerRegionObserver.UNCOVERED_GLOBAL_INDEX) != null;
+    }
+
+    public static boolean isLocalOrUncoveredGlobalIndex(Scan scan) {
+        return isLocalIndex(scan) || isUncoveredGlobalIndex(scan);
     }
 
     public static boolean isNonAggregateScan(Scan scan) {


### PR DESCRIPTION
The Phoenix query optimizer does not use a global index for a query with the columns that are not covered by the global index if the query does not have the corresponding index hint for this index. With the index hint, the optimizer rewrites the query where the index is used within a subquery. With this subquery, the row keys of the index rows that satisfy the subquery are retrieved by the Phoenix client and then pushed into the Phoenix server caches of the data table regions. Finally, on the server side, data table rows are scanned and joined with the index rows using HashJoin. Based on the selectivity of the original query, this join operation may still result in scanning a large amount of data table rows. 

Eliminating these data table scans would be a significant improvement. To do that, instead of rewriting the query, the Phoenix optimizer simply treats the global index as a covered index for the given query. With this, the Phoenix query optimizer chooses the index table for the query especially when the index row key prefix length is greater than the data row key prefix length for the query. On the server side, the index table is scanned using index row key ranges implied by the query and the index row keys are then mapped to the data table row keys (please note an index row key includes all the data row key columns). Finally, the corresponding data table rows are scanned using server-to-server RPCs.  [PHOENIX-6458](https://issues.apache.org/jira/browse/PHOENIX-6458) (this PR) retrieves the data table rows one by one using the HBase get operation. [PHOENIX-6501](https://issues.apache.org/jira/browse/PHOENIX-6501) replaces this get operation with the scan operation to reduce the number of server-to-server RPC calls.