### PR TITLE
PHOENIX-6907 Explain Plan should output region locations with servers

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DerivedTableIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DerivedTableIT.java
@@ -58,8 +58,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import org.apache.phoenix.thirdparty.com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 @Category(ParallelStatsDisabledTest.class)
@@ -72,8 +70,6 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
     private String[] indexDDL;
     private String[] plans;
     private String tableName;
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DerivedTableIT.class);
 
 
     public DerivedTableIT(String[] indexDDL, String[] plans) {
@@ -118,7 +114,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                 {
                         "CREATE INDEX "+dynamicTableName+"_DERIVED_IDX ON "+dynamicTableName+" (a_byte) INCLUDE (A_STRING, B_STRING)"
                 }, {
-                "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX \n" +
+                "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX\n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [\"A_STRING\", \"B_STRING\"]\n" +
                         "CLIENT MERGE SORT\n" +
                         "CLIENT SORTED BY [\"B_STRING\"]\n" +
@@ -126,7 +122,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                         "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
                         "CLIENT SORTED BY [A DESC]",
 
-                "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX \n" +
+                "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX\n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [\"A_STRING\", \"B_STRING\"]\n" +
                         "CLIENT MERGE SORT\n" +
                         "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
@@ -134,7 +130,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                         "CLIENT SORTED BY [A DESC]"}});
         testCases.add(new String[][] {
                 {}, {
-                "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+" \n" +
+                "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+"\n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [A_STRING, B_STRING]\n" +
                         "CLIENT MERGE SORT\n" +
                         "CLIENT SORTED BY [B_STRING]\n" +
@@ -142,7 +138,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                         "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
                         "CLIENT SORTED BY [A DESC]",
 
-                "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+" \n" +
+                "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+"\n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [A_STRING, B_STRING]\n" +
                         "CLIENT MERGE SORT\n" +
                         "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
@@ -383,11 +379,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
             assertFalse(rs.next());
 
             rs = conn.createStatement().executeQuery("EXPLAIN " + query);
-            String explainPlanOutput = QueryUtil.getExplainPlan(rs);
-            LOGGER.info("Explain plan output: {}", explainPlanOutput);
-            String[] splitExplainPlan = explainPlanOutput.split("\\n \\(region locations = \\[region=");
-            String[] secondSplitExplainPlan = splitExplainPlan[1].split("]\\)");
-            assertEquals(plans[0], splitExplainPlan[0] + secondSplitExplainPlan[1]);
+            assertEquals(plans[0], QueryUtil.getExplainPlan(rs));
 
             // distinct b (groupby a, b) groupby a orderby a
             query = "SELECT DISTINCT COLLECTDISTINCT(t.b) FROM (SELECT b_string b, a_string a FROM "+tableName+" GROUP BY a_string, b_string) AS t GROUP BY t.a ORDER BY t.a DESC";
@@ -409,11 +401,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
             assertFalse(rs.next());
 
             rs = conn.createStatement().executeQuery("EXPLAIN " + query);
-            explainPlanOutput = QueryUtil.getExplainPlan(rs);
-            LOGGER.info("Explain plan output: {}", explainPlanOutput);
-            splitExplainPlan = explainPlanOutput.split("\\n \\(region locations = \\[region=");
-            secondSplitExplainPlan = splitExplainPlan[1].split("]\\)");
-            assertEquals(plans[1], splitExplainPlan[0] + secondSplitExplainPlan[1]);
+            assertEquals(plans[1], QueryUtil.getExplainPlan(rs));
 
             // (orderby) groupby
             query = "SELECT t.a_string, count(*) FROM (SELECT * FROM "+tableName+" order by a_integer) AS t where a_byte != 8 group by t.a_string";

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DerivedTableIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DerivedTableIT.java
@@ -58,6 +58,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import org.apache.phoenix.thirdparty.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Category(ParallelStatsDisabledTest.class)
@@ -70,6 +72,8 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
     private String[] indexDDL;
     private String[] plans;
     private String tableName;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DerivedTableIT.class);
 
 
     public DerivedTableIT(String[] indexDDL, String[] plans) {
@@ -114,7 +118,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                 {
                         "CREATE INDEX "+dynamicTableName+"_DERIVED_IDX ON "+dynamicTableName+" (a_byte) INCLUDE (A_STRING, B_STRING)"
                 }, {
-                "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX\n" +
+                "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX \n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [\"A_STRING\", \"B_STRING\"]\n" +
                         "CLIENT MERGE SORT\n" +
                         "CLIENT SORTED BY [\"B_STRING\"]\n" +
@@ -122,7 +126,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                         "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
                         "CLIENT SORTED BY [A DESC]",
 
-                "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX\n" +
+                "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX \n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [\"A_STRING\", \"B_STRING\"]\n" +
                         "CLIENT MERGE SORT\n" +
                         "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
@@ -130,7 +134,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                         "CLIENT SORTED BY [A DESC]"}});
         testCases.add(new String[][] {
                 {}, {
-                "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+"\n" +
+                "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+" \n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [A_STRING, B_STRING]\n" +
                         "CLIENT MERGE SORT\n" +
                         "CLIENT SORTED BY [B_STRING]\n" +
@@ -138,7 +142,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                         "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
                         "CLIENT SORTED BY [A DESC]",
 
-                "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+"\n" +
+                "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+" \n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [A_STRING, B_STRING]\n" +
                         "CLIENT MERGE SORT\n" +
                         "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
@@ -378,8 +382,12 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
 
             assertFalse(rs.next());
 
-            rs = conn.createStatement().executeQuery("EXPLAIN " + query);
-            assertEquals(plans[0], QueryUtil.getExplainPlan(rs));
+            rs = conn.createStatement().executeQuery("EXPLAIN WITH REGIONS " + query);
+            String explainPlanOutput = QueryUtil.getExplainPlan(rs);
+            LOGGER.info("Explain plan output: {}", explainPlanOutput);
+            String[] splitExplainPlan = explainPlanOutput.split("\\n \\(region locations = \\[region=");
+            String[] secondSplitExplainPlan = splitExplainPlan[1].split("]\\)");
+            assertEquals(plans[0], splitExplainPlan[0] + secondSplitExplainPlan[1]);
 
             // distinct b (groupby a, b) groupby a orderby a
             query = "SELECT DISTINCT COLLECTDISTINCT(t.b) FROM (SELECT b_string b, a_string a FROM "+tableName+" GROUP BY a_string, b_string) AS t GROUP BY t.a ORDER BY t.a DESC";
@@ -400,8 +408,12 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
 
             assertFalse(rs.next());
 
-            rs = conn.createStatement().executeQuery("EXPLAIN " + query);
-            assertEquals(plans[1], QueryUtil.getExplainPlan(rs));
+            rs = conn.createStatement().executeQuery("EXPLAIN WITH REGIONS " + query);
+            explainPlanOutput = QueryUtil.getExplainPlan(rs);
+            LOGGER.info("Explain plan output: {}", explainPlanOutput);
+            splitExplainPlan = explainPlanOutput.split("\\n \\(region locations = \\[region=");
+            secondSplitExplainPlan = splitExplainPlan[1].split("]\\)");
+            assertEquals(plans[1], splitExplainPlan[0] + secondSplitExplainPlan[1]);
 
             // (orderby) groupby
             query = "SELECT t.a_string, count(*) FROM (SELECT * FROM "+tableName+" order by a_integer) AS t where a_byte != 8 group by t.a_string";

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/FlappingLocalIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/FlappingLocalIndexIT.java
@@ -50,16 +50,11 @@ import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
 import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.query.QueryServicesOptions;
-import org.apache.phoenix.util.QueryUtil;
 import org.apache.phoenix.util.SchemaUtil;
 import org.apache.phoenix.util.TestUtil;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class FlappingLocalIndexIT extends BaseLocalIndexIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FlappingLocalIndexIT.class);
 
     public FlappingLocalIndexIT(boolean isNamespaceMapped) {
         super(isNamespaceMapped);
@@ -164,13 +159,6 @@ public class FlappingLocalIndexIT extends BaseLocalIndexIT {
             
             String query = "SELECT * FROM " + tableName +" where v1 like 'a%'";
 
-            String explainPlanOutput =
-                    QueryUtil.getExplainPlan(conn1.createStatement().executeQuery("EXPLAIN " + query));
-            LOGGER.info("Explain plan output: {}", explainPlanOutput);
-            // MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN is set as 2
-            assertTrue("Expected total " + numRegions + " regions",
-                    explainPlanOutput.contains("...total size = " + numRegions));
-
             ExplainPlan plan = conn1.prepareStatement(query)
                 .unwrap(PhoenixPreparedStatement.class).optimizeQuery()
                 .getExplainPlan();
@@ -188,7 +176,6 @@ public class FlappingLocalIndexIT extends BaseLocalIndexIT {
                 explainPlanAttributes.getServerWhereFilter());
             assertEquals("CLIENT MERGE SORT",
                 explainPlanAttributes.getClientSortAlgo());
-            assertEquals(numRegions, explainPlanAttributes.getRegionLocations().size());
 
             rs = conn1.createStatement().executeQuery(query);
             assertTrue(rs.next());

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/FlappingLocalIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/FlappingLocalIndexIT.java
@@ -50,11 +50,16 @@ import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
 import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.query.QueryServicesOptions;
+import org.apache.phoenix.util.QueryUtil;
 import org.apache.phoenix.util.SchemaUtil;
 import org.apache.phoenix.util.TestUtil;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FlappingLocalIndexIT extends BaseLocalIndexIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlappingLocalIndexIT.class);
 
     public FlappingLocalIndexIT(boolean isNamespaceMapped) {
         super(isNamespaceMapped);
@@ -159,6 +164,13 @@ public class FlappingLocalIndexIT extends BaseLocalIndexIT {
             
             String query = "SELECT * FROM " + tableName +" where v1 like 'a%'";
 
+            String explainPlanOutput =
+                    QueryUtil.getExplainPlan(conn1.createStatement().executeQuery("EXPLAIN WITH REGIONS " + query));
+            LOGGER.info("Explain plan output: {}", explainPlanOutput);
+            // MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN is set as 2
+            assertTrue("Expected total " + numRegions + " regions",
+                    explainPlanOutput.contains("...total size = " + numRegions));
+
             ExplainPlan plan = conn1.prepareStatement(query)
                 .unwrap(PhoenixPreparedStatement.class).optimizeQuery()
                 .getExplainPlan();
@@ -176,6 +188,7 @@ public class FlappingLocalIndexIT extends BaseLocalIndexIT {
                 explainPlanAttributes.getServerWhereFilter());
             assertEquals("CLIENT MERGE SORT",
                 explainPlanAttributes.getClientSortAlgo());
+            assertEquals(numRegions, explainPlanAttributes.getRegionLocations().size());
 
             rs = conn1.createStatement().executeQuery(query);
             assertTrue(rs.next());

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/FlappingLocalIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/FlappingLocalIndexIT.java
@@ -50,11 +50,16 @@ import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
 import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.query.QueryServicesOptions;
+import org.apache.phoenix.util.QueryUtil;
 import org.apache.phoenix.util.SchemaUtil;
 import org.apache.phoenix.util.TestUtil;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FlappingLocalIndexIT extends BaseLocalIndexIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlappingLocalIndexIT.class);
 
     public FlappingLocalIndexIT(boolean isNamespaceMapped) {
         super(isNamespaceMapped);
@@ -159,6 +164,13 @@ public class FlappingLocalIndexIT extends BaseLocalIndexIT {
             
             String query = "SELECT * FROM " + tableName +" where v1 like 'a%'";
 
+            String explainPlanOutput =
+                    QueryUtil.getExplainPlan(conn1.createStatement().executeQuery("EXPLAIN " + query));
+            LOGGER.info("Explain plan output: {}", explainPlanOutput);
+            // MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN is set as 2
+            assertTrue("Expected total " + numRegions + " regions",
+                    explainPlanOutput.contains("...total size = " + numRegions));
+
             ExplainPlan plan = conn1.prepareStatement(query)
                 .unwrap(PhoenixPreparedStatement.class).optimizeQuery()
                 .getExplainPlan();
@@ -176,6 +188,7 @@ public class FlappingLocalIndexIT extends BaseLocalIndexIT {
                 explainPlanAttributes.getServerWhereFilter());
             assertEquals("CLIENT MERGE SORT",
                 explainPlanAttributes.getClientSortAlgo());
+            assertEquals(numRegions, explainPlanAttributes.getRegionLocations().size());
 
             rs = conn1.createStatement().executeQuery(query);
             assertTrue(rs.next());

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/QueryLoggerIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/QueryLoggerIT.java
@@ -120,7 +120,7 @@ public class QueryLoggerIT extends BaseTest {
 
         // sleep for sometime to let query log committed
         Thread.sleep(delay);
-        try (ResultSet explainRS = conn.createStatement().executeQuery("Explain " + query);
+        try (ResultSet explainRS = conn.createStatement().executeQuery("Explain with regions " + query);
              ResultSet rs = conn.createStatement().executeQuery(logQuery)) {
             boolean foundQueryLog = false;
 
@@ -300,7 +300,7 @@ public class QueryLoggerIT extends BaseTest {
 
             // sleep for sometime to let query log committed
             Thread.sleep(delay);
-            String explainQuery = "Explain " + "SELECT * FROM " + tableName + " where V = 'value5'";
+            String explainQuery = "EXPLAIN WITH REGIONS " + "SELECT * FROM " + tableName + " where V = 'value5'";
             try (ResultSet explainRS = conn.createStatement()
                     .executeQuery(explainQuery);
                  ResultSet rs = conn.createStatement().executeQuery(logQuery)) {

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/BaseLocalIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/BaseLocalIndexIT.java
@@ -61,6 +61,7 @@ public abstract class BaseLocalIndexIT extends BaseTest {
         // setting update frequency to a large value to test out that we are
         // generating stats for local indexes
         clientProps.put(QueryServices.MIN_STATS_UPDATE_FREQ_MS_ATTRIB, "120000");
+        clientProps.put(QueryServices.MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN, "2");
         setUpTestDriver(new ReadOnlyProps(serverProps.entrySet().iterator()), new ReadOnlyProps(clientProps.entrySet().iterator()));
     }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/BaseLocalIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/BaseLocalIndexIT.java
@@ -61,7 +61,6 @@ public abstract class BaseLocalIndexIT extends BaseTest {
         // setting update frequency to a large value to test out that we are
         // generating stats for local indexes
         clientProps.put(QueryServices.MIN_STATS_UPDATE_FREQ_MS_ATTRIB, "120000");
-        clientProps.put(QueryServices.MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN, "2");
         setUpTestDriver(new ReadOnlyProps(serverProps.entrySet().iterator()), new ReadOnlyProps(clientProps.entrySet().iterator()));
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlanAttributes.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlanAttributes.java
@@ -18,10 +18,8 @@
 
 package org.apache.phoenix.compile;
 
-import java.util.List;
 import java.util.Set;
 
-import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.client.Consistency;
 import org.apache.phoenix.parse.HintNode;
 import org.apache.phoenix.parse.HintNode.Hint;
@@ -75,7 +73,6 @@ public class ExplainPlanAttributes {
     // be null
     private final ExplainPlanAttributes rhsJoinQueryExplainPlan;
     private final Set<PColumn> serverMergeColumns;
-    private final List<HRegionLocation> regionLocations;
 
     private static final ExplainPlanAttributes EXPLAIN_PLAN_INSTANCE =
         new ExplainPlanAttributes();
@@ -115,7 +112,6 @@ public class ExplainPlanAttributes {
         this.clientSortAlgo = null;
         this.rhsJoinQueryExplainPlan = null;
         this.serverMergeColumns = null;
-        this.regionLocations = null;
     }
 
     public ExplainPlanAttributes(String abstractExplainPlan,
@@ -136,7 +132,7 @@ public class ExplainPlanAttributes {
             Integer clientSequenceCount, String clientCursorName,
             String clientSortAlgo,
             ExplainPlanAttributes rhsJoinQueryExplainPlan,
-            Set<PColumn> serverMergeColumns, List<HRegionLocation> regionLocations) {
+            Set<PColumn> serverMergeColumns) {
         this.abstractExplainPlan = abstractExplainPlan;
         this.splitsChunk = splitsChunk;
         this.estimatedRows = estimatedRows;
@@ -171,7 +167,6 @@ public class ExplainPlanAttributes {
         this.clientSortAlgo = clientSortAlgo;
         this.rhsJoinQueryExplainPlan = rhsJoinQueryExplainPlan;
         this.serverMergeColumns = serverMergeColumns;
-        this.regionLocations = regionLocations;
     }
 
     public String getAbstractExplainPlan() {
@@ -310,10 +305,6 @@ public class ExplainPlanAttributes {
         return serverMergeColumns;
     }
 
-    public List<HRegionLocation> getRegionLocations() {
-        return regionLocations;
-    }
-
     public static ExplainPlanAttributes getDefaultExplainPlan() {
         return EXPLAIN_PLAN_INSTANCE;
     }
@@ -353,7 +344,6 @@ public class ExplainPlanAttributes {
         private String clientSortAlgo;
         private ExplainPlanAttributes rhsJoinQueryExplainPlan;
         private Set<PColumn> serverMergeColumns;
-        private List<HRegionLocation> regionLocations;
 
         public ExplainPlanAttributesBuilder() {
             // default
@@ -406,7 +396,6 @@ public class ExplainPlanAttributes {
             this.rhsJoinQueryExplainPlan =
                 explainPlanAttributes.getRhsJoinQueryExplainPlan();
             this.serverMergeColumns = explainPlanAttributes.getServerMergeColumns();
-            this.regionLocations = explainPlanAttributes.getRegionLocations();
         }
 
         public ExplainPlanAttributesBuilder setAbstractExplainPlan(
@@ -610,11 +599,6 @@ public class ExplainPlanAttributes {
             return this;
         }
 
-        public ExplainPlanAttributesBuilder setRegionLocations(List<HRegionLocation> regionLocations) {
-            this.regionLocations = regionLocations;
-            return this;
-        }
-
         public ExplainPlanAttributes build() {
             return new ExplainPlanAttributes(abstractExplainPlan, splitsChunk,
                 estimatedRows, estimatedSizeInBytes, iteratorTypeAndScanSize,
@@ -627,8 +611,7 @@ public class ExplainPlanAttributes {
                 clientFilterBy, clientAggregate, clientSortedBy,
                 clientAfterAggregate, clientDistinctFilter, clientOffset,
                 clientRowLimit, clientSequenceCount, clientCursorName,
-                clientSortAlgo, rhsJoinQueryExplainPlan, serverMergeColumns,
-                regionLocations);
+                clientSortAlgo, rhsJoinQueryExplainPlan, serverMergeColumns);
         }
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlanAttributes.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlanAttributes.java
@@ -610,7 +610,8 @@ public class ExplainPlanAttributes {
             return this;
         }
 
-        public ExplainPlanAttributesBuilder setRegionLocations(List<HRegionLocation> regionLocations) {
+        public ExplainPlanAttributesBuilder setRegionLocations(
+                List<HRegionLocation> regionLocations) {
             this.regionLocations = regionLocations;
             return this;
         }

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlanAttributes.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/ExplainPlanAttributes.java
@@ -18,8 +18,10 @@
 
 package org.apache.phoenix.compile;
 
+import java.util.List;
 import java.util.Set;
 
+import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.client.Consistency;
 import org.apache.phoenix.parse.HintNode;
 import org.apache.phoenix.parse.HintNode.Hint;
@@ -73,6 +75,7 @@ public class ExplainPlanAttributes {
     // be null
     private final ExplainPlanAttributes rhsJoinQueryExplainPlan;
     private final Set<PColumn> serverMergeColumns;
+    private final List<HRegionLocation> regionLocations;
 
     private static final ExplainPlanAttributes EXPLAIN_PLAN_INSTANCE =
         new ExplainPlanAttributes();
@@ -112,6 +115,7 @@ public class ExplainPlanAttributes {
         this.clientSortAlgo = null;
         this.rhsJoinQueryExplainPlan = null;
         this.serverMergeColumns = null;
+        this.regionLocations = null;
     }
 
     public ExplainPlanAttributes(String abstractExplainPlan,
@@ -132,7 +136,7 @@ public class ExplainPlanAttributes {
             Integer clientSequenceCount, String clientCursorName,
             String clientSortAlgo,
             ExplainPlanAttributes rhsJoinQueryExplainPlan,
-            Set<PColumn> serverMergeColumns) {
+            Set<PColumn> serverMergeColumns, List<HRegionLocation> regionLocations) {
         this.abstractExplainPlan = abstractExplainPlan;
         this.splitsChunk = splitsChunk;
         this.estimatedRows = estimatedRows;
@@ -167,6 +171,7 @@ public class ExplainPlanAttributes {
         this.clientSortAlgo = clientSortAlgo;
         this.rhsJoinQueryExplainPlan = rhsJoinQueryExplainPlan;
         this.serverMergeColumns = serverMergeColumns;
+        this.regionLocations = regionLocations;
     }
 
     public String getAbstractExplainPlan() {
@@ -305,6 +310,10 @@ public class ExplainPlanAttributes {
         return serverMergeColumns;
     }
 
+    public List<HRegionLocation> getRegionLocations() {
+        return regionLocations;
+    }
+
     public static ExplainPlanAttributes getDefaultExplainPlan() {
         return EXPLAIN_PLAN_INSTANCE;
     }
@@ -344,6 +353,7 @@ public class ExplainPlanAttributes {
         private String clientSortAlgo;
         private ExplainPlanAttributes rhsJoinQueryExplainPlan;
         private Set<PColumn> serverMergeColumns;
+        private List<HRegionLocation> regionLocations;
 
         public ExplainPlanAttributesBuilder() {
             // default
@@ -396,6 +406,7 @@ public class ExplainPlanAttributes {
             this.rhsJoinQueryExplainPlan =
                 explainPlanAttributes.getRhsJoinQueryExplainPlan();
             this.serverMergeColumns = explainPlanAttributes.getServerMergeColumns();
+            this.regionLocations = explainPlanAttributes.getRegionLocations();
         }
 
         public ExplainPlanAttributesBuilder setAbstractExplainPlan(
@@ -599,6 +610,11 @@ public class ExplainPlanAttributes {
             return this;
         }
 
+        public ExplainPlanAttributesBuilder setRegionLocations(List<HRegionLocation> regionLocations) {
+            this.regionLocations = regionLocations;
+            return this;
+        }
+
         public ExplainPlanAttributes build() {
             return new ExplainPlanAttributes(abstractExplainPlan, splitsChunk,
                 estimatedRows, estimatedSizeInBytes, iteratorTypeAndScanSize,
@@ -611,7 +627,8 @@ public class ExplainPlanAttributes {
                 clientFilterBy, clientAggregate, clientSortedBy,
                 clientAfterAggregate, clientDistinctFilter, clientOffset,
                 clientRowLimit, clientSequenceCount, clientCursorName,
-                clientSortAlgo, rhsJoinQueryExplainPlan, serverMergeColumns);
+                clientSortAlgo, rhsJoinQueryExplainPlan, serverMergeColumns,
+                regionLocations);
         }
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
@@ -1724,7 +1724,7 @@ public abstract class BaseResultIterators extends ExplainTable implements Result
             }
         }
 
-        explain(buf.toString(), planSteps, explainPlanAttributesBuilder, scans);
+        explain(buf.toString(), planSteps, explainPlanAttributesBuilder);
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
@@ -1537,7 +1537,6 @@ public abstract class BaseResultIterators extends ExplainTable implements Result
 
     @Override
     public void close() throws SQLException {
-        this.closeExecutorService();
         // Don't call cancel on already started work, as it causes the HConnection
         // to get into a funk. Instead, just cancel queued work.
         boolean cancelledWork = false;

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
@@ -1724,7 +1724,7 @@ public abstract class BaseResultIterators extends ExplainTable implements Result
             }
         }
 
-        explain(buf.toString(), planSteps, explainPlanAttributesBuilder);
+        explain(buf.toString(), planSteps, explainPlanAttributesBuilder, scans);
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
@@ -1537,7 +1537,7 @@ public abstract class BaseResultIterators extends ExplainTable implements Result
 
     @Override
     public void close() throws SQLException {
-       
+        this.closeExecutorService();
         // Don't call cancel on already started work, as it causes the HConnection
         // to get into a funk. Instead, just cancel queued work.
         boolean cancelledWork = false;

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.text.Format;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -156,6 +157,8 @@ public abstract class ExplainTable {
         }
         byte[] currentKey = startKey;
         try (Table table = context.getConnection().getQueryServices().getTable(tableName)) {
+            // include all regions that include key range from the given start key
+            // and end key
             do {
                 HRegionLocation regionLocation =
                         table.getRegionLocator().getRegionLocation(currentKey, reload);
@@ -451,7 +454,9 @@ public abstract class ExplainTable {
 
         @Override
         public int hashCode() {
-            return 0;
+            int result = Arrays.hashCode(startKey);
+            result = 31 * result + Arrays.hashCode(endKey);
+            return result;
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
@@ -17,24 +17,15 @@
  */
 package org.apache.phoenix.iterate;
 
-import java.io.IOException;
 import java.text.Format;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.HRegionLocation;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.Connection;
-import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Consistency;
 import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 import org.apache.hadoop.hbase.filter.PageFilter;
@@ -55,8 +46,6 @@ import org.apache.phoenix.parse.HintNode;
 import org.apache.phoenix.parse.HintNode.Hint;
 import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.query.KeyRange.Bound;
-import org.apache.phoenix.query.QueryServices;
-import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.RowKeySchema;
 import org.apache.phoenix.schema.SortOrder;
@@ -122,59 +111,8 @@ public abstract class ExplainTable {
         return buf.toString();
     }
 
-    /**
-     * Get regions that represent the given range of start and end key for the given table, and all the regions
-     * to the regionLocations list.
-     *
-     * @param tableName the table name.
-     * @param startKey the start rowkey.
-     * @param endKey the end rowkey.
-     * @param includeEndKey true if end key needs to be included.
-     * @param reload true if reload from meta is necessary.
-     * @param regionBoundaries set of region boundaries to get the unique list of region locations.
-     * @param regionLocations the list of region locations as output.
-     * @throws IOException if something goes wrong while creating connection or querying region locations.
-     */
-    private void getRegionsInRange(final String tableName,
-                                   final byte[] startKey,
-                                   final byte[] endKey,
-                                   final boolean includeEndKey,
-                                   final boolean reload,
-                                   Set<RegionBoundary> regionBoundaries,
-                                   List<HRegionLocation> regionLocations)
-            throws IOException {
-        final boolean endKeyIsEndOfTable = Bytes.equals(endKey, HConstants.EMPTY_END_ROW);
-        if ((Bytes.compareTo(startKey, endKey) > 0) && !endKeyIsEndOfTable) {
-            throw new IllegalArgumentException(
-                    "Invalid range: " + Bytes.toStringBinary(startKey) + " > " + Bytes.toStringBinary(endKey));
-        }
-        byte[] currentKey = startKey;
-        try (Connection connection = ConnectionFactory.createConnection(
-                context.getConnection().getQueryServices().getConfiguration());
-             Table table = connection.getTable(TableName.valueOf(tableName))) {
-            do {
-                HRegionLocation regionLocation = table.getRegionLocator().getRegionLocation(currentKey, reload);
-                RegionBoundary regionBoundary = new RegionBoundary(regionLocation.getRegion().getStartKey(),
-                        regionLocation.getRegion().getEndKey());
-                if(!regionBoundaries.contains(regionBoundary)) {
-                    regionLocations.add(regionLocation);
-                    regionBoundaries.add(regionBoundary);
-                }
-                currentKey = regionLocation.getRegion().getEndKey();
-                // condition1 = currentKey != END_ROW_KEY
-                // condition2 = endKeyIsEndOfTable == true
-                // condition3 = currentKey < endKey
-                // condition4 = includeEndKey == true
-                // condition5 = currentKey == endKey
-                // while (condition1 && (condition2 || condition3 || (condition4 && condition5)))
-            } while (!Bytes.equals(currentKey, HConstants.EMPTY_END_ROW) &&
-                    (endKeyIsEndOfTable || Bytes.compareTo(currentKey, endKey) < 0 ||
-                            (includeEndKey && Bytes.compareTo(currentKey, endKey) == 0)));
-        }
-    }
-
     protected void explain(String prefix, List<String> planSteps,
-            ExplainPlanAttributesBuilder explainPlanAttributesBuilder, List<List<Scan>> scansList) {
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
         StringBuilder buf = new StringBuilder(prefix);
         ScanRanges scanRanges = context.getScanRanges();
         Scan scan = context.getScan();
@@ -337,89 +275,12 @@ public abstract class ExplainTable {
         if (groupByLimitBytes != null) {
             groupByLimit = (Integer) PInteger.INSTANCE.toObject(groupByLimitBytes);
         }
-        getRegionLocationsForExplainPlan(planSteps, explainPlanAttributesBuilder, scansList);
         groupBy.explain(planSteps, groupByLimit, explainPlanAttributesBuilder);
         if (scan.getAttribute(BaseScannerRegionObserver.SPECIFIC_ARRAY_INDEX) != null) {
             planSteps.add("    SERVER ARRAY ELEMENT PROJECTION");
             if (explainPlanAttributesBuilder != null) {
                 explainPlanAttributesBuilder.setServerArrayElementProjection(true);
             }
-        }
-    }
-
-    /**
-     * Retrieve region locations from hbase client and set the values for the explain plan output. If the list
-     * of region locations exceed max limit, print only list with the max limit and print num of total list size.
-     *
-     * @param planSteps list of plan steps to add explain plan output to.
-     * @param explainPlanAttributesBuilder explain plan v2 attributes builder instance.
-     * @param scansList list of the list of scans, to be used for parallel scans.
-     */
-    private void getRegionLocationsForExplainPlan(List<String> planSteps,
-                                                  ExplainPlanAttributesBuilder explainPlanAttributesBuilder,
-                                                  List<List<Scan>> scansList) {
-        StringBuilder buf;
-        try {
-            buf = new StringBuilder().append(" (region locations = ");
-            Set<RegionBoundary> regionBoundaries = new HashSet<>();
-            List<HRegionLocation> regionLocations = new ArrayList<>();
-            for (List<Scan> scans : scansList) {
-                for (Scan eachScan : scans) {
-                    getRegionsInRange(tableRef.getTable().getPhysicalName().getString(),
-                            eachScan.getStartRow(),
-                            eachScan.getStopRow(),
-                            true,
-                            false,
-                            regionBoundaries,
-                            regionLocations);
-                }
-            }
-            int maxLimitRegionLoc = context.getConnection().getQueryServices().getConfiguration()
-                    .getInt(QueryServices.MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN,
-                            QueryServicesOptions.DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN);
-            if (explainPlanAttributesBuilder != null) {
-                explainPlanAttributesBuilder.setRegionLocations(Collections.unmodifiableList(regionLocations));
-            }
-            if (regionLocations.size() > maxLimitRegionLoc) {
-                int originalSize = regionLocations.size();
-                List<HRegionLocation> trimmedRegionLocations = regionLocations.subList(0, maxLimitRegionLoc);
-                buf.append(trimmedRegionLocations);
-                buf.append("...total size = ");
-                buf.append(originalSize);
-            } else {
-                buf.append(regionLocations);
-            }
-            buf.append(") ");
-            planSteps.add(buf.toString());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    static class RegionBoundary {
-        private final byte[] startKey;
-        private final byte[] endKey;
-
-        public RegionBoundary(byte[] startKey, byte[] endKey) {
-            this.startKey = startKey;
-            this.endKey = endKey;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            RegionBoundary that = (RegionBoundary) o;
-            return Bytes.compareTo(startKey, that.startKey) == 0 && Bytes.compareTo(endKey, that.endKey) == 0;
-        }
-
-        @Override
-        public int hashCode() {
-            return 0;
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
@@ -127,8 +127,8 @@ public abstract class ExplainTable {
     }
 
     /**
-     * Get regions that represent the given range of start and end key for the given table, and all the regions
-     * to the regionLocations list.
+     * Get regions that represent the given range of start and end key for the given table, and
+     * all the regions to the regionLocations list.
      *
      * @param tableName the table name.
      * @param startKey the start rowkey.
@@ -137,7 +137,8 @@ public abstract class ExplainTable {
      * @param reload true if reload from meta is necessary.
      * @param regionBoundaries set of region boundaries to get the unique list of region locations.
      * @param regionLocations the list of region locations as output.
-     * @throws IOException if something goes wrong while creating connection or querying region locations.
+     * @throws IOException if something goes wrong while creating connection or querying region
+     * locations.
      */
     private void getRegionsInRange(final byte[] tableName,
                                    final byte[] startKey,
@@ -150,7 +151,8 @@ public abstract class ExplainTable {
         final boolean endKeyIsEndOfTable = Bytes.equals(endKey, HConstants.EMPTY_END_ROW);
         if ((Bytes.compareTo(startKey, endKey) > 0) && !endKeyIsEndOfTable) {
             throw new IllegalArgumentException(
-                    "Invalid range: " + Bytes.toStringBinary(startKey) + " > " + Bytes.toStringBinary(endKey));
+                    "Invalid range: " + Bytes.toStringBinary(startKey) + " > " +
+                            Bytes.toStringBinary(endKey));
         }
         byte[] currentKey = startKey;
         try (Table table = context.getConnection().getQueryServices().getTable(tableName)) {
@@ -160,7 +162,7 @@ public abstract class ExplainTable {
                 RegionBoundary regionBoundary =
                         new RegionBoundary(regionLocation.getRegion().getStartKey(),
                                 regionLocation.getRegion().getEndKey());
-                if(!regionBoundaries.contains(regionBoundary)) {
+                if (!regionBoundaries.contains(regionBoundary)) {
                     regionLocations.add(regionLocation);
                     regionBoundaries.add(regionBoundary);
                 }
@@ -171,9 +173,9 @@ public abstract class ExplainTable {
                 // condition4 = includeEndKey == true
                 // condition5 = currentKey == endKey
                 // while (condition1 && (condition2 || condition3 || (condition4 && condition5)))
-            } while (!Bytes.equals(currentKey, HConstants.EMPTY_END_ROW) &&
-                    (endKeyIsEndOfTable || Bytes.compareTo(currentKey, endKey) < 0 ||
-                            (includeEndKey && Bytes.compareTo(currentKey, endKey) == 0)));
+            } while (!Bytes.equals(currentKey, HConstants.EMPTY_END_ROW)
+                    && (endKeyIsEndOfTable || Bytes.compareTo(currentKey, endKey) < 0
+                    || (includeEndKey && Bytes.compareTo(currentKey, endKey) == 0)));
         }
     }
 
@@ -363,8 +365,11 @@ public abstract class ExplainTable {
     private void getRegionLocations(List<String> planSteps,
                                     ExplainPlanAttributesBuilder explainPlanAttributesBuilder,
                                     List<List<Scan>> scansList) {
-        planSteps.add(
-                getRegionLocationsForExplainPlan(explainPlanAttributesBuilder, scansList));
+        String regionLocationPlan = getRegionLocationsForExplainPlan(explainPlanAttributesBuilder,
+                scansList);
+        if (regionLocationPlan.length() > 0) {
+            planSteps.add(regionLocationPlan);
+        }
     }
 
     /**
@@ -413,17 +418,20 @@ public abstract class ExplainTable {
             }
             buf.append(") ");
             return buf.toString();
-        } catch (IOException | SQLException e) {
+        } catch (IOException | SQLException | UnsupportedOperationException e) {
             LOGGER.error("Explain table unable to add region locations.", e);
             return "";
         }
     }
 
+    /**
+     * Region boundary class with start and end key of the region.
+     */
     private static class RegionBoundary {
         private final byte[] startKey;
         private final byte[] endKey;
 
-        public RegionBoundary(byte[] startKey, byte[] endKey) {
+        RegionBoundary(byte[] startKey, byte[] endKey) {
             this.startKey = startKey;
             this.endKey = endKey;
         }
@@ -437,8 +445,8 @@ public abstract class ExplainTable {
                 return false;
             }
             RegionBoundary that = (RegionBoundary) o;
-            return Bytes.compareTo(startKey, that.startKey) == 0 &&
-                    Bytes.compareTo(endKey, that.endKey) == 0;
+            return Bytes.compareTo(startKey, that.startKey) == 0
+                    && Bytes.compareTo(endKey, that.endKey) == 0;
         }
 
         @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
@@ -436,7 +436,7 @@ public abstract class ExplainTable {
         }
     }
 
-    static class RegionBoundary {
+    private static class RegionBoundary {
         private final byte[] startKey;
         private final byte[] endKey;
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
@@ -17,15 +17,24 @@
  */
 package org.apache.phoenix.iterate;
 
+import java.io.IOException;
 import java.text.Format;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Consistency;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 import org.apache.hadoop.hbase.filter.PageFilter;
@@ -46,6 +55,8 @@ import org.apache.phoenix.parse.HintNode;
 import org.apache.phoenix.parse.HintNode.Hint;
 import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.query.KeyRange.Bound;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.RowKeySchema;
 import org.apache.phoenix.schema.SortOrder;
@@ -111,8 +122,59 @@ public abstract class ExplainTable {
         return buf.toString();
     }
 
+    /**
+     * Get regions that represent the given range of start and end key for the given table, and all the regions
+     * to the regionLocations list.
+     *
+     * @param tableName the table name.
+     * @param startKey the start rowkey.
+     * @param endKey the end rowkey.
+     * @param includeEndKey true if end key needs to be included.
+     * @param reload true if reload from meta is necessary.
+     * @param regionBoundaries set of region boundaries to get the unique list of region locations.
+     * @param regionLocations the list of region locations as output.
+     * @throws IOException if something goes wrong while creating connection or querying region locations.
+     */
+    private void getRegionsInRange(final String tableName,
+                                   final byte[] startKey,
+                                   final byte[] endKey,
+                                   final boolean includeEndKey,
+                                   final boolean reload,
+                                   Set<RegionBoundary> regionBoundaries,
+                                   List<HRegionLocation> regionLocations)
+            throws IOException {
+        final boolean endKeyIsEndOfTable = Bytes.equals(endKey, HConstants.EMPTY_END_ROW);
+        if ((Bytes.compareTo(startKey, endKey) > 0) && !endKeyIsEndOfTable) {
+            throw new IllegalArgumentException(
+                    "Invalid range: " + Bytes.toStringBinary(startKey) + " > " + Bytes.toStringBinary(endKey));
+        }
+        byte[] currentKey = startKey;
+        try (Connection connection = ConnectionFactory.createConnection(
+                context.getConnection().getQueryServices().getConfiguration());
+             Table table = connection.getTable(TableName.valueOf(tableName))) {
+            do {
+                HRegionLocation regionLocation = table.getRegionLocator().getRegionLocation(currentKey, reload);
+                RegionBoundary regionBoundary = new RegionBoundary(regionLocation.getRegion().getStartKey(),
+                        regionLocation.getRegion().getEndKey());
+                if(!regionBoundaries.contains(regionBoundary)) {
+                    regionLocations.add(regionLocation);
+                    regionBoundaries.add(regionBoundary);
+                }
+                currentKey = regionLocation.getRegion().getEndKey();
+                // condition1 = currentKey != END_ROW_KEY
+                // condition2 = endKeyIsEndOfTable == true
+                // condition3 = currentKey < endKey
+                // condition4 = includeEndKey == true
+                // condition5 = currentKey == endKey
+                // while (condition1 && (condition2 || condition3 || (condition4 && condition5)))
+            } while (!Bytes.equals(currentKey, HConstants.EMPTY_END_ROW) &&
+                    (endKeyIsEndOfTable || Bytes.compareTo(currentKey, endKey) < 0 ||
+                            (includeEndKey && Bytes.compareTo(currentKey, endKey) == 0)));
+        }
+    }
+
     protected void explain(String prefix, List<String> planSteps,
-            ExplainPlanAttributesBuilder explainPlanAttributesBuilder) {
+            ExplainPlanAttributesBuilder explainPlanAttributesBuilder, List<List<Scan>> scansList) {
         StringBuilder buf = new StringBuilder(prefix);
         ScanRanges scanRanges = context.getScanRanges();
         Scan scan = context.getScan();
@@ -275,12 +337,89 @@ public abstract class ExplainTable {
         if (groupByLimitBytes != null) {
             groupByLimit = (Integer) PInteger.INSTANCE.toObject(groupByLimitBytes);
         }
+        getRegionLocationsForExplainPlan(planSteps, explainPlanAttributesBuilder, scansList);
         groupBy.explain(planSteps, groupByLimit, explainPlanAttributesBuilder);
         if (scan.getAttribute(BaseScannerRegionObserver.SPECIFIC_ARRAY_INDEX) != null) {
             planSteps.add("    SERVER ARRAY ELEMENT PROJECTION");
             if (explainPlanAttributesBuilder != null) {
                 explainPlanAttributesBuilder.setServerArrayElementProjection(true);
             }
+        }
+    }
+
+    /**
+     * Retrieve region locations from hbase client and set the values for the explain plan output. If the list
+     * of region locations exceed max limit, print only list with the max limit and print num of total list size.
+     *
+     * @param planSteps list of plan steps to add explain plan output to.
+     * @param explainPlanAttributesBuilder explain plan v2 attributes builder instance.
+     * @param scansList list of the list of scans, to be used for parallel scans.
+     */
+    private void getRegionLocationsForExplainPlan(List<String> planSteps,
+                                                  ExplainPlanAttributesBuilder explainPlanAttributesBuilder,
+                                                  List<List<Scan>> scansList) {
+        StringBuilder buf;
+        try {
+            buf = new StringBuilder().append(" (region locations = ");
+            Set<RegionBoundary> regionBoundaries = new HashSet<>();
+            List<HRegionLocation> regionLocations = new ArrayList<>();
+            for (List<Scan> scans : scansList) {
+                for (Scan eachScan : scans) {
+                    getRegionsInRange(tableRef.getTable().getPhysicalName().getString(),
+                            eachScan.getStartRow(),
+                            eachScan.getStopRow(),
+                            true,
+                            false,
+                            regionBoundaries,
+                            regionLocations);
+                }
+            }
+            int maxLimitRegionLoc = context.getConnection().getQueryServices().getConfiguration()
+                    .getInt(QueryServices.MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN,
+                            QueryServicesOptions.DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN);
+            if (explainPlanAttributesBuilder != null) {
+                explainPlanAttributesBuilder.setRegionLocations(Collections.unmodifiableList(regionLocations));
+            }
+            if (regionLocations.size() > maxLimitRegionLoc) {
+                int originalSize = regionLocations.size();
+                List<HRegionLocation> trimmedRegionLocations = regionLocations.subList(0, maxLimitRegionLoc);
+                buf.append(trimmedRegionLocations);
+                buf.append("...total size = ");
+                buf.append(originalSize);
+            } else {
+                buf.append(regionLocations);
+            }
+            buf.append(") ");
+            planSteps.add(buf.toString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static class RegionBoundary {
+        private final byte[] startKey;
+        private final byte[] endKey;
+
+        public RegionBoundary(byte[] startKey, byte[] endKey) {
+            this.startKey = startKey;
+            this.endKey = endKey;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            RegionBoundary that = (RegionBoundary) o;
+            return Bytes.compareTo(startKey, that.startKey) == 0 && Bytes.compareTo(endKey, that.endKey) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -820,7 +820,10 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
             List<String> planSteps = plan.getExplainPlan().getPlanSteps();
             ExplainType explainType = getExplainType();
             if (explainType == ExplainType.DEFAULT) {
-                planSteps.removeIf(planStep -> planStep != null && planStep.contains(ExplainTable.REGION_LOCATIONS));
+                List<String> updatedExplainPlanSteps = new ArrayList<>(planSteps);
+                updatedExplainPlanSteps.removeIf(
+                        planStep -> planStep != null && planStep.contains(ExplainTable.REGION_LOCATIONS));
+                planSteps = Collections.unmodifiableList(updatedExplainPlanSteps);
             }
             List<Tuple> tuples = Lists.newArrayListWithExpectedSize(planSteps.size());
             Long estimatedBytesToScan = plan.getEstimatedBytesToScan();

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -791,7 +791,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
 
     private static class ExecutableExplainStatement extends ExplainStatement implements CompilableStatement {
 
-        public ExecutableExplainStatement(BindableStatement statement, ExplainType explainType) {
+        ExecutableExplainStatement(BindableStatement statement, ExplainType explainType) {
             super(statement, explainType);
         }
 
@@ -821,8 +821,8 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
             ExplainType explainType = getExplainType();
             if (explainType == ExplainType.DEFAULT) {
                 List<String> updatedExplainPlanSteps = new ArrayList<>(planSteps);
-                updatedExplainPlanSteps.removeIf(
-                        planStep -> planStep != null && planStep.contains(ExplainTable.REGION_LOCATIONS));
+                updatedExplainPlanSteps.removeIf(planStep -> planStep != null
+                        && planStep.contains(ExplainTable.REGION_LOCATIONS));
                 planSteps = Collections.unmodifiableList(updatedExplainPlanSteps);
             }
             List<Tuple> tuples = Lists.newArrayListWithExpectedSize(planSteps.size());

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ExplainType.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ExplainType.java
@@ -1,11 +1,10 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -18,6 +17,9 @@
 
 package org.apache.phoenix.parse;
 
+/**
+ * Explain type attributes used to differentiate output of the explain plan.
+ */
 public enum ExplainType {
     WITH_REGIONS,
     DEFAULT

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ExplainType.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ExplainType.java
@@ -15,34 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.phoenix.parse;
 
-import org.apache.phoenix.jdbc.PhoenixStatement.Operation;
-
-public class ExplainStatement implements BindableStatement {
-    private final BindableStatement statement;
-    private final ExplainType explainType;
-
-    public ExplainStatement(BindableStatement statement, ExplainType explainType) {
-        this.statement = statement;
-        this.explainType = explainType;
-    }
-
-    public BindableStatement getStatement() {
-        return statement;
-    }
-
-    @Override
-    public int getBindCount() {
-        return statement.getBindCount();
-    }
-
-    @Override
-    public Operation getOperation() {
-        return Operation.QUERY;
-    }
-
-    public ExplainType getExplainType() {
-        return explainType;
-    }
+public enum ExplainType {
+    WITH_REGIONS,
+    DEFAULT
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
@@ -216,8 +216,8 @@ public class ParseNodeFactory {
         return "$" + tempAliasCounter.incrementAndGet();
     }
 
-    public ExplainStatement explain(BindableStatement statement) {
-        return new ExplainStatement(statement);
+    public ExplainStatement explain(BindableStatement statement, ExplainType explainType) {
+        return new ExplainStatement(statement, explainType);
     }
 
     public AliasedNode aliasedNode(String alias, ParseNode expression) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -405,9 +405,11 @@ public interface QueryServices extends SQLCloseable {
     String SKIP_SYSTEM_TABLES_EXISTENCE_CHECK = "phoenix.skip.system.tables.existence.check";
 
     /**
-     * Config key to represent max region locations to be displayed as part of the Explain plan output.
+     * Config key to represent max region locations to be displayed as part of the Explain plan
+     * output.
      */
-    String MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN = "phoenix.max.region.locations.size.explain.plan";
+    String MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN =
+            "phoenix.max.region.locations.size.explain.plan";
 
     /**
      * Get executor service used for parallel scans

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -403,6 +403,12 @@ public interface QueryServices extends SQLCloseable {
      * Region server holding the SYSTEM.CATALOG table in batch oriented jobs.
      */
     String SKIP_SYSTEM_TABLES_EXISTENCE_CHECK = "phoenix.skip.system.tables.existence.check";
+
+    /**
+     * Config key to represent max region locations to be displayed as part of the Explain plan output.
+     */
+    String MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN = "phoenix.max.region.locations.size.explain.plan";
+
     /**
      * Get executor service used for parallel scans
      */

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -403,12 +403,6 @@ public interface QueryServices extends SQLCloseable {
      * Region server holding the SYSTEM.CATALOG table in batch oriented jobs.
      */
     String SKIP_SYSTEM_TABLES_EXISTENCE_CHECK = "phoenix.skip.system.tables.existence.check";
-
-    /**
-     * Config key to represent max region locations to be displayed as part of the Explain plan output.
-     */
-    String MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN = "phoenix.max.region.locations.size.explain.plan";
-
     /**
      * Get executor service used for parallel scans
      */

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -57,6 +57,7 @@ import static org.apache.phoenix.query.QueryServices.MASTER_INFO_PORT_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_CLIENT_METADATA_CACHE_SIZE_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_MEMORY_PERC_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_MUTATION_SIZE_ATTRIB;
+import static org.apache.phoenix.query.QueryServices.MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN;
 import static org.apache.phoenix.query.QueryServices.MAX_SERVER_CACHE_SIZE_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_SERVER_CACHE_TIME_TO_LIVE_MS_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_SERVER_METADATA_CACHE_SIZE_ATTRIB;
@@ -399,6 +400,7 @@ public class QueryServicesOptions {
     public static final int DEFAULT_SCAN_PAGE_SIZE = 32768;
     public static final boolean DEFAULT_APPLY_TIME_ZONE_DISPLACMENT = false;
     public static final boolean DEFAULT_PHOENIX_TABLE_TTL_ENABLED = true;
+    public static final int DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN = 10;
 
 
     private final Configuration config;
@@ -489,7 +491,8 @@ public class QueryServicesOptions {
             .setIfUnset(INDEX_CREATE_DEFAULT_STATE, DEFAULT_CREATE_INDEX_STATE)
             .setIfUnset(SKIP_SYSTEM_TABLES_EXISTENCE_CHECK,
                 DEFAULT_SKIP_SYSTEM_TABLES_EXISTENCE_CHECK)
-            .setIfUnset(MAX_IN_LIST_SKIP_SCAN_SIZE, DEFAULT_MAX_IN_LIST_SKIP_SCAN_SIZE);
+            .setIfUnset(MAX_IN_LIST_SKIP_SCAN_SIZE, DEFAULT_MAX_IN_LIST_SKIP_SCAN_SIZE)
+            .setIfUnset(MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN, DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN);
 
         // HBase sets this to 1, so we reset it to something more appropriate.
         // Hopefully HBase will change this, because we can't know if a user set

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -57,7 +57,6 @@ import static org.apache.phoenix.query.QueryServices.MASTER_INFO_PORT_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_CLIENT_METADATA_CACHE_SIZE_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_MEMORY_PERC_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_MUTATION_SIZE_ATTRIB;
-import static org.apache.phoenix.query.QueryServices.MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN;
 import static org.apache.phoenix.query.QueryServices.MAX_SERVER_CACHE_SIZE_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_SERVER_CACHE_TIME_TO_LIVE_MS_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.MAX_SERVER_METADATA_CACHE_SIZE_ATTRIB;
@@ -400,7 +399,6 @@ public class QueryServicesOptions {
     public static final int DEFAULT_SCAN_PAGE_SIZE = 32768;
     public static final boolean DEFAULT_APPLY_TIME_ZONE_DISPLACMENT = false;
     public static final boolean DEFAULT_PHOENIX_TABLE_TTL_ENABLED = true;
-    public static final int DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN = 10;
 
 
     private final Configuration config;
@@ -491,8 +489,7 @@ public class QueryServicesOptions {
             .setIfUnset(INDEX_CREATE_DEFAULT_STATE, DEFAULT_CREATE_INDEX_STATE)
             .setIfUnset(SKIP_SYSTEM_TABLES_EXISTENCE_CHECK,
                 DEFAULT_SKIP_SYSTEM_TABLES_EXISTENCE_CHECK)
-            .setIfUnset(MAX_IN_LIST_SKIP_SCAN_SIZE, DEFAULT_MAX_IN_LIST_SKIP_SCAN_SIZE)
-            .setIfUnset(MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN, DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN);
+            .setIfUnset(MAX_IN_LIST_SKIP_SCAN_SIZE, DEFAULT_MAX_IN_LIST_SKIP_SCAN_SIZE);
 
         // HBase sets this to 1, so we reset it to something more appropriate.
         // Hopefully HBase will change this, because we can't know if a user set

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -492,7 +492,8 @@ public class QueryServicesOptions {
             .setIfUnset(SKIP_SYSTEM_TABLES_EXISTENCE_CHECK,
                 DEFAULT_SKIP_SYSTEM_TABLES_EXISTENCE_CHECK)
             .setIfUnset(MAX_IN_LIST_SKIP_SCAN_SIZE, DEFAULT_MAX_IN_LIST_SKIP_SCAN_SIZE)
-            .setIfUnset(MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN, DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN);
+            .setIfUnset(MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN,
+                    DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN);
 
         // HBase sets this to 1, so we reset it to something more appropriate.
         // Hopefully HBase will change this, because we can't know if a user set

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -400,7 +400,7 @@ public class QueryServicesOptions {
     public static final int DEFAULT_SCAN_PAGE_SIZE = 32768;
     public static final boolean DEFAULT_APPLY_TIME_ZONE_DISPLACMENT = false;
     public static final boolean DEFAULT_PHOENIX_TABLE_TTL_ENABLED = true;
-    public static final int DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN = 10;
+    public static final int DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN = 5;
 
 
     private final Configuration config;


### PR DESCRIPTION
Query syntax: `EXPLAIN WITH REGIONS {query}`

Example:

Assuming the scan is prepared for 4 region locations,

When `phoenix.max.region.locations.size.explain.plan` is set as `2`, only 2 region locations are printed:
```
CLIENT PARALLEL 4-WAY RANGE SCAN OVER N000001:N000002 [1,'a'] - [1,'b']
    SERVER MERGE [0.K3]
    SERVER FILTER BY FIRST KEY ONLY
 (region locations = [region=N000001:N000002,,1683068961616.4773aca00009beabd2316e0be5828ffa., hostname=localhost,55546,1683068927671, seqNum=9, region=N000001:N000002,e\x00\x00\x00\x00\x00\x00\x00\x00\x00,1683068961616.77243f1c70242067f53018949e146393., hostname=localhost,55546,1683068927671, seqNum=9]...total size = 4) 
CLIENT MERGE SORT
```

With default value of `phoenix.max.region.locations.size.explain.plan` as `5`, all region locations are printed:
```
CLIENT PARALLEL 4-WAY RANGE SCAN OVER N000001:N000002 [1,'a'] - [1,'b']
    SERVER MERGE [0.K3]
    SERVER FILTER BY FIRST KEY ONLY
 (region locations = [region=N000001:N000002,,1683068843354.6f20f10367637072dabf805a38ac8d55., hostname=localhost,55344,1683068805683, seqNum=9, region=N000001:N000002,e\x00\x00\x00\x00\x00\x00\x00\x00\x00,1683068843354.fdfd4eb63d0fff6d80da1d08726bfeb0., hostname=localhost,55344,1683068805683, seqNum=9, region=N000001:N000002,i\x00\x00\x00\x00\x00\x00\x00\x00\x00,1683068843354.effe18db5f4a093d005706910436ed18., hostname=localhost,55344,1683068805683, seqNum=9, region=N000001:N000002,o\x00\x00\x00\x00\x00\x00\x00\x00\x00,1683068843354.d7d0cec570fe9c626d39a0b2075918d2., hostname=localhost,55344,1683068805683, seqNum=9]) 
CLIENT MERGE SORT
```