### PR TITLE
Revert "PHOENIX-6884 Phoenix to use hbase.rpc.read.timeout and hbase.rpc.writ…"

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataRegionObserver.java
@@ -636,10 +636,6 @@ public class MetaDataRegionObserver implements RegionObserver,RegionCoprocessor 
                 Long.toString(indexRebuildClientScannerTimeOutMs));
             props.setProperty(HConstants.HBASE_RPC_TIMEOUT_KEY,
                 Long.toString(indexRebuildRPCTimeoutMs));
-            props.setProperty(HConstants.HBASE_RPC_READ_TIMEOUT_KEY,
-                    Long.toString(indexRebuildRPCTimeoutMs));
-            props.setProperty(HConstants.HBASE_RPC_WRITE_TIMEOUT_KEY,
-                    Long.toString(indexRebuildRPCTimeoutMs));
             props.setProperty(HConstants.HBASE_CLIENT_RETRIES_NUMBER,
                 Long.toString(indexRebuildRpcRetriesCounter));
             // don't run a second index populations upsert select

--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/index/IndexTool.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/index/IndexTool.java
@@ -716,10 +716,6 @@ public class IndexTool extends Configured implements Tool {
                     Long.toString(indexRebuildClientScannerTimeOutMs));
             configuration.set(HConstants.HBASE_RPC_TIMEOUT_KEY,
                     Long.toString(indexRebuildRPCTimeoutMs));
-            configuration.set(HConstants.HBASE_RPC_READ_TIMEOUT_KEY,
-                    Long.toString(indexRebuildRPCTimeoutMs));
-            configuration.set(HConstants.HBASE_RPC_WRITE_TIMEOUT_KEY,
-                    Long.toString(indexRebuildRPCTimeoutMs));
             configuration.set(HConstants.HBASE_CLIENT_RETRIES_NUMBER,
                     Long.toString(indexRebuildRpcRetriesCounter));
             configuration.set("mapreduce.task.timeout", Long.toString(indexRebuildQueryTimeoutMs));

--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/index/IndexUpgradeTool.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/index/IndexUpgradeTool.java
@@ -357,7 +357,6 @@ public class IndexUpgradeTool extends Configured implements Tool {
         long indexRebuildRPCTimeoutMs =
                 conf.getLong(QueryServices.INDEX_REBUILD_RPC_TIMEOUT_ATTRIB,
                         QueryServicesOptions.DEFAULT_INDEX_REBUILD_RPC_TIMEOUT);
-
         long indexRebuildClientScannerTimeOutMs =
                 conf.getLong(QueryServices.INDEX_REBUILD_CLIENT_SCANNER_TIMEOUT_ATTRIB,
                         QueryServicesOptions.DEFAULT_INDEX_REBUILD_CLIENT_SCANNER_TIMEOUT);
@@ -368,8 +367,6 @@ public class IndexUpgradeTool extends Configured implements Tool {
         // Set phoenix and hbase level timeouts and rpc retries
         conf.setLong(QueryServices.THREAD_TIMEOUT_MS_ATTRIB, indexRebuildQueryTimeoutMs);
         conf.setLong(HConstants.HBASE_RPC_TIMEOUT_KEY, indexRebuildRPCTimeoutMs);
-        conf.setLong(HConstants.HBASE_RPC_READ_TIMEOUT_KEY, indexRebuildRPCTimeoutMs);
-        conf.setLong(HConstants.HBASE_RPC_WRITE_TIMEOUT_KEY, indexRebuildRPCTimeoutMs);
         conf.setLong(HConstants.HBASE_CLIENT_SCANNER_TIMEOUT_PERIOD,
                 indexRebuildClientScannerTimeOutMs);
         conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, indexRebuildRpcRetriesCounter);

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
@@ -1302,32 +1302,6 @@ public class ScanUtil {
         }
     }
 
