### PR TITLE
PHOENIX-6604 Allow using indexes for wildcard topN queries on salted tables

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/TupleProjectionCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/TupleProjectionCompiler.java
@@ -51,6 +51,7 @@ import org.apache.phoenix.schema.PTable.IndexType;
 import org.apache.phoenix.schema.PTableImpl;
 import org.apache.phoenix.schema.PTableType;
 import org.apache.phoenix.schema.ProjectedColumn;
+import org.apache.phoenix.schema.SaltingUtil;
 import org.apache.phoenix.schema.TableRef;
 import org.apache.phoenix.util.EncodedColumnsUtil;
 import org.apache.phoenix.util.IndexUtil;
@@ -90,6 +91,10 @@ public class TupleProjectionCompiler {
                             table.getSchemaName().getString(),
                             table.getParentTableName().getString());
                     for (PColumn column : parentTableRef.getTable().getColumns()) {
+                        // don't attempt to rewrite the parents SALTING COLUMN
+                        if (column == SaltingUtil.SALTING_COLUMN) {
+                            continue;
+                        }
                         NODE_FACTORY.column(null, '"' + IndexUtil.getIndexColumnName(column) + '"', null).accept(visitor);
                     }
                 }


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/PHOENIX-6604
Basically due to incorrect resolution of columns any index on a wildcard query * or count(*) will incorrectly be rejected for salted tables.