### PR TITLE
PHOENIX-6766 Fix failure of sqlline due to conflicting jline dependency pulled from Hadoop 3.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -845,6 +845,18 @@
         </exclusions>
         <version>${hadoop.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-yarn-client</artifactId>
+        <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
       <!-- Only for shading in phoenix-server - remove ? -->
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/PHOENIX-6766

Dependency on org.jline:jline:jar:3.9.0 conflicts with org.jline:jline-*:jar:3.12.1. It causes following error on invoking sqlline. It should be excluded from transitive dependency of Hadoop (>= 3.3.0).

```
$ mvn clean install -DskipTests -Dhadoop.version=3.3.4 -Dhbase.version=2.4.13 -Dhbase.profile=2.4
$ bin/sqlline.py
Exception in thread "main" java.lang.NoSuchMethodError: org.apache.phoenix.shaded.org.jline.reader.impl.completer.StringsCompleter.<init>([Lorg/apache/phoenix/shaded/org/jline/reader/Candidate;)V
        at sqlline.SqlLineOpts.setOptionCompleters(SqlLineOpts.java:160)
        at sqlline.Application.getCommandHandlers(Application.java:294)
        at sqlline.SqlLine$Config.<init>(SqlLine.java:1946)
        at sqlline.SqlLine.setAppConfig(SqlLine.java:1875)
        at sqlline.SqlLine.<init>(SqlLine.java:229)
        at sqlline.SqlLine.start(SqlLine.java:266)
        at sqlline.SqlLine.main(SqlLine.java:206)
```
