### PR TITLE
PHOENIX-6545 IndexToolForNonTxGlobalIndexIT.testIndexToolFailedMapper…

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexToolForNonTxGlobalIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexToolForNonTxGlobalIndexIT.java
@@ -622,9 +622,7 @@ public class IndexToolForNonTxGlobalIndexIT extends BaseUniqueNamesOwnClusterIT 
 
     @Test
     public void testIndexToolFailedMapperNotRecordToResultTable() throws Exception {
-        if (mutable != true || singleCell != true ) {
-            return;
-        }
+        Assume.assumeTrue(HbaseCompatCapabilities.isRawFilterSupported() && mutable && singleCell);
         Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
         try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
             String schemaName = generateUniqueName();


### PR DESCRIPTION
…NotRecordToResultTable() fails with HBase 2.1