### PR TITLE
DOCS - grant and revoke command rule definition fix

### DIFF
--- a/docs/phoenix.csv
+++ b/docs/phoenix.csv
@@ -372,7 +372,7 @@ DROP SCHEMA my_schema
 "
 
 "Commands","GRANT","
-GRANT {permissionString} [ON [[SCHEMA schemaName] | tableRef] ] TO [GROUP] userString
+GRANT {permissionString} [ON { {SCHEMA schemaName} | tableRef}] TO [GROUP] userString
 ","
 Grant permissions at table, schema or user level. Permissions are managed by HBase in hbase:acl table, hence access controls need to be enabled. This feature will be available from Phoenix 4.14 version onwards.
 
@@ -398,7 +398,7 @@ GRANT 'A' ON SCHEMA my_schema TO 'User3'
 "
 
 "Commands","REVOKE","
-REVOKE [ON [[SCHEMA schemaName] | tableRef] ] FROM [GROUP] userString
+REVOKE [ON { {SCHEMA schemaName} | tableRef}] FROM [GROUP] userString
 ","
 Revoke permissions at table, schema or user level. Permissions are managed by HBase in hbase:acl table, hence access controls need to be enabled. This feature will be available from Phoenix 4.14 version onwards.
 

--- a/docs/phoenix.csv
+++ b/docs/phoenix.csv
@@ -372,7 +372,7 @@ DROP SCHEMA my_schema
 "
 
 "Commands","GRANT","
-GRANT {permissionString} [ON [SCHEMA schemaName | [tableRef | tableName] ] ] TO [GROUP] userString
+GRANT {permissionString} [ON [SCHEMA schemaName | tableRef] ] TO [GROUP] userString
 ","
 Grant permissions at table, schema or user level. Permissions are managed by HBase in hbase:acl table, hence access controls need to be enabled. This feature will be available from Phoenix 4.14 version onwards.
 
@@ -398,7 +398,7 @@ GRANT 'A' ON SCHEMA my_schema TO 'User3'
 "
 
 "Commands","REVOKE","
-REVOKE [ON [SCHEMA schemaName] tableName] FROM [GROUP] userString
+REVOKE [ON [SCHEMA schemaName | tableRef] ] FROM [GROUP] userString
 ","
 Revoke permissions at table, schema or user level. Permissions are managed by HBase in hbase:acl table, hence access controls need to be enabled. This feature will be available from Phoenix 4.14 version onwards.
 

--- a/docs/phoenix.csv
+++ b/docs/phoenix.csv
@@ -372,7 +372,7 @@ DROP SCHEMA my_schema
 "
 
 "Commands","GRANT","
-GRANT {permissionString} [ON [SCHEMA schemaName] tableName] TO [GROUP] userString
+GRANT {permissionString} [ON [SCHEMA schemaName | [tableRef | tableName] ] ] TO [GROUP] userString
 ","
 Grant permissions at table, schema or user level. Permissions are managed by HBase in hbase:acl table, hence access controls need to be enabled. This feature will be available from Phoenix 4.14 version onwards.
 

--- a/docs/phoenix.csv
+++ b/docs/phoenix.csv
@@ -372,7 +372,7 @@ DROP SCHEMA my_schema
 "
 
 "Commands","GRANT","
-GRANT {permissionString} [ON [SCHEMA schemaName | tableRef] ] TO [GROUP] userString
+GRANT {permissionString} [ON [[SCHEMA schemaName] | tableRef] ] TO [GROUP] userString
 ","
 Grant permissions at table, schema or user level. Permissions are managed by HBase in hbase:acl table, hence access controls need to be enabled. This feature will be available from Phoenix 4.14 version onwards.
 
@@ -398,7 +398,7 @@ GRANT 'A' ON SCHEMA my_schema TO 'User3'
 "
 
 "Commands","REVOKE","
-REVOKE [ON [SCHEMA schemaName | tableRef] ] FROM [GROUP] userString
+REVOKE [ON [[SCHEMA schemaName] | tableRef] ] FROM [GROUP] userString
 ","
 Revoke permissions at table, schema or user level. Permissions are managed by HBase in hbase:acl table, hence access controls need to be enabled. This feature will be available from Phoenix 4.14 version onwards.
 


### PR DESCRIPTION
The current rule is wrong as it permits statements such as:

GRANT 'R' ON SCHEMA schema table TO 'user'

also it does not mention tableRef rule which is listed on one of the examples