### PR TITLE
PHOENIX-6723 Update client to use Zookeeper 3.5.7 and Curator 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
     <stream.version>2.9.5</stream.version>
     <i18n-util.version>1.0.4</i18n-util.version>
     <guice.version>4.0</guice.version>
-    <zookeeper.version>3.4.14</zookeeper.version>
-    <curator.version>4.0.0</curator.version>
+    <zookeeper.version>3.5.7</zookeeper.version>
+    <curator.version>4.2.0</curator.version>
     <jcodings.version>1.0.55</jcodings.version>
     <thrift.version>0.9.3-1</thrift.version>
     <!-- Test Dependencies -->
@@ -1532,7 +1532,6 @@
         <hbase.compat.version>2.4.1</hbase.compat.version>
         <hbase.version>${hbase-2.4.runtime.version}</hbase.version>
         <hbase.thirdparty.version>3.4.1</hbase.thirdparty.version>
-        <zookeeper.version>3.5.7</zookeeper.version>
         <tephra.hbase.compat.version>2.4</tephra.hbase.compat.version>
       </properties>
     </profile>
@@ -1550,7 +1549,6 @@
         <hbase.compat.version>2.3.0</hbase.compat.version>
         <hbase.version>${hbase-2.3.runtime.version}</hbase.version>
         <hbase.thirdparty.version>3.3.0</hbase.thirdparty.version>
-        <zookeeper.version>3.5.7</zookeeper.version>
         <hadoop.version>3.1.3</hadoop.version>
         <tephra.hbase.compat.version>2.3</tephra.hbase.compat.version>
       </properties>
@@ -1569,7 +1567,6 @@
         <hbase.compat.version>2.4.0</hbase.compat.version>
         <hbase.version>${hbase-2.4.0.runtime.version}</hbase.version>
         <hbase.thirdparty.version>3.4.1</hbase.thirdparty.version>
-        <zookeeper.version>3.5.7</zookeeper.version>
         <tephra.hbase.compat.version>2.4</tephra.hbase.compat.version>
       </properties>
     </profile>
@@ -1587,7 +1584,6 @@
         <hbase.compat.version>2.4.1</hbase.compat.version>
         <hbase.version>${hbase-2.4.runtime.version}</hbase.version>
         <hbase.thirdparty.version>3.4.1</hbase.thirdparty.version>
-        <zookeeper.version>3.5.7</zookeeper.version>
         <tephra.hbase.compat.version>2.4</tephra.hbase.compat.version>
       </properties>
     </profile>


### PR DESCRIPTION
Previous Zookeeper version was broken on JDK 14+ due to the incorrect usage of
InetSocketAddress.toString. For reference see: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8232369