### PR TITLE
PHOENIX-6823 calling Joda-based round() function on temporal PK field…

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilMonthExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilMonthExpression.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
 import org.joda.time.DateTime;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -41,4 +42,16 @@ public class CeilMonthExpression extends RoundJodaDateExpression {
         return dateTime.monthOfYear().roundCeilingCopy().getMillis();
     }
 
+    @Override
+    public long rangeLower(long time) {
+        // floor(time - 1) + 1
+        return (new DateTime(time - 1, GJChronology.getInstanceUTC())).monthOfYear()
+                .roundFloorCopy().getMillis() + 1;
+    }
+
+    @Override
+    public long rangeUpper(long time) {
+        // ceil
+        return roundDateTime(new DateTime(time, GJChronology.getInstanceUTC()));
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilWeekExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilWeekExpression.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
 import org.joda.time.DateTime;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -41,4 +42,16 @@ public class CeilWeekExpression extends RoundJodaDateExpression {
         return dateTime.weekOfWeekyear().roundCeilingCopy().getMillis();
     }
 
+    @Override
+    public long rangeLower(long time) {
+        // floor(time - 1) + 1
+        return (new DateTime(time - 1, GJChronology.getInstanceUTC())).weekOfWeekyear()
+                .roundFloorCopy().getMillis() + 1;
+    }
+
+    @Override
+    public long rangeUpper(long time) {
+        // ceil
+        return roundDateTime(new DateTime(time, GJChronology.getInstanceUTC()));
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilYearExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CeilYearExpression.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
 import org.joda.time.DateTime;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -41,4 +42,16 @@ public class CeilYearExpression extends RoundJodaDateExpression {
        return dateTime.year().roundCeilingCopy().getMillis();
     }
 
+    @Override
+    public long rangeLower(long time) {
+        // floor(time - 1) + 1
+        return (new DateTime(time - 1, GJChronology.getInstanceUTC())).year().roundFloorCopy()
+                .getMillis() + 1;
+    }
+
+    @Override
+    public long rangeUpper(long time) {
+        // ceil
+        return roundDateTime(new DateTime(time, GJChronology.getInstanceUTC()));
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorMonthExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorMonthExpression.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
 import org.joda.time.DateTime;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -41,4 +42,16 @@ public class FloorMonthExpression extends RoundJodaDateExpression {
         return datetime.monthOfYear().roundFloorCopy().getMillis();
     }
 
+    @Override
+    public long rangeLower(long time) {
+        // floor
+        return roundDateTime(new DateTime(time, GJChronology.getInstanceUTC()));
+    }
+
+    @Override
+    public long rangeUpper(long time) {
+        // ceil(time + 1) -1
+        return (new DateTime(time + 1, GJChronology.getInstanceUTC())).monthOfYear()
+                .roundCeilingCopy().getMillis() - 1;
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorWeekExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorWeekExpression.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
 import org.joda.time.DateTime;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * Floor function that rounds up the {@link DateTime} to start of week. 
@@ -40,4 +41,16 @@ public class FloorWeekExpression extends RoundJodaDateExpression {
         return datetime.weekOfWeekyear().roundFloorCopy().getMillis();
     }
 
+    @Override
+    public long rangeLower(long time) {
+        // floor
+        return roundDateTime(new DateTime(time, GJChronology.getInstanceUTC()));
+    }
+
+    @Override
+    public long rangeUpper(long time) {
+        // ceil(time + 1) -1
+        return (new DateTime(time + 1, GJChronology.getInstanceUTC())).weekOfWeekyear()
+                .roundCeilingCopy().getMillis() - 1;
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorYearExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/FloorYearExpression.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
 import org.joda.time.DateTime;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -41,4 +42,16 @@ public class FloorYearExpression extends RoundJodaDateExpression {
         return datetime.year().roundFloorCopy().getMillis();
     }
 
+    @Override
+    public long rangeLower(long time) {
+        // floor
+        return roundDateTime(new DateTime(time, GJChronology.getInstanceUTC()));
+    }
+
+    @Override
+    public long rangeUpper(long time) {
+        // ceil(time + 1) -1
+        return (new DateTime(time + 1, GJChronology.getInstanceUTC())).year().roundCeilingCopy()
+                .getMillis() - 1;
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundDateExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundDateExpression.java
@@ -45,9 +45,9 @@ import org.apache.phoenix.schema.types.PDataType.PDataCodec;
 import org.apache.phoenix.schema.types.PDate;
 import org.apache.phoenix.schema.types.PInteger;
 import org.apache.phoenix.schema.types.PVarchar;
-import org.apache.phoenix.util.ByteUtil;
-
+import org.apache.phoenix.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.phoenix.thirdparty.com.google.common.collect.Lists;
+import org.apache.phoenix.util.ByteUtil;
 
 /**
  * Function used to bucketize date/time values by rounding them to
@@ -105,7 +105,7 @@ public class RoundDateExpression extends ScalarFunction {
     
     public static Expression create(List<Expression> children) throws SQLException {
         int numChildren = children.size();
-        if(numChildren < 2 || numChildren > 3) {
+        if (numChildren < 2 || numChildren > 3) {
             throw new IllegalArgumentException("Wrong number of arguments : " + numChildren);
         }
         Object timeUnitValue = ((LiteralExpression)children.get(1)).getValue();
@@ -138,7 +138,7 @@ public class RoundDateExpression extends ScalarFunction {
         Object multiplierValue = numChildren > 2 ? ((LiteralExpression)children.get(2)).getValue() : null;
         int multiplier = multiplierValue == null ? 1 :((Number)multiplierValue).intValue();
         TimeUnit timeUnit = TimeUnit.getTimeUnit(timeUnitValue != null ? timeUnitValue.toString() : null);
-        if(timeUnit.ordinal() < TIME_UNIT_MS.length) {
+        if (timeUnit.ordinal() < TIME_UNIT_MS.length) {
             divBy = multiplier * TIME_UNIT_MS[timeUnit.ordinal()];
         }
     }
@@ -148,8 +148,8 @@ public class RoundDateExpression extends ScalarFunction {
         return divBy/2;
     }
     
-    
-    protected long roundTime(long time) {
+    @VisibleForTesting
+    public long roundTime(long time) {
         long value;
         long roundUpAmount = getRoundUpAmount();
         if (time <= Long.MAX_VALUE - roundUpAmount) { // If no overflow, add
@@ -159,7 +159,21 @@ public class RoundDateExpression extends ScalarFunction {
         }
         return value * divBy;
     }
-    
+
+    @VisibleForTesting
+    public long rangeLower(long time) {
+        // This is for the ms based intervals. This needs to be separately implemented for the
+        // joda based intervals
+        return roundTime(time) - getRoundUpAmount();
+    }
+
+    @VisibleForTesting
+    public long rangeUpper(long time) {
+        // This is for the ms based intervals. This needs to be separately implemented for the
+        // joda based intervals
+        return roundTime(time) + (divBy - getRoundUpAmount()) - 1;
+    }
+
     @Override
     public boolean evaluate(Tuple tuple, ImmutableBytesWritable ptr) {
         if (children.get(0).evaluate(tuple, ptr)) {
@@ -260,7 +274,8 @@ public class RoundDateExpression extends ScalarFunction {
                 PDataCodec codec = getKeyRangeCodec(type);
                 int offset = ByteUtil.isInclusive(op) ? 1 : 0;
                 long value = codec.decodeLong(key, 0, SortOrder.getDefault());
-                byte[] nextKey = new byte[type.getByteSize()];
+                byte[] lowerKey = new byte[type.getByteSize()];
+                byte[] upperKey = new byte[type.getByteSize()];
                 KeyRange range;
                 switch (op) {
                 case EQUAL:
@@ -269,21 +284,58 @@ public class RoundDateExpression extends ScalarFunction {
                     // had ROUND(dateCol,'DAY') = TO_DATE('2013-01-01 23:00:00')
                     // it could never be equal, since date constant isn't at a day
                     // boundary.
-                    if (value % divBy != 0) {
+                    if (value != roundTime(value)) {
                         return KeyRange.EMPTY_RANGE;
                     }
-                    codec.encodeLong(value + divBy, nextKey, 0);
-                    range = type.getKeyRange(key, true, nextKey, false);
+                    codec.encodeLong(rangeLower(value), lowerKey, 0);
+                    codec.encodeLong(rangeUpper(value), upperKey, 0);
+                    range = type.getKeyRange(lowerKey, true, upperKey, true);
                     break;
+                    // a simple number example (with half up rounding):
+                    // round(x) = 10 ==> [9.5, 10.5)
+                    // round(x) <= 10 ==> [-inf, 10.5)
+                    // round(x) <= 10.1 === round(x) <= 10 => [-inf, 10.5)
+                    // round(x) <= 9.9 === round(x) <= 9 => [-inf, 9.5)
+                    // round(x) < 10 ==> round(x) <= 9 ==> [-inf, 9.5)
                 case GREATER:
+                    if (value == roundTime(value)) {
+                        codec.encodeLong(rangeUpper(value), lowerKey, 0);
+                        range = type.getKeyRange(lowerKey, false, KeyRange.UNBOUND, false);
+                        break;
+                    }
+                    //fallthrough intended
                 case GREATER_OR_EQUAL:
-                    codec.encodeLong((value + divBy - offset)/divBy*divBy, nextKey, 0);
-                    range = type.getKeyRange(nextKey, true, KeyRange.UNBOUND, false);
+                    codec.encodeLong(rangeLower(value), lowerKey, 0);
+                    range = type.getKeyRange(lowerKey, true, KeyRange.UNBOUND, false);
+                    if (value <= roundTime(value)) {
+                        //always true for ceil
+                        codec.encodeLong(rangeLower(value), lowerKey, 0);
+                        range = type.getKeyRange(lowerKey, true, KeyRange.UNBOUND, false);
+                    } else {
+                        //always true for floor, except when exact
+                        codec.encodeLong(rangeUpper(value), lowerKey, 0);
+                        range = type.getKeyRange(lowerKey, false, KeyRange.UNBOUND, false);
+                    }
                     break;
                 case LESS:
+                    if (value == roundTime(value)) {
+                        codec.encodeLong(rangeLower(value), upperKey, 0);
+                        range = type.getKeyRange(KeyRange.UNBOUND, false, upperKey, false);
+                        break;
+                    }
+                    //fallthrough intended
                 case LESS_OR_EQUAL:
-                    codec.encodeLong((value + divBy - (1 -offset))/divBy*divBy, nextKey, 0);
-                    range = type.getKeyRange(KeyRange.UNBOUND, false, nextKey, false);
+                    codec.encodeLong(rangeUpper(value), upperKey, 0);
+                    range = type.getKeyRange(KeyRange.UNBOUND, false, upperKey, true);
+                    if (value >= roundTime(value)) {
+                        //always true for floor
+                        codec.encodeLong(rangeUpper(value), upperKey, 0);
+                        range = type.getKeyRange(KeyRange.UNBOUND, false, upperKey, true);
+                    } else {
+                        //always true for ceil, except when exact
+                        codec.encodeLong(rangeLower(value), upperKey, 0);
+                        range = type.getKeyRange(KeyRange.UNBOUND, false, upperKey, false);
+                    }
                     break;
                 default:
                     return childPart.getKeyRange(op, rhs);

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundJodaDateExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundJodaDateExpression.java
@@ -25,7 +25,7 @@ import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PDataType;
 import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -48,7 +48,7 @@ public abstract class RoundJodaDateExpression extends RoundDateExpression{
             }
             PDataType dataType = getDataType();
             long time = dataType.getCodec().decodeLong(ptr, children.get(0).getSortOrder());
-            DateTime dt = new DateTime(time, ISOChronology.getInstanceUTC());
+            DateTime dt = new DateTime(time, GJChronology.getInstanceUTC());
             long value = roundDateTime(dt);
             Date d = new Date(value);
             byte[] byteValue = dataType.toBytes(d);
@@ -63,4 +63,10 @@ public abstract class RoundJodaDateExpression extends RoundDateExpression{
      * @return Time in millis.
      */
     public abstract long roundDateTime(DateTime dateTime);
+
+    @Override
+    // We need a working roundTime() for the RowKey pushdown logic.
+    public long roundTime(long time) {
+        return roundDateTime(new DateTime(time, GJChronology.getInstanceUTC()));
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundMonthExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundMonthExpression.java
@@ -20,7 +20,10 @@ package org.apache.phoenix.expression.function;
 import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
+import org.apache.phoenix.util.DateUtil;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -39,4 +42,22 @@ public class RoundMonthExpression extends RoundJodaDateExpression {
        return dateTime.monthOfYear().roundHalfEvenCopy().getMillis();
     }
 
+    @Override
+    public long rangeLower(long epochMs) {
+        // We're doing unnecessary conversions here, but this is not perf sensitive
+        DateTime rounded =
+                new DateTime(roundDateTime(new DateTime(epochMs, GJChronology.getInstanceUTC())),
+                        GJChronology.getInstanceUTC());
+        DateTime prev = rounded.minusMonths(1);
+        return DateUtil.rangeJodaHalfEven(rounded, prev, DateTimeFieldType.monthOfYear());
+    }
+
+    @Override
+    public long rangeUpper(long epochMs) {
+        DateTime rounded =
+                new DateTime(roundDateTime(new DateTime(epochMs, GJChronology.getInstanceUTC())),
+                        GJChronology.getInstanceUTC());
+        DateTime next = rounded.plusMonths(1);
+        return DateUtil.rangeJodaHalfEven(rounded, next, DateTimeFieldType.monthOfYear());
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundWeekExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundWeekExpression.java
@@ -20,7 +20,10 @@ package org.apache.phoenix.expression.function;
 import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
+import org.apache.phoenix.util.DateUtil;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -37,5 +40,24 @@ public class RoundWeekExpression extends RoundJodaDateExpression {
     @Override
     public long roundDateTime(DateTime dateTime) {
        return dateTime.weekOfWeekyear().roundHalfEvenCopy().getMillis();
+    }
+
+    @Override
+    public long rangeLower(long epochMs) {
+        // We're doing unnecessary conversions here, but this is NOT perf sensitive
+        DateTime rounded =
+                new DateTime(roundDateTime(new DateTime(epochMs, GJChronology.getInstanceUTC())),
+                        GJChronology.getInstanceUTC());
+        DateTime prev = rounded.minusWeeks(1);
+        return DateUtil.rangeJodaHalfEven(rounded, prev, DateTimeFieldType.weekOfWeekyear());
+    }
+
+    @Override
+    public long rangeUpper(long epochMs) {
+        DateTime rounded =
+                new DateTime(roundDateTime(new DateTime(epochMs, GJChronology.getInstanceUTC())),
+                        GJChronology.getInstanceUTC());
+        DateTime next = rounded.plusWeeks(1);
+        return DateUtil.rangeJodaHalfEven(rounded, next, DateTimeFieldType.weekOfWeekyear());
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundYearExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/RoundYearExpression.java
@@ -20,7 +20,10 @@ package org.apache.phoenix.expression.function;
 import java.util.List;
 
 import org.apache.phoenix.expression.Expression;
+import org.apache.phoenix.util.DateUtil;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.chrono.GJChronology;
 
 /**
  * 
@@ -39,4 +42,22 @@ public class RoundYearExpression extends RoundJodaDateExpression {
         return dateTime.year().roundHalfEvenCopy().getMillis();
     }
 
+    @Override
+    public long rangeLower(long epochMs) {
+        // We're doing unnecessary conversions here, but this is NOT perf sensitive
+        DateTime rounded =
+                new DateTime(roundDateTime(new DateTime(epochMs, GJChronology.getInstanceUTC())),
+                        GJChronology.getInstanceUTC());
+        DateTime prev = rounded.minusYears(1);
+        return DateUtil.rangeJodaHalfEven(rounded, prev, DateTimeFieldType.year());
+    }
+
+    @Override
+    public long rangeUpper(long epochMs) {
+        DateTime rounded =
+                new DateTime(roundDateTime(new DateTime(epochMs, GJChronology.getInstanceUTC())),
+                        GJChronology.getInstanceUTC());
+        DateTime next = rounded.plusYears(1);
+        return DateUtil.rangeJodaHalfEven(rounded, next, DateTimeFieldType.year());
+    }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/DateUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/DateUtil.java
@@ -40,15 +40,14 @@ import org.apache.phoenix.schema.types.PDate;
 import org.apache.phoenix.schema.types.PTimestamp;
 import org.apache.phoenix.schema.types.PUnsignedDate;
 import org.apache.phoenix.schema.types.PUnsignedTimestamp;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Lists;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
 import org.joda.time.DateTimeZone;
-import org.joda.time.chrono.ISOChronology;
 import org.joda.time.chrono.GJChronology;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.ISODateTimeFormat;
-
-import org.apache.phoenix.thirdparty.com.google.common.collect.Lists;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -155,7 +154,7 @@ public class DateUtil {
         if (pattern == null || pattern.length() == 0) {
             pattern = defaultPattern;
         }
-        if(defaultPattern.equals(pattern)) {
+        if (defaultPattern.equals(pattern)) {
             return JulianDateFormatParserFactory.getParser(timeZone);
         } else {
             return new SimpleDateFormatParser(pattern, timeZone);
@@ -207,7 +206,7 @@ public class DateUtil {
             String nanosStr = timestampValue.substring(period + 1);
             if (nanosStr.length() > 9)
                 throw new IllegalDataException("nanos > 999999999 or < 0");
-            if(nanosStr.length() > 3 ) {
+            if (nanosStr.length() > 3) {
                 int nanos = Integer.parseInt(nanosStr);
                 for (int i = 0; i < 9 - nanosStr.length(); i++) {
                     nanos *= 10;
@@ -345,6 +344,52 @@ public class DateUtil {
         @Override
         public TimeZone getTimeZone() {
             return formatter.getZone().toTimeZone();
+        }
+    }
+
+    public static long rangeJodaHalfEven(DateTime roundedDT, DateTime otherDT,
+            DateTimeFieldType type) {
+        // It's OK if this is slow, as it's only called O(1) times per query
+        //
+        // We need to reverse engineer what roundHalfEvenCopy() does
+        // and return the lower/upper (inclusive) range here
+        // Joda simply works on milliseconds between the floor and ceil values.
+        // We could avoid the period call for units less than a day, but this is not a perf
+        // critical function.
+        long roundedMs = roundedDT.getMillis();
+        long otherMs = otherDT.getMillis();
+        long midMs = (roundedMs + otherMs) / 2;
+        long remainder = (roundedMs + otherMs) % 2;
+        if (remainder == 0) {
+            int roundedUnits = roundedDT.get(type);
+            if (otherMs > roundedMs) {
+                // Upper range, other is bigger.
+                if ((roundedUnits & 1) == 0) {
+                    // This unit is even, the next second is odd, so we get the mid point
+                    return midMs;
+                } else {
+                    // This unit is odd, the next second is even and takes the midpoint.
+                    return midMs - 1;
+                }
+            } else {
+                // Lower range, other is smaller.
+                if ((roundedUnits & 1) == 0) {
+                    // This unit is even, the next second is odd, so we get the mid point
+                    return midMs;
+                } else {
+                    // This unit is odd, the next second is even and takes the midpoint.
+                    return midMs + 1;
+                }
+            }
+        } else {
+            // probably never happens
+            if (otherMs > roundedMs) {
+                // Upper range, return the rounded down value
+                return midMs;
+            } else {
+                // Lower range, the mid value belongs to the previous unit.
+                return midMs + 1;
+            }
         }
     }
 }


### PR DESCRIPTION
… causes division by zero error

also fix other bugs in the key range pushdown logic for temporals