### PR TITLE
PHOENIX-5066 The TimeZone is incorrectly used during writing or readi…

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/TimeZoneDisplacementIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/TimeZoneDisplacementIT.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.end2end;
+
+import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.util.DateUtil;
+import org.apache.phoenix.util.PropertiesUtil;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelStatsEnabledTest.class)
+public class TimeZoneDisplacementIT extends ParallelStatsEnabledIT {
+
+    @Test
+    public void testCompliantCorrection() throws Exception {
+        String tableName = generateUniqueName();
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        props.put(QueryServices.APPLY_TIME_ZONE_DISPLACMENT_ATTRIB, Boolean.TRUE.toString());
+        try (PhoenixConnection conn =
+                (PhoenixConnection) DriverManager.getConnection(getUrl(), props);
+                Statement stmt = conn.createStatement();
+                PreparedStatement insertPstmt =
+                        conn.prepareStatement("upsert into " + tableName
+                                + " (ID, D1, D2, T1, T2, S1, S2, UD1, UD2, UT1, UT2, US1, US2) VALUES"
+                                + " (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ")) {
+            conn.setAutoCommit(true);
+            stmt.executeUpdate("create table " + tableName + " (id integer primary key,"
+                    + "D1 DATE, D2 DATE," + "T1 TIME, T2 TIME," + "S1 TIMESTAMP, S2 TIMESTAMP,"
+                    + "UD1 UNSIGNED_DATE, UD2 UNSIGNED_DATE,"
+                    + "UT1 UNSIGNED_TIME, UT2 UNSIGNED_TIME,"
+                    + "US1 UNSIGNED_TIMESTAMP, US2 UNSIGNED_TIMESTAMP)");
+
+            java.util.Date nowJud = new java.util.Date();
+            java.sql.Date nowSqlDate = new java.sql.Date(nowJud.getTime());
+            java.sql.Time nowSqlTime = new java.sql.Time(nowJud.getTime());
+            java.sql.Timestamp nowSqlTimestamp = new java.sql.Timestamp(nowJud.getTime());
+
+            String nowString =
+                    DateUtil.getDateFormatter(conn.getDatePattern(), TimeZone.getDefault().getID())
+                            .format(nowJud);
+
+            insertPstmt.setInt(1, 1);
+            insertPstmt.setString(2, nowString);
+            insertPstmt.setDate(3, nowSqlDate);
+            insertPstmt.setString(4, nowString);
+            insertPstmt.setTime(5, nowSqlTime);
+            insertPstmt.setString(6, nowString);
+            insertPstmt.setTimestamp(7, nowSqlTimestamp);
+            insertPstmt.setString(8, nowString);
+            insertPstmt.setDate(9, nowSqlDate);
+            insertPstmt.setString(10, nowString);
+            insertPstmt.setTime(11, nowSqlTime);
+            insertPstmt.setString(12, nowString);
+            insertPstmt.setTimestamp(13, nowSqlTimestamp);
+            insertPstmt.execute();
+
+            ResultSet rs =
+                    stmt.executeQuery("select * from " + tableName + " where "
+                            + "D1 = D2 AND T1 = T2 and S1 = S2 and UD1 = UD2 and UT1 = UT2 and US1 = US2");
+            assertTrue(rs.next());
+            assertEquals(nowSqlDate, rs.getDate("D1"));
+            assertEquals(nowSqlDate, rs.getDate("D2"));
+            assertEquals(nowSqlTime, rs.getDate("T1"));
+            assertEquals(nowSqlTime, rs.getDate("T2"));
+            assertEquals(nowSqlTimestamp, rs.getTimestamp("S1"));
+            assertEquals(nowSqlTimestamp, rs.getTimestamp("S2"));
+            assertEquals(nowSqlDate, rs.getDate("UD1"));
+            assertEquals(nowSqlDate, rs.getDate("UD2"));
+            assertEquals(nowSqlTime, rs.getDate("UT1"));
+            assertEquals(nowSqlTime, rs.getDate("UT2"));
+            assertEquals(nowSqlTimestamp, rs.getTimestamp("US1"));
+            assertEquals(nowSqlTimestamp, rs.getTimestamp("US2"));
+
+            assertEquals(nowString, rs.getString("D1"));
+            assertEquals(nowString, rs.getString("D2"));
+            assertEquals(nowString, rs.getString("T1"));
+            assertEquals(nowString, rs.getString("T2"));
+            assertEquals(nowString, rs.getString("S1"));
+            assertEquals(nowString, rs.getString("S2"));
+            assertEquals(nowString, rs.getString("UD1"));
+            assertEquals(nowString, rs.getString("UD2"));
+            assertEquals(nowString, rs.getString("UT1"));
+            assertEquals(nowString, rs.getString("UT2"));
+            assertEquals(nowString, rs.getString("US1"));
+            assertEquals(nowString, rs.getString("US2"));
+        }
+    }
+
+    @Test
+    public void testPhoenix5066() throws Exception {
+        String tableName = generateUniqueName();
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        props.put(QueryServices.APPLY_TIME_ZONE_DISPLACMENT_ATTRIB, Boolean.TRUE.toString());
+        try (PhoenixConnection conn =
+                (PhoenixConnection) DriverManager.getConnection(getUrl(), props);
+                Statement stmt = conn.createStatement();
+                PreparedStatement insertPstmt =
+                        conn.prepareStatement("upsert into " + tableName + " (ID, D, T, S) VALUES"
+                                + " (?, ?, ?, ?) ")) {
+            conn.setAutoCommit(true);
+            stmt.executeUpdate("create table " + tableName + " (id integer primary key,"
+                    + "D DATE, T TIME, S TIMESTAMP)");
+
+            String dateString = "2018-12-10 15:40:47";
+            java.util.Date dateJud =
+                    new java.util.Date(LocalDateTime.parse(dateString.replace(" ", "T"))
+                            .atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli());
+            java.sql.Date sqlDate = new java.sql.Date(dateJud.getTime());
+            java.sql.Time sqlTime = new java.sql.Time(dateJud.getTime());
+            java.sql.Timestamp sqlTimestamp = new java.sql.Timestamp(dateJud.getTime());
+
+            stmt.executeUpdate("upsert into " + tableName + "(ID, D, T, S) VALUES (" + "1," + "'"
+                    + dateString + "'," + "'" + dateString + "'," + "'" + dateString + "')");
+
+            stmt.executeUpdate("upsert into " + tableName + "(ID, D, T, S) VALUES (" + "2,"
+                    + "to_date('" + dateString + "')," + "to_time('" + dateString + "'),"
+                    + "to_timestamp('" + dateString + "'))");
+
+            insertPstmt.setInt(1, 3);
+            insertPstmt.setDate(2, sqlDate);
+            insertPstmt.setTime(3, sqlTime);
+            insertPstmt.setTimestamp(4, sqlTimestamp);
+            insertPstmt.executeUpdate();
+
+            ResultSet rs = stmt.executeQuery("select * from " + tableName + " order by id asc");
+            for (int i = 0; i < 3; i++) {
+                assertTrue(rs.next());
+                assertEquals(dateString + ".000", rs.getString("D"));
+                assertEquals(dateString + ".000", rs.getString("T"));
+                assertEquals(dateString + ".000", rs.getString("S"));
+                assertEquals(sqlDate, rs.getDate("D"));
+                assertEquals(sqlTime, rs.getTime("T"));
+                assertEquals(sqlTimestamp, rs.getTimestamp("S"));
+            }
+
+        }
+    }
+
+    @Test
+    public void testCurrent() throws Exception {
+        String tableName = generateUniqueName();
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        // NOTE that this succeeds with either TRUE or FALSE, but the actual HBase value stored
+        // is different
+        // We are testing that the displacement gets applied both ways
+        props.put(QueryServices.APPLY_TIME_ZONE_DISPLACMENT_ATTRIB, Boolean.TRUE.toString());
+        try (PhoenixConnection conn =
+                (PhoenixConnection) DriverManager.getConnection(getUrl(), props);
+                Statement stmt = conn.createStatement();) {
+            conn.setAutoCommit(true);
+            stmt.executeUpdate("create table " + tableName + " (ID integer primary key,"
+                    + " D DATE," + " T TIME," + " S TIMESTAMP," + " UD UNSIGNED_DATE,"
+                    + " UT UNSIGNED_TIME," + " US UNSIGNED_TIMESTAMP)");
+
+            java.util.Date nowJud = new java.util.Date();
+
+            stmt.executeUpdate("UPSERT INTO " + tableName + " (ID, D, T, S, UD, UT, US) "
+                    + "VALUES (1, CURRENT_DATE(), CURRENT_TIME(), CURRENT_DATE(),"
+                    + "CURRENT_DATE(), CURRENT_TIME(), CURRENT_DATE())");
+
+            ResultSet rs = stmt.executeQuery("select * from " + tableName + " order by id asc");
+            assertTrue(rs.next());
+            assertTrue(Math.abs(nowJud.getTime() - rs.getDate("D").getTime()) < 1000);
+            assertTrue(Math.abs(nowJud.getTime() - rs.getTime("T").getTime()) < 1000);
+            assertTrue(Math.abs(nowJud.getTime() - rs.getTimestamp("S").getTime()) < 1000);
+            assertTrue(Math.abs(nowJud.getTime() - rs.getDate("UD").getTime()) < 1000);
+            assertTrue(Math.abs(nowJud.getTime() - rs.getTime("UT").getTime()) < 1000);
+            assertTrue(Math.abs(nowJud.getTime() - rs.getTimestamp("US").getTime()) < 1000);
+        }
+    }
+
+    @Test
+    public void testRowTimestamp() throws Exception {
+        // The lack of DATE WITH TIMEZONE type in Phoenix causes the rowTimestamp function
+        // to behave erratically with COMPLIANT_TIMEZONE_HANDLING
+
+        // For normal operation HBase expects the TS to be a Instant-like UTC timestamp.
+        // However we apply the TZ displacement on setting and retrieving Temporal objects from/to
+        // java temporal types.
+
+        // This can cause a lot of problems as if the HBase TS is displaced relative to UTC
+        // by setting it explicitly to the current timestamp by setDate() or similar, then
+        // The the valid value may not be actual latest TS if clients from more than one TZ
+        // are writing the row.
+
+        // When using ROW_TIMESTAMP with COMPLIANT_TIMEZONE_HANDLING, the ROWTS should always be
+        // set from string or long types, NOT from java temporal types to avoid this.
+
+        TimeZone tz = TimeZone.getDefault();
+
+        String tableName = generateUniqueName();
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        props.put(QueryServices.APPLY_TIME_ZONE_DISPLACMENT_ATTRIB, Boolean.TRUE.toString());
+        try (PhoenixConnection conn =
+                (PhoenixConnection) DriverManager.getConnection(getUrl(), props);
+                Statement stmt = conn.createStatement();
+                PreparedStatement upsertStmt =
+                        conn.prepareStatement(
+                            "upsert into " + tableName + " (ID, ROWTS, D) VALUES (?, ?, ?)");) {
+            conn.setAutoCommit(true);
+            stmt.executeUpdate(
+                "create table " + tableName + " (ID integer not null," + " ROWTS DATE NOT NULL,"
+                        + " D DATE," + " CONSTRAINT pk PRIMARY KEY (ID, ROWTS ROW_TIMESTAMP) )");
+
+            String dateString = "2018-12-10 15:40:47";
+            java.util.Date dateJudLocal =
+                    new java.util.Date(LocalDateTime.parse(dateString.replace(" ", "T"))
+                            .atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli());
+            java.sql.Date sqlDateLocal = new java.sql.Date(dateJudLocal.getTime());
+
+            // Default ROWTS
+            stmt.executeUpdate(
+                "upsert into " + tableName + " (ID, D) VALUES (1, '" + dateString + "')");
+            // Set ROWTS from literal, displacement doesn't apply
+            stmt.executeUpdate("upsert into " + tableName + " (ID, ROWTS, D) VALUES (2, '"
+                    + dateString + "','" + dateString + "')");
+            // Set ROWTS from parameter, displacement DOES apply
+            upsertStmt.setInt(1, 3);
+            upsertStmt.setDate(2, sqlDateLocal);
+            upsertStmt.setDate(3, sqlDateLocal);
+            upsertStmt.executeUpdate();
+
+            java.sql.Date nowDate = new java.sql.Date(new java.util.Date().getTime());
+            upsertStmt.setInt(1, 4);
+            upsertStmt.setDate(2, nowDate);
+            upsertStmt.setDate(3, nowDate);
+            upsertStmt.executeUpdate();
+
+            ResultSet rs = stmt.executeQuery("select * from " + tableName + " order by id asc");
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt("ID"));
+            assertEquals(sqlDateLocal, rs.getDate("D"));
+            // UTC now() rowTs gets gets applied the displacement when read as java.sql.Date
+            // This is NOT intuitive, but at least the TS contains the current UTC epoch.
+            assertTrue(Math.abs(DateUtil
+                    .applyOutputDisplacement(new java.sql.Date(new java.util.Date().getTime()), tz)
+                    .getTime() - rs.getDate("ROWTS").getTime()) < 10000);
+
+            assertTrue(rs.next());
+            assertEquals(2, rs.getInt("ID"));
+            assertEquals(sqlDateLocal, rs.getDate("D"));
+            // No displacement on write, because the date literal gets parsed as UTC.
+            // So the HBase Ttimestamp is "2018-12-10 15:40:47 UTC"
+            // getDate() applies the TZ displacement on read as normal
+            // so we get "2018-12-10 15:40:47" parsed in the client TZ (which is sqlDate)
+            assertEquals(sqlDateLocal, rs.getDate("ROWTS"));
+            assertEquals(dateString + ".000", rs.getString("ROWTS"));
+
+            assertTrue(rs.next());
+            assertEquals(3, rs.getInt("ID"));
+            assertEquals(sqlDateLocal, rs.getDate("D"));
+            assertEquals(sqlDateLocal, rs.getDate("ROWTS"));
+            // the stored timestamp is in UTC, but only because sqlDateLocal pre-applies the
+            // displacement by parsing the date in the local TZ
+            assertEquals(dateString + ".000", rs.getString("ROWTS"));
+
+            assertTrue(rs.next());
+            assertEquals(4, rs.getInt("ID"));
+            assertEquals(nowDate, rs.getDate("D"));
+            // The stored Hbase timestamp is NOT the current UTC timestamp. We have applied the
+            // displacement on setting the date value.
+            // This is very much not ideal behaviour, and probably NOT what the user wanted
+            // in this case
+            assertEquals(nowDate, rs.getDate("ROWTS"));
+            // To further demonstrate that the HBase TS is NOT the current epoch value.
+            assertEquals(DateUtil.getDateFormatter(DateUtil.DEFAULT_DATE_FORMAT)
+                    .format(DateUtil.applyInputDisplacement(nowDate, tz)),
+                rs.getString("ROWTS"));
+        }
+    }
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/StatementContext.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/StatementContext.java
@@ -42,11 +42,13 @@ import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTableType;
 import org.apache.phoenix.schema.TableRef;
