### PR TITLE
PHOENIX-5893 Code coverage report not generated sometimes because of …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,7 @@
           <configuration>
             <encoding>UTF-8</encoding>
             <forkCount>${numForkedIT}</forkCount>
+            <forkedProcessExitTimeoutInSeconds>180</forkedProcessExitTimeoutInSeconds>
             <runOrder>alphabetical</runOrder>
             <redirectTestOutputToFile>${test.output.tofile}</redirectTestOutputToFile>
             <shutdown>kill</shutdown>
@@ -501,6 +502,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>${numForkedUT}</forkCount>
+          <forkedProcessExitTimeoutInSeconds>180</forkedProcessExitTimeoutInSeconds>
           <reuseForks>true</reuseForks>
           <argLine>@{jacocoArgLine} -enableassertions -Xmx2250m -XX:MaxPermSize=128m
             -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/</argLine>


### PR DESCRIPTION
…malformed input

increase forkedProcessExitTimeoutInSeconds to 180s