### PR TITLE
PHOENIX-5893 Code coverage report not generated sometimes because of …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,7 @@
           <configuration>
             <encoding>UTF-8</encoding>
             <forkCount>${numForkedIT}</forkCount>
+            <forkedProcessExitTimeoutInSeconds>180</forkedProcessExitTimeoutInSeconds>
             <runOrder>alphabetical</runOrder>
             <redirectTestOutputToFile>${test.output.tofile}</redirectTestOutputToFile>
             <shutdown>kill</shutdown>
@@ -552,6 +553,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>${numForkedUT}</forkCount>
+          <forkedProcessExitTimeoutInSeconds>180</forkedProcessExitTimeoutInSeconds>
           <reuseForks>true</reuseForks>
           <argLine>@{jacocoArgLine} -enableassertions -Xmx2250m -XX:MaxPermSize=128m
             -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <maven-antlr-eclipse-plugin.version>${antlr.version}</maven-antlr-eclipse-plugin.version>
     <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
     <!-- Override property in ASF parent -->
-    <surefire.version>2.22.2</surefire.version>
+    <surefire.version>3.0.0-M5</surefire.version>
     <spotbugs-maven-plugin.version>4.1.3</spotbugs-maven-plugin.version>
     <spotbugs.version>4.1.3</spotbugs.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>


### PR DESCRIPTION
…malformed input

increase forkedProcessExitTimeoutInSeconds to 180s