+import org.apache.phoenix.schema.types.PDate;
+import org.apache.phoenix.schema.types.PTime;
+import org.apache.phoenix.schema.types.PTimestamp;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 import org.apache.phoenix.util.DateUtil;
 import org.apache.phoenix.util.NumberUtil;
 import org.apache.phoenix.util.ReadOnlyProps;
-
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 
 
 /**
@@ -59,17 +61,11 @@ import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
  */
 public class StatementContext {
     private ColumnResolver resolver;
+    private final PhoenixConnection connection;
     private final BindManager binds;
     private final Scan scan;
     private final ExpressionManager expressions;
     private final AggregationManager aggregates;
-    private final String dateFormat;
-    private final Format dateFormatter;
-    private final String timeFormat;
-    private final Format timeFormatter;
-    private final String timestampFormat;
-    private final Format timestampFormatter;
-    private final TimeZone dateFormatTimeZone;
     private final String numberFormat;
     private final ImmutableBytesWritable tempPtr;
     private final PhoenixStatement statement;
@@ -124,17 +120,8 @@ public class StatementContext {
         this.binds = binds;
         this.aggregates = new AggregationManager();
         this.expressions = new ExpressionManager();
-        PhoenixConnection connection = statement.getConnection();
+        this.connection = statement.getConnection();
         ReadOnlyProps props = connection.getQueryServices().getProps();
-        String timeZoneID = props.get(QueryServices.DATE_FORMAT_TIMEZONE_ATTRIB,
-                DateUtil.DEFAULT_TIME_ZONE_ID);
-        this.dateFormat = props.get(QueryServices.DATE_FORMAT_ATTRIB, DateUtil.DEFAULT_DATE_FORMAT);
-        this.dateFormatter = DateUtil.getDateFormatter(dateFormat, timeZoneID);
-        this.timeFormat = props.get(QueryServices.TIME_FORMAT_ATTRIB, DateUtil.DEFAULT_TIME_FORMAT);
-        this.timeFormatter = DateUtil.getTimeFormatter(timeFormat, timeZoneID);
-        this.timestampFormat = props.get(QueryServices.TIMESTAMP_FORMAT_ATTRIB, DateUtil.DEFAULT_TIMESTAMP_FORMAT);
-        this.timestampFormatter = DateUtil.getTimestampFormatter(timestampFormat, timeZoneID);
-        this.dateFormatTimeZone = DateUtil.getTimeZone(timeZoneID);
         this.numberFormat = props.get(QueryServices.NUMBER_FORMAT_ATTRIB, NumberUtil.DEFAULT_NUMBER_FORMAT);
         this.tempPtr = new ImmutableBytesWritable();
         this.currentTable = resolver != null && !resolver.getTables().isEmpty() ? resolver.getTables().get(0) : null;
@@ -176,32 +163,32 @@ public class StatementContext {
         return dataColumns;
     }
 
-    public String getDateFormat() {
-        return dateFormat;
+    public String getDateFormatTimeZoneId() {
+        return connection.getDateFormatTimeZoneId();
     }
 
-    public TimeZone getDateFormatTimeZone() {
-        return dateFormatTimeZone;
+    public String getDateFormat() {
+        return connection.getDatePattern();
     }
 
     public Format getDateFormatter() {
-        return dateFormatter;
+        return connection.getFormatter(PDate.INSTANCE);
     }
 
     public String getTimeFormat() {
-        return timeFormat;
+        return connection.getTimePattern();
     }
 
     public Format getTimeFormatter() {
-        return timeFormatter;
+        return connection.getFormatter(PTime.INSTANCE);
     }
 
     public String getTimestampFormat() {
-        return timestampFormat;
+        return connection.getTimestampPattern();
     }
 
     public Format getTimestampFormatter() {
-        return timestampFormatter;
+        return connection.getFormatter(PTimestamp.INSTANCE);
     }
 
     public String getNumberFormat() {
@@ -255,7 +242,7 @@ public class StatementContext {
     }
 
     public PhoenixConnection getConnection() {
-        return statement.getConnection();
+        return connection;
     }
 
     public PhoenixStatement getStatement() {
@@ -281,10 +268,18 @@ public class StatementContext {
          * purely to bind the current time based on the server time.
          */
         PTable table = this.getCurrentTable().getTable();
-        PhoenixConnection connection = getConnection();
         MetaDataClient client = new MetaDataClient(connection);
         currentTime = client.getCurrentTime(table.getSchemaName().getString(), table.getTableName().getString());
         return currentTime;
+    }
+
+    public long getCurrentTimeWithDisplacement() throws SQLException {
+        if (connection.isApplyTimeZoneDisplacement()) {
+            return DateUtil.applyInputDisplacement(new java.sql.Date(getCurrentTime()),
+                statement.getLocalCalendar().getTimeZone()).getTime();
+        } else {
+            return getCurrentTime();
+        }
     }
 
     public SequenceManager getSequenceManager(){

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CurrentDateFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CurrentDateFunction.java
@@ -52,7 +52,9 @@ public class CurrentDateFunction extends CurrentDateTimeFunction {
     }
 
     public CurrentDateFunction(List<Expression> children, StatementContext context) throws SQLException {
-        this(context.getCurrentTime());
+        // Note that according to the standard Date is always WITHOUT TIMEZONE, but we don't
+        // implement real dates
+        this(context.getCurrentTimeWithDisplacement());
     }
 
     public CurrentDateFunction(long timeStamp) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CurrentTimeFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/CurrentTimeFunction.java
@@ -52,7 +52,7 @@ public class CurrentTimeFunction extends CurrentDateTimeFunction {
     }
 
     public CurrentTimeFunction(List<Expression> children, StatementContext context) throws SQLException {
-        this(context.getCurrentTime());
+        this(context.getCurrentTimeWithDisplacement());
     }
 
     public CurrentTimeFunction(long timeStamp) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToDateFunction.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/function/ToDateFunction.java
@@ -70,7 +70,7 @@ public class ToDateFunction extends ScalarFunction {
             dateFormat = context.getDateFormat();
         }
         if (timeZoneId == null) {
-            timeZoneId = context.getDateFormatTimeZone().getID();
+            timeZoneId = context.getDateFormatTimeZoneId();
         }
         init(dateFormat, timeZoneId);
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
@@ -156,6 +156,7 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
     private boolean isAutoFlush = false;
     private boolean isAutoCommit = false;
     private final PName tenantId;
+    private final String dateFormatTimeZoneId;
     private final String datePattern;
     private final String timePattern;
     private final String timestampPattern;
@@ -185,6 +186,7 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
     //For now just the copy constructor paths will have this as true as I don't want to change the
     //public interfaces.
     private final boolean isInternalConnection;
+    private boolean isApplyTimeZoneDisplacement;
 
     static {
         Tracing.addTraceMetricsSource();
@@ -346,11 +348,14 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
         long maxSizeBytes = this.services.getProps().getLong(
                 QueryServices.MAX_MUTATION_SIZE_BYTES_ATTRIB,
                 QueryServicesOptions.DEFAULT_MAX_MUTATION_SIZE_BYTES);
-        String timeZoneID = this.services.getProps().get(QueryServices.DATE_FORMAT_TIMEZONE_ATTRIB,
+        this.isApplyTimeZoneDisplacement = this.services.getProps().getBoolean(
+            QueryServices.APPLY_TIME_ZONE_DISPLACMENT_ATTRIB,
+            QueryServicesOptions.DEFAULT_APPLY_TIME_ZONE_DISPLACMENT);
+        this.dateFormatTimeZoneId = this.services.getProps().get(QueryServices.DATE_FORMAT_TIMEZONE_ATTRIB,
                 DateUtil.DEFAULT_TIME_ZONE_ID);
-        Format dateFormat = DateUtil.getDateFormatter(datePattern, timeZoneID);
-        Format timeFormat = DateUtil.getDateFormatter(timePattern, timeZoneID);
-        Format timestampFormat = DateUtil.getDateFormatter(timestampPattern, timeZoneID);
+        Format dateFormat = DateUtil.getDateFormatter(datePattern, dateFormatTimeZoneId);
+        Format timeFormat = DateUtil.getDateFormatter(timePattern, dateFormatTimeZoneId);
+        Format timestampFormat = DateUtil.getDateFormatter(timestampPattern, dateFormatTimeZoneId);
         formatters.put(PDate.INSTANCE, dateFormat);
         formatters.put(PTime.INSTANCE, timeFormat);
         formatters.put(PTimestamp.INSTANCE, timestampFormat);
@@ -652,6 +657,14 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
 
     public String getDatePattern() {
         return datePattern;
+    }
+
+    public String getTimePattern() {
+        return timePattern;
+    }
+
+    public String getTimestampPattern() {
+        return timestampPattern;
     }
 
     public Format getFormatter(PDataType type) {
@@ -1361,5 +1374,13 @@ public class PhoenixConnection implements Connection, MetaDataMutated, SQLClosea
      */
     public String getSourceOfOperation() {
         return sourceOfOperation;
+    }
+
+    public String getDateFormatTimeZoneId() {
+        return dateFormatTimeZoneId;
+    }
+
+    public boolean isApplyTimeZoneDisplacement() {
+        return isApplyTimeZoneDisplacement;
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -34,6 +34,7 @@ import java.sql.Statement;
 import java.text.Format;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -257,7 +258,9 @@ public class PhoenixStatement implements Statement, SQLCloseable {
     private int maxRows;
     private int fetchSize = -1;
     private int queryTimeoutMillis;
-    
+    // Caching per Statement
+    protected final Calendar localCalendar = Calendar.getInstance();
+
     public PhoenixStatement(PhoenixConnection connection) {
         this.connection = connection;
         this.queryTimeoutMillis = getDefaultQueryTimeoutMillis();
@@ -2328,4 +2331,9 @@ public class PhoenixStatement implements Statement, SQLCloseable {
             }
         }
     }
+
+    public Calendar getLocalCalendar() {
+        return localCalendar;
+    }
+
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/CurrentDateParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/CurrentDateParseNode.java
@@ -34,6 +34,6 @@ public class CurrentDateParseNode extends FunctionParseNode {
 
     @Override
     public FunctionExpression create(List<Expression> children, StatementContext context) throws SQLException {
-        return new CurrentDateFunction(context.getCurrentTime());
+        return new CurrentDateFunction(context.getCurrentTimeWithDisplacement());
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/CurrentTimeParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/CurrentTimeParseNode.java
@@ -34,6 +34,6 @@ public class CurrentTimeParseNode extends FunctionParseNode {
 
     @Override
     public FunctionExpression create(List<Expression> children, StatementContext context) throws SQLException {
-        return new CurrentTimeFunction(context.getCurrentTime());
+        return new CurrentTimeFunction(context.getCurrentTimeWithDisplacement());
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ToDateParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ToDateParseNode.java
@@ -41,7 +41,7 @@ public class ToDateParseNode extends FunctionParseNode {
             dateFormat = context.getDateFormat();
         }
         if (timeZoneId == null) {
-            timeZoneId = context.getDateFormatTimeZone().getID();
+            timeZoneId = context.getDateFormatTimeZoneId();
         }
         return new ToDateFunction(children, dateFormat, timeZoneId);
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ToTimeParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ToTimeParseNode.java
@@ -41,7 +41,7 @@ public class ToTimeParseNode extends FunctionParseNode {
             dateFormat = context.getTimeFormat();
         }
         if (timeZoneId == null) {
-            timeZoneId = context.getDateFormatTimeZone().getID();
+            timeZoneId = context.getDateFormatTimeZoneId();
         }
         return new ToTimeFunction(children, dateFormat, timeZoneId);
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ToTimestampParseNode.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ToTimestampParseNode.java
@@ -41,7 +41,7 @@ public class ToTimestampParseNode extends FunctionParseNode {
             dateFormat = context.getTimestampFormat();
         }
         if (timeZoneId == null) {
-            timeZoneId = context.getDateFormatTimeZone().getID();
+            timeZoneId = context.getDateFormatTimeZoneId();
         }
         return new ToTimestampFunction(children, dateFormat, timeZoneId);
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -87,6 +87,7 @@ public interface QueryServices extends SQLCloseable {
     public static final String MAX_MEMORY_PERC_ATTRIB = "phoenix.query.maxGlobalMemoryPercentage";
     public static final String MAX_TENANT_MEMORY_PERC_ATTRIB = "phoenix.query.maxTenantMemoryPercentage";
     public static final String MAX_SERVER_CACHE_SIZE_ATTRIB = "phoenix.query.maxServerCacheBytes";
+    public static final String APPLY_TIME_ZONE_DISPLACMENT_ATTRIB = "phoenix.query.applyTimeZoneDisplacement";
     public static final String DATE_FORMAT_TIMEZONE_ATTRIB = "phoenix.query.dateFormatTimeZone";
     public static final String DATE_FORMAT_ATTRIB = "phoenix.query.dateFormat";
     public static final String TIME_FORMAT_ATTRIB = "phoenix.query.timeFormat";

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -379,6 +379,7 @@ public class QueryServicesOptions {
     public static final boolean DEFAULT_PENDING_MUTATIONS_DDL_THROW = false;
 
     public static final boolean DEFAULT_SKIP_SYSTEM_TABLES_EXISTENCE_CHECK = false;
+    public static final boolean DEFAULT_APPLY_TIME_ZONE_DISPLACMENT = false;
 
     private final Configuration config;
 

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
               <id>ParallelStatsEnabledTest</id>
               <configuration>
                 <reuseForks>true</reuseForks>
-                <argLine>@{jacocoArgLine} -Xmx3000m -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/ -XX:NewRatio=4 -XX:SurvivorRatio=8 -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC -XX:+UseCMSInitiatingOccupancyOnly -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:CMSInitiatingOccupancyFraction=68</argLine>
+                <argLine>@{jacocoArgLine} -Duser.timezone="America/Los_Angeles" -Xmx3000m -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/ -XX:NewRatio=4 -XX:SurvivorRatio=8 -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC -XX:+UseCMSInitiatingOccupancyOnly -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:CMSInitiatingOccupancyFraction=68</argLine>
                 <groups>org.apache.phoenix.end2end.ParallelStatsEnabledTest</groups>
               </configuration>
               <goals>
@@ -341,7 +341,7 @@
               <id>ParallelStatsDisabledTest</id>
               <configuration>
                 <reuseForks>true</reuseForks>
-                <argLine>@{jacocoArgLine} -Xmx3000m -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/ -XX:NewRatio=4 -XX:SurvivorRatio=8 -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC -XX:+UseCMSInitiatingOccupancyOnly -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:CMSInitiatingOccupancyFraction=68</argLine>
+                <argLine>@{jacocoArgLine} -Duser.timezone="America/Los_Angeles" -Xmx3000m -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/ -XX:NewRatio=4 -XX:SurvivorRatio=8 -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC -XX:+UseCMSInitiatingOccupancyOnly -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:CMSInitiatingOccupancyFraction=68</argLine>
                 <groups>org.apache.phoenix.end2end.ParallelStatsDisabledTest</groups>
               </configuration>
               <goals>
@@ -353,7 +353,7 @@
               <id>NeedTheirOwnClusterTests</id>
               <configuration>
                  <reuseForks>false</reuseForks>
-                 <argLine>@{jacocoArgLine} -enableassertions -Xmx3000m -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/ -XX:NewRatio=4 -XX:SurvivorRatio=8 -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC -XX:+UseCMSInitiatingOccupancyOnly -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:CMSInitiatingOccupancyFraction=68</argLine>
+                 <argLine>@{jacocoArgLine} -Duser.timezone="America/Los_Angeles" -enableassertions -Xmx3000m -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/ -XX:NewRatio=4 -XX:SurvivorRatio=8 -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC -XX:+UseCMSInitiatingOccupancyOnly -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:CMSInitiatingOccupancyFraction=68</argLine>
                  <groups>org.apache.phoenix.end2end.NeedsOwnMiniClusterTest</groups>
               </configuration>
               <goals>
@@ -574,7 +574,7 @@
         <configuration>
           <forkCount>${numForkedUT}</forkCount>
           <reuseForks>true</reuseForks>
-          <argLine>@{jacocoArgLine} -enableassertions -Xmx2250m
+          <argLine>@{jacocoArgLine} -enableassertions -Xmx2250m -Duser.timezone="America/Los_Angeles"
             -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/</argLine>
           <redirectTestOutputToFile>${test.output.tofile}</redirectTestOutputToFile>
           <shutdown>exit</shutdown>


### PR DESCRIPTION
…ng data

Add the phoenix.query.applyTimeZoneDisplacement option, that causes the java.sql time types to be treated as local times.
This option is disabled by default, it needs to be enabled to get the new behaviour.