-    public static Long getRPCReadTimeout(ReadOnlyProps props) {
-        if (props.get(HConstants.HBASE_RPC_READ_TIMEOUT_KEY) != null) {
-            return props.getLong(HConstants.HBASE_RPC_READ_TIMEOUT_KEY,
-                    HConstants.DEFAULT_HBASE_RPC_TIMEOUT);
-        } else {
-            return props.getLong(HConstants.HBASE_RPC_TIMEOUT_KEY,
-                    HConstants.DEFAULT_HBASE_RPC_TIMEOUT);
-        }
-    }
-
-    public static Long getPageSizeInMs(ReadOnlyProps props) {
-        if (props.getBoolean(QueryServices.PHOENIX_SERVER_PAGING_ENABLED_ATTRIB,
-                QueryServicesOptions.DEFAULT_PHOENIX_SERVER_PAGING_ENABLED)) {
-            long pageSizeMs = props.getInt(QueryServices.PHOENIX_SERVER_PAGE_SIZE_MS, -1);
-            if (pageSizeMs == -1) {
-                // Use the half of the HBase RPC read timeout value as the server page size to
-                // make sure that the HBase region server will be able to send a heartbeat
-                // message to the client before the client times out
-                return getRPCReadTimeout(props) / 2;
-            } else {
-                return pageSizeMs;
-            }
-        }
-        return null;
-    }
-
     public static void setScanAttributesForClient(Scan scan, PTable table,
                                                   PhoenixConnection phoenixConnection) throws SQLException {
         setScanAttributesForIndexReadRepair(scan, table, phoenixConnection);
@@ -1345,11 +1319,20 @@ public class ScanUtil {
             scan.setAttribute(BaseScannerRegionObserver.EMPTY_COLUMN_QUALIFIER_NAME, emptyCQ);
             addEmptyColumnToScan(scan, emptyCF, emptyCQ);
         }
-        Long pageSizeMs = getPageSizeInMs(phoenixConnection.getQueryServices().getProps());
-        if (pageSizeMs != null) {
-            scan.setAttribute(BaseScannerRegionObserver.SERVER_PAGE_SIZE_MS,
-                    Bytes.toBytes(pageSizeMs));
+        if (phoenixConnection.getQueryServices().getProps().getBoolean(
+                QueryServices.PHOENIX_SERVER_PAGING_ENABLED_ATTRIB,
+                QueryServicesOptions.DEFAULT_PHOENIX_SERVER_PAGING_ENABLED)) {
+            long pageSizeMs = phoenixConnection.getQueryServices().getProps()
+                    .getInt(QueryServices.PHOENIX_SERVER_PAGE_SIZE_MS, -1);
+            if (pageSizeMs == -1) {
+                // Use the half of the HBase RPC timeout value as the the server page size to make sure that the HBase
+                // region server will be able to send a heartbeat message to the client before the client times out
+                pageSizeMs = (long) (phoenixConnection.getQueryServices().getProps()
+                        .getLong(HConstants.HBASE_RPC_TIMEOUT_KEY, HConstants.DEFAULT_HBASE_RPC_TIMEOUT) * 0.5);
+            }
+            scan.setAttribute(BaseScannerRegionObserver.SERVER_PAGE_SIZE_MS, Bytes.toBytes(Long.valueOf(pageSizeMs)));
         }
+
     }
 
     public static void getDummyResult(byte[] rowKey, List<Cell> result) {

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
@@ -632,7 +632,12 @@ public abstract class BaseTest {
         conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 2);
         conf.setInt(NUM_CONCURRENT_INDEX_WRITER_THREADS_CONF_KEY, 1);
         conf.setInt(GLOBAL_INDEX_ROW_AGE_THRESHOLD_TO_DELETE_MS_ATTRIB, 0);
-        conf.setInt(HConstants.HBASE_RPC_READ_TIMEOUT_KEY, 20); // 20ms
+        // This results in processing one row at a time in each next operation of the aggregate region
+        // scanner, i.e.,  one row pages. In other words, 0ms page allows only one row to be processed
+        // within one page; 0ms page is equivalent to one-row page
+        if (conf.getLong(QueryServices.PHOENIX_SERVER_PAGE_SIZE_MS, 0) == 0) {
+            conf.setLong(QueryServices.PHOENIX_SERVER_PAGE_SIZE_MS, 0);
+        }
         return conf;
     }
 


### PR DESCRIPTION
Reverts apache/phoenix#1566

As described in https://issues.apache.org/jira/browse/PHOENIX-6898 this change is breaking indexing tests with 2.5 profile.

I will reopen PHOENIX-6884 and working on a fix for it.