### PR TITLE
PHOENIX-6671 Avoid ShortCirtuation Coprocessor Connection with HBase 2.x

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ServerUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ServerUtil.java
@@ -311,7 +311,7 @@ public class ServerUtil {
                 @Override
                     public Connection apply(ConnectionType t) {
                     try {
-                        return env.createConnection(getTypeSpecificConfiguration(connectionType, env.getConfiguration()));
+                        return org.apache.hadoop.hbase.client.ConnectionFactory.createConnection(getTypeSpecificConfiguration(connectionType, env.getConfiguration()));
                     } catch (IOException e) {
                        throw new RuntimeException(e);
                     }


### PR DESCRIPTION
From Jira: 
See [PHOENIX-6501](https://issues.apache.org/jira/browse/PHOENIX-6501), [PHOENIX-6458](https://issues.apache.org/jira/browse/PHOENIX-6458), and [HBASE-26812](https://issues.apache.org/jira/browse/HBASE-26812).

HBase's ShortCircuit Connection are fundamentally broken in HBase 2. We might be able to fix it there, but with all the work the RPC handlers perform now (closing scanning, resolving current user, etc), I doubt we'll get that 100% right. HBase 3 has removed this functionality.

Even with HBase 2, which does not have the async protobuf code, I could hardly see any performance improvement from circumventing the RPC stack in case the target of a Get or Scan is local. Even in the most ideal conditions where everything is local, there was improvement outside of noise.

I suggest we do not use ShortCircuited Connections in Phoenix 5+.