### PR TITLE
PHOENIX-5274 - ConnectionQueryServiceImpl should use HBase Namespace …

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CreateSchemaIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CreateSchemaIT.java
@@ -18,7 +18,7 @@
 package org.apache.phoenix.end2end;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.sql.Connection;
@@ -27,13 +27,13 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import org.apache.hadoop.hbase.client.Admin;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.schema.SchemaAlreadyExistsException;
 import org.apache.phoenix.util.PropertiesUtil;
 import org.apache.phoenix.util.SchemaUtil;
+import org.apache.phoenix.util.ServerUtil;
 import org.apache.phoenix.util.TestUtil;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -57,9 +57,9 @@ public class CreateSchemaIT extends ParallelStatsDisabledIT {
         try (Connection conn = DriverManager.getConnection(getUrl(), props);
                 Admin admin = conn.unwrap(PhoenixConnection.class).getQueryServices().getAdmin();) {
             conn.createStatement().execute(ddl1);
-            assertNotNull(admin.getNamespaceDescriptor(schemaName1));
+            assertTrue(ServerUtil.isHBaseNamespaceAvailable(admin, schemaName1));
             conn.createStatement().execute(ddl2);
-            assertNotNull(admin.getNamespaceDescriptor(schemaName2.toUpperCase()));
+            assertTrue(ServerUtil.isHBaseNamespaceAvailable(admin, schemaName2.toUpperCase()));
         }
         // Try creating it again and verify that it throws SchemaAlreadyExistsException
         try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
@@ -97,8 +97,10 @@ public class CreateSchemaIT extends ParallelStatsDisabledIT {
             conn.createStatement().execute("CREATE SCHEMA \""
                     + SchemaUtil.HBASE_NAMESPACE.toUpperCase() + "\"");
 
-            assertNotNull(admin.getNamespaceDescriptor(SchemaUtil.SCHEMA_FOR_DEFAULT_NAMESPACE.toUpperCase()));
-            assertNotNull(admin.getNamespaceDescriptor(SchemaUtil.HBASE_NAMESPACE.toUpperCase()));
+            assertTrue(ServerUtil.isHBaseNamespaceAvailable(admin,
+                SchemaUtil.SCHEMA_FOR_DEFAULT_NAMESPACE.toUpperCase()));
+            assertTrue(ServerUtil.isHBaseNamespaceAvailable(admin,
+                SchemaUtil.HBASE_NAMESPACE.toUpperCase()));
         }
     }
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DropSchemaIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DropSchemaIT.java
@@ -18,7 +18,8 @@
 package org.apache.phoenix.end2end;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.sql.Connection;
@@ -30,7 +31,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.hadoop.hbase.NamespaceDescriptor;
-import org.apache.hadoop.hbase.NamespaceNotFoundException;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.jdbc.PhoenixConnection;
@@ -39,6 +39,7 @@ import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.schema.SchemaNotFoundException;
 import org.apache.phoenix.util.ReadOnlyProps;
 import org.apache.phoenix.util.SchemaUtil;
+import org.apache.phoenix.util.ServerUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -95,22 +96,17 @@ public class DropSchemaIT extends BaseTest {
             } catch (SQLException e) {
                 assertEquals(e.getErrorCode(), SQLExceptionCode.CANNOT_MUTATE_SCHEMA.getErrorCode());
             }
-            assertNotNull(admin.getNamespaceDescriptor(normalizeSchemaIdentifier));
+            assertTrue(ServerUtil.isHBaseNamespaceAvailable(admin, normalizeSchemaIdentifier));
 
             conn.createStatement().execute("DROP TABLE " + schema + "." + tableName);
             conn.createStatement().execute(ddl);
-            try {
-                admin.getNamespaceDescriptor(normalizeSchemaIdentifier);
-                fail();
-            } catch (NamespaceNotFoundException ne) {
-                // expected
-            }
-            
+            assertFalse(ServerUtil.isHBaseNamespaceAvailable(admin, normalizeSchemaIdentifier));
+
             conn.createStatement().execute("DROP SCHEMA IF EXISTS " + schema);
             
             admin.createNamespace(NamespaceDescriptor.create(normalizeSchemaIdentifier).build());
             conn.createStatement().execute("DROP SCHEMA IF EXISTS " + schema);
