### PR TITLE
PHOENIX-6682 Jenkins tests are failing for Java 11.0.14.1

### DIFF
--- a/dev/docker/Dockerfile.multibranch
+++ b/dev/docker/Dockerfile.multibranch
@@ -28,10 +28,11 @@ RUN mkdir -p /run/user/910/gnupg/ \
     && chown -R 910:910 /var/run/user/910 \
     && chmod -R 700 /var/run/user/910
 #####
-# Update Java 11 packages to 11.0.11 (to avoid Java 11.0.9.1 version Jetty bug)
+# Pin the Java 11 packages to the release version to avoid the Java four number version Jetty bug
+# We cannot pin to an updated version, because Ubuntu removes old updates from its repos.
 #####
 RUN apt-get update \
-    && apt-get -q install --no-install-recommends -y openjdk-11-jdk-headless openjdk-11-jre-headless openjdk-11-jre
+    && apt-get -q install --no-install-recommends -y openjdk-11-jdk-headless=11.0.7+10-3ubuntu1 openjdk-11-jre-headless=11.0.7+10-3ubuntu1 openjdk-11-jre=11.0.7+10-3ubuntu1
 #####
 # Set default JDK to 11
 #####

--- a/dev/docker/Dockerfile.yetus
+++ b/dev/docker/Dockerfile.yetus
@@ -40,7 +40,9 @@ RUN mkdir -p /run/user/910/gnupg/ \
     && chown -R 910:910 /var/run/user/910 \
     && chmod -R 700 /var/run/user/910
 #####
-# Update Java 11 packages to 11.0.11 (to avoid Java 11.0.9.1 version Jetty bug)
+# Update Java 11 packages to the latest.
+# We don't have to care about avoiding the micro versions, because this runs with HBase 2.4,
+# which has a fixed Jetty.
 #####
 RUN apt-get update \
     && apt-get -q install --no-install-recommends -y openjdk-11-jdk-headless openjdk-11-jre-headless openjdk-11-jre


### PR DESCRIPTION
pin Java11 to the Ubuntu 20.04 release version