### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/phoenix-core/src/main/java/org/apache/hadoop/hbase/regionserver/DataTableLocalIndexRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/hadoop/hbase/regionserver/DataTableLocalIndexRegionScanner.java
@@ -93,7 +93,7 @@ public class DataTableLocalIndexRegionScanner extends DelegateRegionScanner {
         boolean next = super.next(dataTableResults);
         addMutations(dataTableResults);
         if (ServerUtil.readyToCommit(mutationList.size(), mutationList.byteSize(), maxBatchSize, maxBatchSizeBytes)||!next) {
-            region.batchMutate(mutationList.toArray(new Mutation[mutationList.size()]));
+            region.batchMutate(mutationList.toArray(new Mutation[0]));
             mutationList.clear();
         }
         return next;

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/IndexRepairRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/IndexRepairRegionScanner.java
@@ -130,7 +130,7 @@ public class IndexRepairRegionScanner extends GlobalIndexRegionScanner {
 
     protected void commitBatch(List<Mutation> indexUpdates) throws IOException, InterruptedException {
         ungroupedAggregateRegionObserver.checkForRegionClosingOrSplitting();
-        region.batchMutate(indexUpdates.toArray(new Mutation[indexUpdates.size()]));
+        region.batchMutate(indexUpdates.toArray(new Mutation[0]));
     }
 
     protected void repairIndexRows(Map<byte[], List<Mutation>> indexMutationMap,

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/InListExpression.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/InListExpression.java
@@ -184,7 +184,7 @@ public class InListExpression extends BaseSingleExpression {
         }
         this.fixedWidth = isFixedLength ? fixedWidth : -1;
         // Sort values by byte value so we can get min/max easily
-        ImmutableBytesPtr[] valuesArray = values.toArray(new ImmutableBytesPtr[values.size()]);
+        ImmutableBytesPtr[] valuesArray = values.toArray(new ImmutableBytesPtr[0]);
         Arrays.sort(valuesArray, ByteUtil.BYTES_PTR_COMPARATOR);
         if (values.isEmpty()) {
             this.minValue = ByteUtil.EMPTY_BYTE_ARRAY_PTR;

--- a/phoenix-core/src/main/java/org/apache/phoenix/expression/aggregator/ClientAggregators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/expression/aggregator/ClientAggregators.java
@@ -45,7 +45,7 @@ public class ClientAggregators extends Aggregators {
     }
     
     public ClientAggregators(List<SingleAggregateFunction> functions, int minNullableIndex) {
-        super(functions.toArray(new SingleAggregateFunction[functions.size()]), getAggregators(functions), minNullableIndex);
+        super(functions.toArray(new SingleAggregateFunction[0]), getAggregators(functions), minNullableIndex);
         this.tempValueSet = ValueBitSet.newInstance(schema);
     }
     

--- a/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/Indexer.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/Indexer.java
@@ -524,7 +524,7 @@ public class Indexer implements RegionObserver, RegionCoprocessor {
           }
           if (!localUpdates.isEmpty()) {
               miniBatchOp.addOperationsFromCP(0,
-                  localUpdates.toArray(new Mutation[localUpdates.size()]));
+                  localUpdates.toArray(new Mutation[0]));
           }
           if (!indexUpdates.isEmpty()) {
               context.indexUpdates = indexUpdates;

--- a/phoenix-core/src/main/java/org/apache/phoenix/index/PhoenixTransactionalIndexer.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/index/PhoenixTransactionalIndexer.java
@@ -188,7 +188,7 @@ public class PhoenixTransactionalIndexer implements RegionObserver, RegionCoproc
             }
             if (!localUpdates.isEmpty()) {
                 miniBatchOp.addOperationsFromCP(0,
-                    localUpdates.toArray(new Mutation[localUpdates.size()]));
+                    localUpdates.toArray(new Mutation[0]));
             }
             if (!indexUpdates.isEmpty()) {
                 context.indexUpdates = indexUpdates;

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/types/PDataTypeFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/types/PDataTypeFactory.java
@@ -101,7 +101,7 @@ public class PDataTypeFactory {
     for (PDataType t : types) {
       classToInstance.put(t.getClass(), t);
     }
-    orderedTypes = types.toArray(new PDataType[types.size()]);
+    orderedTypes = types.toArray(new PDataType[0]);
   }
 
   public Set<PDataType> getTypes() {

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/CSVCommonsLoader.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/CSVCommonsLoader.java
@@ -75,7 +75,7 @@ public class CSVCommonsLoader {
     public enum PhoenixHeaderSource {
         FROM_TABLE,
         IN_LINE,
-        SUPPLIED_BY_USER
+        SUPPLIED_BY_USER;
     }
 
     public CSVCommonsLoader(PhoenixConnection conn, String tableName,
@@ -140,7 +140,7 @@ public class CSVCommonsLoader {
             break;
         case SUPPLIED_BY_USER:
             // a populated string array supplied by the user
-            format = format.withHeader(columns.toArray(new String[columns.size()]));
+            format = format.withHeader(columns.toArray(new String[0]));
             break;
         default:
             throw new RuntimeException("Header source was unable to be inferred.");

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/CSVCommonsLoader.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/CSVCommonsLoader.java
@@ -75,7 +75,7 @@ public class CSVCommonsLoader {
     public enum PhoenixHeaderSource {
         FROM_TABLE,
         IN_LINE,
-        SUPPLIED_BY_USER;
+        SUPPLIED_BY_USER
     }
 
     public CSVCommonsLoader(PhoenixConnection conn, String tableName,

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/i18n/LinguisticSort.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/i18n/LinguisticSort.java
@@ -894,7 +894,7 @@ public enum LinguisticSort {
         if (alphabet.size() > 6) {
             // Strip off first and last (which are ...)
             List<String> alphabetWithoutEllipses = alphabet.subList(1, alphabet.size() - 1);
-            return alphabetWithoutEllipses.toArray(new String[alphabetWithoutEllipses.size()]);
+            return alphabetWithoutEllipses.toArray(new String[0]);
         } else {
             return new String[0];
         }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:1176120126 -->
<!-- fingerprint:110992419 -->
<!-- fingerprint:-1043980438 -->
<!-- fingerprint:-1973336090 -->
<!-- fingerprint:-1274265671 -->
<!-- fingerprint:1211470235 -->
<!-- fingerprint:-745472861 -->
<!-- fingerprint:1691024976 -->
<!-- fingerprint:2125217390 -->
<!-- fingerprint:168761762 -->
<!-- fingerprint:1080720431 -->
<!-- fingerprint:481393296 -->
<!-- fingerprint:-2107721345 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (13)
