### PR TITLE
PHOENIX-6776 :- Abort scans of closed connections at ScanningResultIterator

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/PreMatureTimelyAbortScanIt.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/PreMatureTimelyAbortScanIt.java
@@ -57,10 +57,10 @@ public class PreMatureTimelyAbortScanIt extends ParallelStatsDisabledIT {
     public void testPreMatureScannerAbortForCount() throws Exception {
 
         try (Connection conn = DriverManager.getConnection(getUniqueUrl())) {
-            conn.createStatement().execute("CREATE TABLE LONG_BUG (ID INTEGER PRIMARY KEY, AMOUNT DECIMAL)");
+            conn.createStatement().execute("CREATE TABLE LONG_BUG (ID INTEGER PRIMARY KEY, AMOUNT DECIMAL) SALT_BUCKETS = 16");
         }
         try (Connection conn = DriverManager.getConnection(getUniqueUrl())) {
-            for (int i = 0; i<200000 ; i++) {
+            for (int i = 0; i<500000 ; i++) {
                 int amount = -50000 + i;
                 String s = "UPSERT INTO LONG_BUG (ID, AMOUNT) VALUES( " + i + ", " + amount + ")";
                 conn.createStatement().execute(s);
@@ -90,7 +90,7 @@ public class PreMatureTimelyAbortScanIt extends ParallelStatsDisabledIT {
                             fail();
                         }
                     } catch (Exception e) {
-                        LOG.error("Error" +e);
+                        LOG.error("Error", e);
                         fail();
                     }
                 }
@@ -105,7 +105,7 @@ public class PreMatureTimelyAbortScanIt extends ParallelStatsDisabledIT {
                         }
                         Thread.sleep(1000);
                         conn.close();
-                    } catch (SQLException | InterruptedException e) {
+                    } catch (InterruptedException | SQLException e) {
                         fail();
                     }
                 }
@@ -113,7 +113,7 @@ public class PreMatureTimelyAbortScanIt extends ParallelStatsDisabledIT {
             Thread t = new Thread(runnable);
             Thread t1 = new Thread(runnable1);
             t.start();
-            Thread.sleep(1000);
+            Thread.sleep(1500);
             t1.start();
             t.join();
             t1.join();

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/PreMatureTimelyAbortScanIt.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/PreMatureTimelyAbortScanIt.java
@@ -1,0 +1,98 @@
+package org.apache.phoenix.end2end;
+
+import org.apache.phoenix.coprocessor.BaseScannerRegionObserver;
+import org.apache.phoenix.exception.SQLExceptionCode;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
+import org.apache.phoenix.util.ReadOnlyProps;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+@Category(ParallelStatsDisabledTest.class)
+public class PreMatureTimelyAbortScanIt extends ParallelStatsDisabledIT {
+    static final Logger LOG = LoggerFactory.getLogger(PreMatureTimelyAbortScanIt.class);
+
+    @BeforeClass
+    public static synchronized void doSetup() throws Exception {
+        Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
+        props.put(BaseScannerRegionObserver.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY, Integer.toString(60*60)); // An hour
+        props.put(QueryServices.USE_STATS_FOR_PARALLELIZATION, Boolean.toString(false));
+        props.put(QueryServices.PHOENIX_SERVER_PAGE_SIZE_MS, Integer.toString(0));
+        setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+    }
+
+    private String getUniqueUrl() {
+        return url + generateUniqueName();
+    }
+
+    @Test
+    public void testPreMatureScannerAbortForCount() throws Exception {
+
+        try (Connection conn = DriverManager.getConnection(getUniqueUrl())) {
+            conn.createStatement().execute("CREATE TABLE LONG_BUG (ID INTEGER PRIMARY KEY, AMOUNT DECIMAL)");
+        }
+        try (Connection conn = DriverManager.getConnection(getUniqueUrl())) {
+            for (int i = 0; i<500000 ; i++) {
+                int amount = -50000 + i;
+                String s = "UPSERT INTO LONG_BUG (ID, AMOUNT) VALUES( " + i + ", " + amount + ")";
+                conn.createStatement().execute(s);
+                conn.commit();
+            }
+        }
+
+        try {
+            Connection conn = DriverManager.getConnection(getUniqueUrl());
+            Runnable runnable = new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        ResultSet resultSet = conn.createStatement().executeQuery(
+                                "SELECT COUNT(*) FROM LONG_BUG WHERE ID % 2 = 0");
+                        boolean result = resultSet.next();
+                        assertTrue(result);
+                        LOG.info("Count of modulus 2 for LONG_BUG :- " + resultSet.getInt(1));
+                        fail();
+                    } catch (SQLException sqe) {
+                        //RESULTSET_CLOSED exception expected
+                        if (sqe.getErrorCode() != SQLExceptionCode.RESULTSET_CLOSED.getErrorCode()) {
+                            fail();
+                        }
+                    } catch (Exception e) {
+                        fail();
+                    }
+                }
+            };
+
+            Runnable runnable1 = new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(1500);
+                        LOG.info("Closing Connection");
+                        conn.close();
+                    } catch (SQLException | InterruptedException e) {
+                        fail();
+                    }
+                }
+            };
+            Thread t = new Thread(runnable);
+            Thread t1 = new Thread(runnable1);
+            t.start();
+            t1.start();
+            t.join();
+            t1.join();
+        } finally {
+
+        }
+    }
+}

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/PreMatureTimelyAbortScanIt.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/PreMatureTimelyAbortScanIt.java
@@ -61,12 +61,12 @@ public class PreMatureTimelyAbortScanIt extends ParallelStatsDisabledIT {
             conn.createStatement().execute("CREATE TABLE LONG_BUG (ID INTEGER PRIMARY KEY, AMOUNT DECIMAL) SALT_BUCKETS = 16 ");
         }
         try (Connection conn = DriverManager.getConnection(getUniqueUrl())) {
-            for (int i = 0; i<5000 ; i++) {
+            for (int i = 0; i<100 ; i++) {
                 int amount = -50000 + i;
                 String s = "UPSERT INTO LONG_BUG (ID, AMOUNT) VALUES( " + i + ", " + amount + ")";
                 conn.createStatement().execute(s);
-                conn.commit();
             }
+            conn.commit();
         }
 
         try {

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/PreMatureTimelyAbortScanIt.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/PreMatureTimelyAbortScanIt.java
@@ -71,7 +71,7 @@ public class PreMatureTimelyAbortScanIt extends ParallelStatsDisabledIT {
 
         try {
             PhoenixConnection conn = DriverManager.getConnection(getUniqueUrl()).unwrap(PhoenixConnection.class);
-            ScanningResultIterator.setIsScannerClosedForceFully(true);
+            ScanningResultIterator.setIsScannerClosedForcefully(true);
             ResultSet resultSet = conn.createStatement().executeQuery(
                     "SELECT COUNT(*) FROM LONG_BUG WHERE ID % 2 = 0");
             conn.setIsClosing(true);
@@ -83,7 +83,7 @@ public class PreMatureTimelyAbortScanIt extends ParallelStatsDisabledIT {
         } catch (Exception e) {
             fail();
         } finally {
-            ScanningResultIterator.setIsScannerClosedForceFully(false);
+            ScanningResultIterator.setIsScannerClosedForcefully(false);
         }
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
@@ -262,7 +262,7 @@ abstract public class BaseScannerRegionObserver implements RegionObserver {
             // last possible moment. You need to swap the start/stop and make the
             // start exclusive and the stop inclusive.
             ScanUtil.setupReverseScan(scan);
-            if (scan.getFilter() != null && !(scan.getFilter() instanceof PagedFilter)) {
+            if (!(scan.getFilter() instanceof PagedFilter)) {
                 byte[] pageSizeMsBytes = scan.getAttribute(BaseScannerRegionObserver.SERVER_PAGE_SIZE_MS);
                 if (pageSizeMsBytes != null) {
                     scan.setFilter(new PagedFilter(scan.getFilter(), getPageSizeMsForFilter(scan)));

--- a/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
@@ -583,7 +583,10 @@ public enum SQLExceptionCode {
 
     CANNOT_TRANSFORM_TABLE_WITH_APPEND_ONLY_SCHEMA(913, "43M24", "Cannot transform a table with append-only schema."),
 
-    CANNOT_TRANSFORM_TRANSACTIONAL_TABLE(914, "43M25", "Cannot transform a transactional table.");
+    CANNOT_TRANSFORM_TRANSACTIONAL_TABLE(914, "43M25", "Cannot transform a transactional table."),
+
+    //SQLCode for testing exceptions
+    FAILED_KNOWINGLY_FOR_TEST(7777, "TEST", "Exception was thrown to test something");
 
     private final int errorCode;
     private final String sqlState;

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -1415,6 +1416,8 @@ public abstract class BaseResultIterators extends ExplainTable implements Result
                             }
                             
                         }
+                    } catch (CancellationException ce) {
+                        LOGGER.warn("Iterator scheduled to be executed in Future was being cancelled", ce);
                     }
                 }
                 addIterator(iterators, concatIterators);

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ScanningResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ScanningResultIterator.java
@@ -170,7 +170,7 @@ public class ScanningResultIterator implements ResultIterator {
         try {
             Result result = scanner.next();
             while (result != null && (result.isEmpty() || isDummy(result))) {
-                if (context.getConnection().isClosed() || context.getConnection().isClosing()) {
+                if (context.getConnection().isClosing() || context.getConnection().isClosed()) {
                     LOG.warn("Closing ResultScanner as Connection is already closed or in middle of closing");
                     if (throwExceptionIfScannerClosedForceFully) {
                         throw new SQLExceptionInfo.Builder(SQLExceptionCode.FAILED_KNOWINGLY_FOR_TEST).build().buildException();

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ScanningResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ScanningResultIterator.java
@@ -211,7 +211,7 @@ public class ScanningResultIterator implements ResultIterator {
     }
 
     @VisibleForTesting
-    public static void setIsScannerClosedForceFully(boolean throwException) {
+    public static void setIsScannerClosedForcefully(boolean throwException) {
         throwExceptionIfScannerClosedForceFully = throwException;
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableResultIterator.java
@@ -237,7 +237,7 @@ public class TableResultIterator implements ResultIterator {
             if (delegate == UNINITIALIZED_SCANNER) {
                 try {
                     this.scanIterator =
-                            new ScanningResultIterator(htable.getScanner(scan), scan, scanMetricsHolder);
+                            new ScanningResultIterator(htable.getScanner(scan), scan, scanMetricsHolder, plan.getContext());
                 } catch (IOException e) {
                     Closeables.closeQuietly(htable);
                     throw ServerUtil.parseServerException(e);

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableSnapshotResultIterator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/TableSnapshotResultIterator.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.SnapshotManifest;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.phoenix.compile.ExplainPlanAttributes.ExplainPlanAttributesBuilder;
+import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.mapreduce.util.PhoenixConfigurationUtil;
 import org.apache.phoenix.monitoring.ScanMetricsHolder;
 import org.apache.phoenix.schema.tuple.Tuple;
@@ -74,12 +75,14 @@ public class TableSnapshotResultIterator implements ResultIterator {
   private FileSystem fs;
   private int currentRegion;
   private boolean closed = false;
+  private StatementContext context;
 
-  public TableSnapshotResultIterator(Configuration configuration, Scan scan, ScanMetricsHolder scanMetricsHolder)
+  public TableSnapshotResultIterator(Configuration configuration, Scan scan, ScanMetricsHolder scanMetricsHolder, StatementContext context)
       throws IOException {
     this.configuration = configuration;
     this.currentRegion = -1;
     this.scan = scan;
+    this.context = context;
     this.scanMetricsHolder = scanMetricsHolder;
     this.scanIterator = UNINITIALIZED_SCANNER;
     if (PhoenixConfigurationUtil.isMRSnapshotManagedExternally(configuration)) {
@@ -153,7 +156,7 @@ public class TableSnapshotResultIterator implements ResultIterator {
         RegionInfo hri = regions.get(this.currentRegion);
         this.scanIterator =
             new ScanningResultIterator(new SnapshotScanner(configuration, fs, restoreDir, htd, hri, scan),
-                scan, scanMetricsHolder);
+                scan, scanMetricsHolder, context);
       } catch (Throwable e) {
         throw ServerUtil.parseServerException(e);
       }

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
@@ -1381,6 +1381,11 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
         this.tableResultIteratorFactory = factory;
     }
 
+    @VisibleForTesting
+    public void setIsClosing(boolean imitateIsClosing) {
+        isClosing = imitateIsClosing;
+    }
+
     @Override
     public void removeSchema(PSchema schema, long schemaTimeStamp) {
         metaData.removeSchema(schema, schemaTimeStamp);

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
@@ -165,6 +165,7 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
     private int statementExecutionCounter;
     private TraceScope traceScope = null;
     private volatile boolean isClosed = false;
+    private volatile boolean isClosing = false;
     private Sampler<?> sampler;
     private boolean readOnly = false;
     private Consistency consistency = Consistency.STRONG;
@@ -700,7 +701,7 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
     }
 
     void checkOpen() throws SQLException {
-        if (isClosed) {
+        if (isClosed || isClosing) {
             throw reasonForClose != null
                 ? reasonForClose
                 : new SQLExceptionInfo.Builder(SQLExceptionCode.CONNECTION_CLOSED)
@@ -719,7 +720,7 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
      * @see #close()
      */
     public void close(SQLException reasonForClose) throws SQLException {
-        if (isClosed) {
+        if (isClosed || isClosing) {
             return;
         }
         this.reasonForClose = reasonForClose;
@@ -731,11 +732,12 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
     //Does this need to be synchronized?
     @Override
     synchronized public void close() throws SQLException {
-        if (isClosed) {
+        if (isClosed || isClosing) {
             return;
         }
 
         try {
+            isClosing = true;
             TableMetricsManager.pushMetricsFromConnInstanceMethod(getMutationMetrics());
             if(!(reasonForClose instanceof FailoverSQLException)) {
                 // If the reason for close is because of failover, the metrics will be kept for
@@ -757,6 +759,7 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
             }
             
         } finally {
+            isClosing = false;
             isClosed = true;
             if(isInternalConnection()){
                 GLOBAL_OPEN_INTERNAL_PHOENIX_CONNECTIONS.decrement();
@@ -965,6 +968,10 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
         return isClosed;
     }
 
+    public boolean isClosing() throws SQLException {
+        return isClosing;
+    }
+
     @Override
     public boolean isReadOnly() throws SQLException {
         return readOnly;
@@ -973,7 +980,7 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
     @Override
     public boolean isValid(int timeout) throws SQLException {
         // TODO: run query here or ping
-        return !isClosed;
+        return !isClosed && !isClosing;
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
@@ -1381,6 +1381,9 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
         this.tableResultIteratorFactory = factory;
     }
 
+     /**
+     * Added for testing purposes. Do not use this elsewhere.
+     */
     @VisibleForTesting
     public void setIsClosing(boolean imitateIsClosing) {
         isClosing = imitateIsClosing;

--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/PhoenixRecordReader.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/PhoenixRecordReader.java
@@ -138,7 +138,7 @@ public class PhoenixRecordReader<T extends DBWritable> extends RecordReader<Null
                 if (snapshotName != null) {
                   // result iterator to read snapshots
                   final TableSnapshotResultIterator tableSnapshotResultIterator = new TableSnapshotResultIterator(configuration, scan,
-                      scanMetricsHolder);
+                      scanMetricsHolder, queryPlan.getContext());
                     peekingResultIterator = LookAheadResultIterator.wrap(tableSnapshotResultIterator);
                     LOGGER.info("Adding TableSnapshotResultIterator for scan: " + scan);
                 } else {

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <!-- The default hbase versions to build with (override with hbase.version) -->
     <hbase-2.3.runtime.version>2.3.7</hbase-2.3.runtime.version>
     <hbase-2.4.0.runtime.version>2.4.0</hbase-2.4.0.runtime.version>
-    <hbase-2.4.runtime.version>2.4.12</hbase-2.4.runtime.version>
+    <hbase-2.4.runtime.version>2.4.13</hbase-2.4.runtime.version>
     <hbase-2.5.runtime.version>2.5.0</hbase-2.5.runtime.version>
 
     <!-- General Properties -->

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <!-- The default hbase versions to build with (override with hbase.version) -->
     <hbase-2.3.runtime.version>2.3.7</hbase-2.3.runtime.version>
     <hbase-2.4.0.runtime.version>2.4.0</hbase-2.4.0.runtime.version>
-    <hbase-2.4.runtime.version>2.4.13</hbase-2.4.runtime.version>
+    <hbase-2.4.runtime.version>2.4.12</hbase-2.4.runtime.version>
     <hbase-2.5.runtime.version>2.5.0</hbase-2.5.runtime.version>
 
     <!-- General Properties -->


### PR DESCRIPTION
Added isClosing property in PhoenixConnection as well, as we change isClose status after closing all the underline objects (Iterators, scanners, statements).