-            assertNotNull(admin.getNamespaceDescriptor(normalizeSchemaIdentifier));
+            assertTrue(ServerUtil.isHBaseNamespaceAvailable(admin, normalizeSchemaIdentifier));
             conn.createStatement().execute("CREATE SCHEMA " + schema);
             conn.createStatement().execute("DROP SCHEMA " + schema);
             try {

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -1298,14 +1298,9 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
         SQLException sqlE = null;
         boolean createdNamespace = false;
         try (Admin admin = getAdmin()) {
-            NamespaceDescriptor namespaceDescriptor = null;
-            try {
-                namespaceDescriptor = admin.getNamespaceDescriptor(schemaName);
-            } catch (NamespaceNotFoundException ignored) {
-
-            }
-            if (namespaceDescriptor == null) {
-                namespaceDescriptor = NamespaceDescriptor.create(schemaName).build();
+            if (!ServerUtil.isHBaseNamespaceAvailable(admin, schemaName)) {
+                NamespaceDescriptor namespaceDescriptor =
+                    NamespaceDescriptor.create(schemaName).build();
                 admin.createNamespace(namespaceDescriptor);
                 createdNamespace = true;
             }
@@ -5938,13 +5933,7 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
             final String quorum = ZKConfig.getZKQuorumServersString(config);
             final String znode = this.props.get(HConstants.ZOOKEEPER_ZNODE_PARENT);
             LOGGER.debug("Found quorum: " + quorum + ":" + znode);
-            boolean nameSpaceExists = true;
-            try {
-                admin.getNamespaceDescriptor(schemaName);
-            } catch (org.apache.hadoop.hbase.NamespaceNotFoundException e) {
-                nameSpaceExists = false;
-            }
-            if (nameSpaceExists) {
+            if (ServerUtil.isHBaseNamespaceAvailable(admin, schemaName)) {
                 admin.deleteNamespace(schemaName);
             }
         } catch (IOException e) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ServerUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ServerUtil.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.NotServingRegionException;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
 import org.apache.hadoop.hbase.client.Table;
@@ -416,5 +417,28 @@ public class ServerUtil {
             t = e;
         }
         return t;
+    }
+
+    /**
+     * Returns true if HBase namespace exists, else returns false
+     * @param admin HbaseAdmin Object
+     * @param schemaName Phoenix schema name for which we check existence of the HBase namespace
+     * @return true if the HBase namespace exists, else returns false
+     * @throws SQLException If there is an exception checking the HBase namespace
+     */
+    public static boolean isHBaseNamespaceAvailable(Admin admin, String schemaName) throws IOException{
+        boolean namespaceExists = false;
+        try{
+            String[] hbaseNamespaces = admin.listNamespaces();
+            for(String namespace : hbaseNamespaces){
+                if(namespace.equals(schemaName)){
+                    namespaceExists = true;
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+        return namespaceExists;
     }
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/ServerUtilTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/ServerUtilTest.java
@@ -16,16 +16,14 @@
  */
 package org.apache.phoenix.util;
 
-import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
-import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.hbase.index.table.HTableFactory;
 import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
 import org.apache.phoenix.hbase.index.write.IndexWriterUtils;
-import org.apache.phoenix.query.HBaseFactoryProvider;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -33,7 +31,34 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class ServerUtilTest {
+
+    String existingNamespaceOne = "existingNamespaceOne";
+    String existingNamespaceTwo = "existingNamespaceTwo";
+    String nonExistingNamespace = "nonExistingNamespace";
+
+    String[] namespaces = { existingNamespaceOne, existingNamespaceTwo };
+
+    @Test
+    public void testIsHbaseNamespaceAvailableWithExistingNamespace() throws Exception {
+        Admin mockAdmin = getMockedAdmin();
+        assertTrue(ServerUtil.isHBaseNamespaceAvailable(mockAdmin, existingNamespaceOne));
+    }
+
+    @Test
+    public void testIsHbaseNamespaceAvailableWithNonExistingNamespace() throws Exception{
+        Admin mockAdmin = getMockedAdmin();
+        assertFalse(ServerUtil.isHBaseNamespaceAvailable(mockAdmin,nonExistingNamespace));
+    }
+
+    private Admin getMockedAdmin() throws Exception {
+        Admin mockAdmin = Mockito.mock(Admin.class);
+        Mockito.when(mockAdmin.listNamespaces()).thenReturn(namespaces);
+        return mockAdmin;
+    }
 
     @Test
     public void testCoprocessorHConnectionGetTableWithClosedConnection() throws Exception {


### PR DESCRIPTION
…APIs that do not require ADMIN permissions for existence checks