### PR TITLE
PHOENIX-6568 NullPointerException in phoenix-queryserver-client not i…

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixResultSetMetaData.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixResultSetMetaData.java
@@ -117,7 +117,7 @@ public class PhoenixResultSetMetaData implements ResultSetMetaData {
     @Override
     public String getColumnTypeName(int column) throws SQLException {
         PDataType type = rowProjector.getColumnProjector(column-1).getExpression().getDataType();
-        return type == null ? null : type.getSqlTypeName();
+        return type == null ? "NULL" : type.getSqlTypeName();
     }
 
     @Override

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixResultSetMetadataTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixResultSetMetadataTest.java
@@ -24,7 +24,6 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 
 import org.apache.phoenix.query.BaseConnectionlessQueryTest;
-import org.apache.phoenix.query.QueryConstants;
 import org.junit.Test;
 
 public class PhoenixResultSetMetadataTest extends BaseConnectionlessQueryTest {
@@ -41,5 +40,13 @@ public class PhoenixResultSetMetadataTest extends BaseConnectionlessQueryTest {
         assertEquals(15, rs.getMetaData().getColumnDisplaySize(3));
         assertEquals(conn.unwrap(PhoenixConnection.class).getDatePattern().length(), rs.getMetaData().getColumnDisplaySize(4));
         assertEquals(40, rs.getMetaData().getColumnDisplaySize(5));
+    }
+
+    @Test
+    public void testNullTypeName() throws Exception {
+        Connection conn = DriverManager.getConnection(getUrl());
+        ResultSet rs = conn.createStatement().executeQuery("select null");
+
+        assertEquals("NULL", rs.getMetaData().getColumnTypeName(1));
     }
 }


### PR DESCRIPTION
…n phoenix-client-hbase

return "NULL" instead of null in ResultSetMetaData.getColumnTypeName() for null type