### PR TITLE
PHOENIX-6582 Bump default HBase version to 2.3.7 and 2.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,9 +86,9 @@
     <!-- The default hbase versions to build with (override with hbase.version) -->
     <hbase-2.1.runtime.version>2.1.10</hbase-2.1.runtime.version>
     <hbase-2.2.runtime.version>2.2.7</hbase-2.2.runtime.version>
-    <hbase-2.3.runtime.version>2.3.6</hbase-2.3.runtime.version>
+    <hbase-2.3.runtime.version>2.3.7</hbase-2.3.runtime.version>
     <hbase-2.4.0.runtime.version>2.4.0</hbase-2.4.0.runtime.version>
-    <hbase-2.4.runtime.version>2.4.6</hbase-2.4.runtime.version>
+    <hbase-2.4.runtime.version>2.4.8</hbase-2.4.runtime.version>
 
     <!-- General Properties -->
     <antlr-input.dir>src/main/antlr3</antlr-input.dir>


### PR DESCRIPTION
# [PHOENIX-6582](https://issues.apache.org/jira/browse/PHOENIX-6582): Bump default HBase version to 2.3.7 and 2.4.8
## Description
N/A

## Documentation
N/A

## Testing
Build with the hbase 2.3.7 and 2.4.8, skip the unit tests :
```bash
mvn clean install -DskipTests -Dhbase.profile=2.3 -Dhbase.version=2.3.7
mvn clean install -DskipTests -Dhbase.profile=2.4 -Dhbase.version=2.4.8
```
<pre>
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Phoenix 5.1.3-SNAPSHOT:
[INFO] 
[INFO] Apache Phoenix ..................................... SUCCESS [  3.868 s]
[INFO] Phoenix Hbase 2.4.1 compatibility .................. SUCCESS [ 17.509 s]
[INFO] Phoenix Hbase 2.4.0 compatibility .................. SUCCESS [  1.541 s]
[INFO] Phoenix Hbase 2.3.0 compatibility .................. SUCCESS [  1.973 s]
[INFO] Phoenix Hbase 2.2.5 compatibility .................. SUCCESS [  1.322 s]
[INFO] Phoenix Hbase 2.1.6 compatibility .................. SUCCESS [  1.180 s]
[INFO] Phoenix Core ....................................... SUCCESS [ 20.284 s]
[INFO] Phoenix - Pherf .................................... SUCCESS [  9.079 s]
[INFO] Phoenix - Tracing Web Application .................. SUCCESS [  5.207 s]
[INFO] Phoenix Client Parent .............................. SUCCESS [  0.029 s]
[INFO] Phoenix Client ..................................... SUCCESS [03:07 min]
[INFO] Phoenix Client Embedded ............................ SUCCESS [03:22 min]
[INFO] Phoenix Server JAR ................................. SUCCESS [ 47.652 s]
[INFO] Phoenix Assembly ................................... SUCCESS [ 13.922 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
</pre>