### PR TITLE
PHOENIX-6526 Bump default HBase version on 2.3 profile to 2.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <!-- The default hbase versions to build with (override with hbase.version) -->
     <hbase-2.1.runtime.version>2.1.10</hbase-2.1.runtime.version>
     <hbase-2.2.runtime.version>2.2.6</hbase-2.2.runtime.version>
-    <hbase-2.3.runtime.version>2.3.5</hbase-2.3.runtime.version>
+    <hbase-2.3.runtime.version>2.3.6</hbase-2.3.runtime.version>
     <hbase-2.4.0.runtime.version>2.4.0</hbase-2.4.0.runtime.version>
     <hbase-2.4.runtime.version>2.4.4</hbase-2.4.runtime.version>
 


### PR DESCRIPTION
# [PHOENIX-6526](https://issues.apache.org/jira/browse/PHOENIX-6526): Bump default HBase version on 2.3 profile to 2.3.6

## Description
HBase 2.3.6 is released on Aug 2, and the 2.3.6 is more stable than the previous version.

## Documentation
N/A

## Testing
Build with the hbase 2.3.6, skip the unit tests :
```bash
mvn clean install -DskipTests -Dhbase.profile=2.3 -Dhbase.version=2.3.6
```
<pre>
[INFO] Reactor Summary for Apache Phoenix 5.1.3-SNAPSHOT:
[INFO] 
[INFO] Apache Phoenix ..................................... SUCCESS [  1.715 s]
[INFO] Phoenix Hbase 2.4.1 compatibility .................. SUCCESS [  2.796 s]
[INFO] Phoenix Hbase 2.4.0 compatibility .................. SUCCESS [  1.622 s]
[INFO] Phoenix Hbase 2.3.0 compatibility .................. SUCCESS [  1.448 s]
[INFO] Phoenix Hbase 2.2.5 compatibility .................. SUCCESS [  1.129 s]
[INFO] Phoenix Hbase 2.1.6 compatibility .................. SUCCESS [  1.178 s]
[INFO] Phoenix Core ....................................... SUCCESS [ 21.269 s]
[INFO] Phoenix - Pherf .................................... SUCCESS [  5.653 s]
[INFO] Phoenix Client Parent .............................. SUCCESS [  0.019 s]
[INFO] Phoenix Client ..................................... SUCCESS [02:57 min]
[INFO] Phoenix Client Embedded ............................ SUCCESS [02:50 min]
[INFO] Phoenix Server JAR ................................. SUCCESS [ 38.277 s]
[INFO] Phoenix - Tracing Web Application .................. SUCCESS [  4.771 s]
[INFO] Phoenix Assembly ................................... SUCCESS [ 13.399 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
</pre>