### PR TITLE
PHOENIX-6952 Do not disable normalizer on salted tables

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/AlterTableIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/AlterTableIT.java
@@ -55,7 +55,6 @@ import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
-import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.coprocessor.MetaDataEndpointImpl;
 import org.apache.phoenix.exception.SQLExceptionCode;
@@ -1687,102 +1686,6 @@ public class AlterTableIT extends ParallelStatsDisabledIT {
                 assertEquals(schemaName2, e.getSchemaName());
             }
 
-        }
-    }
-
-    @Test
-    public void testNormalizerCannotBeEnabledForSalted() throws Exception {
-        String tableName = generateUniqueName();
-        String indexName = generateUniqueName();
-
-        String mtTableName = generateUniqueName();
-        String mtViewName = generateUniqueName();
-        String mtIndexName = generateUniqueName();
-
-        String ddl =
-                "create table  " + tableName + " ( id integer PRIMARY KEY," + " col1 integer,"
-                        + " col2 bigint" + " ) SALT_BUCKETS=4";
-        String indexDdl =
-                "create index IF NOT EXISTS " + indexName + " on " + tableName + " (col2)";
-        String mtDdl =
-                "CREATE TABLE " + mtTableName + " (TenantId UNSIGNED_INT NOT NULL ,"
-                        + " Id UNSIGNED_INT NOT NULL ," + " val VARCHAR, "
-                        + " CONSTRAINT pk PRIMARY KEY(TenantId, Id) "
-                        + " ) MULTI_TENANT=true, SALT_BUCKETS=4";
-        String mtViewDdl =
-                "CREATE VIEW " + mtViewName + "(view_column CHAR(15)) AS " + " SELECT * FROM "
-                        + mtTableName + " WHERE val='L' ";
-        String mtIndexDdl = "CREATE INDEX " + mtIndexName + " on " + mtViewName + " (view_column) ";
-
-        String conflictDdl =
-                "ALTER TABLE " + tableName + " SET " + TableDescriptorBuilder.NORMALIZATION_ENABLED
-                        + "=true";
-
-        String conflictIndexDdl =
-                "ALTER TABLE " + indexName + " SET " + TableDescriptorBuilder.NORMALIZATION_ENABLED
-                        + "=true";
-
-        String conflictMtDdl =
-                "ALTER TABLE " + mtTableName + " SET "
-                        + TableDescriptorBuilder.NORMALIZATION_ENABLED + "=true";
-
-        String conflictMtViewDdl =
-                "ALTER TABLE " + indexName + " SET " + TableDescriptorBuilder.NORMALIZATION_ENABLED
-                        + "=true";
-
-        String conflictMtIndexDdl =
-                "ALTER TABLE " + mtIndexName + " SET "
-                        + TableDescriptorBuilder.NORMALIZATION_ENABLED + "=true";
-
-        String okDdl =
-                "ALTER TABLE " + tableName + " SET " + TableDescriptorBuilder.NORMALIZATION_ENABLED
-                        + "=false";
-
-        Properties props = new Properties();
-        try (Connection conn = DriverManager.getConnection(getUrl(), props);
-                Statement stmt = conn.createStatement()) {
-            stmt.execute(ddl);
-            stmt.execute(indexDdl);
-            stmt.execute(mtDdl);
-            stmt.execute(mtViewDdl);
-            stmt.execute(mtIndexDdl);
-
-            try {
-                stmt.execute(conflictDdl);
-                fail("Should have thrown an exception");
-            } catch (SQLException e) {
-                assertEquals(1147, e.getErrorCode());
-            }
-
-            try {
-                stmt.execute(conflictIndexDdl);
-                fail("Should have thrown an exception");
-            } catch (SQLException e) {
-                assertEquals(1147, e.getErrorCode());
-            }
-
-            try {
-                stmt.execute(conflictMtDdl);
-                fail("Should have thrown an exception");
-            } catch (SQLException e) {
-                assertEquals(1147, e.getErrorCode());
-            }
-
-            try {
-                stmt.execute(conflictMtViewDdl);
-                fail("Should have thrown an exception");
-            } catch (SQLException e) {
-                assertEquals(1147, e.getErrorCode());
-            }
-
-            try {
-                stmt.execute(conflictMtIndexDdl);
-                fail("Should have thrown an exception");
-            } catch (SQLException e) {
-                assertEquals(1147, e.getErrorCode());
-            }
-
-            stmt.execute(okDdl);
         }
     }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CreateTableIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CreateTableIT.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
-import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.ipc.PhoenixRpcSchedulerFactory;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.phoenix.exception.SQLExceptionCode;
@@ -1244,63 +1243,6 @@ public class CreateTableIT extends ParallelStatsDisabledIT {
         try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
             conn.createStatement().execute(ddl);
             verifyLastDDLTimestamp(dataTableFullName, startTS, conn);
-        }
-    }
-
-    @Test
-    public void testNormalizerIsDisbledForSalted() throws Exception {
-        String tableName = generateUniqueName();
-        String indexName = generateUniqueName();
-
-        String mtTableName = generateUniqueName();
-        String mtViewName = generateUniqueName();
-        String mtIndexName = generateUniqueName();
-
-        String conflictTableName = generateUniqueName();
-
-        String ddl =
-                "create table  " + tableName + " ( id integer PRIMARY KEY," + " col1 integer,"
-                        + " col2 bigint" + " ) SALT_BUCKETS=4";
-        String indexDdl =
-                "create index IF NOT EXISTS " + indexName + " on " + tableName + " (col2)";
-        String mtDdl =
-                "CREATE TABLE " + mtTableName + " (TenantId UNSIGNED_INT NOT NULL ,"
-                        + " Id UNSIGNED_INT NOT NULL ," + " val VARCHAR, "
-                        + " CONSTRAINT pk PRIMARY KEY(TenantId, Id) "
-                        + " ) MULTI_TENANT=true, SALT_BUCKETS=4";
-        String mtViewDdl =
-                "CREATE VIEW " + mtViewName + "(view_column CHAR(15)) AS " + " SELECT * FROM "
-                        + mtTableName + " WHERE val='L' ";
-        String mtIndexDdl = "CREATE INDEX " + mtIndexName + " on " + mtViewName + " (view_column) ";
-
-        String confictDdl =
-                "create table  " + conflictTableName + " ( id integer PRIMARY KEY,"
-                        + " col1 integer," + " col2 bigint" + " ) SALT_BUCKETS=4, "
-                        + TableDescriptorBuilder.NORMALIZATION_ENABLED + "=true";
-
-        Properties props = new Properties();
-        Connection conn = DriverManager.getConnection(getUrl(), props);
-        conn.createStatement().execute(ddl);
-        conn.createStatement().execute(indexDdl);
-        conn.createStatement().execute(mtDdl);
-        conn.createStatement().execute(mtViewDdl);
-        conn.createStatement().execute(mtIndexDdl);
-
-        Admin admin = driver.getConnectionQueryServices(getUrl(), props).getAdmin();
-        assertEquals("false", admin.getDescriptor(TableName.valueOf(tableName))
-                .getValue(TableDescriptorBuilder.NORMALIZATION_ENABLED));
-        assertEquals("false", admin.getDescriptor(TableName.valueOf(indexName))
-                .getValue(TableDescriptorBuilder.NORMALIZATION_ENABLED));
-        assertEquals("false", admin.getDescriptor(TableName.valueOf(mtTableName))
-                .getValue(TableDescriptorBuilder.NORMALIZATION_ENABLED));
-        assertEquals("false", admin.getDescriptor(TableName.valueOf("_IDX_" + mtTableName))
-                .getValue(TableDescriptorBuilder.NORMALIZATION_ENABLED));
-
-        try {
-            conn.createStatement().execute(confictDdl);
-            fail("Should have thrown an exception");
-        } catch (Exception e) {
-            assertTrue(e instanceof SQLException);
         }
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -1557,16 +1557,6 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                         PBoolean.INSTANCE.toObject(newDesc.build().getValue(MetaDataUtil.IS_LOCAL_INDEX_TABLE_PROP_BYTES)))) {
                     newDesc.setRegionSplitPolicyClassName(IndexRegionSplitPolicy.class.getName());
                 }
-                if (props.get(PhoenixDatabaseMetaData.SALT_BUCKETS) != null
-                        && (Integer) (props.get(PhoenixDatabaseMetaData.SALT_BUCKETS)) > 0) {
-                    if (props.get(TableDescriptorBuilder.NORMALIZATION_ENABLED) != null
-                            && (Boolean)(props.get(TableDescriptorBuilder.NORMALIZATION_ENABLED))) {
-                        throw new SQLExceptionInfo.Builder(SQLExceptionCode.NO_NORMALIZER_ON_SALTED_TABLE)
-                        .setSchemaName(SchemaUtil.getSchemaNameFromFullName(physicalTableName))
-                        .setTableName(SchemaUtil.getTableNameFromFullName(physicalTableName)).build().buildException();
-                    }
-                    newDesc.setNormalizationEnabled(false);
-                }
                 try {
                     if (splits == null) {
                         admin.createTable(newDesc.build());
@@ -2605,8 +2595,8 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
             // Special case for call during drop table to ensure that the empty column family exists.
             // In this, case we only include the table header row, as until we add schemaBytes and tableBytes
             // as args to this function, we have no way of getting them in this case.
-            // Also used to update table descriptor property values on ALTER TABLE t SET prop=xxx
             // TODO: change to  if (tableMetaData.isEmpty()) once we pass through schemaBytes and tableBytes
+            // Also, could be used to update table descriptor property values on ALTER TABLE t SET prop=xxx
             if ((tableMetaData.isEmpty()) || (tableMetaData.size() == 1 && tableMetaData.get(0).isEmpty())) {
                 if (modifyHTable) {
                     sendHBaseMetaData(tableDescriptors, pollingNeeded);
@@ -2876,16 +2866,6 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                         if (!family.equals(QueryConstants.ALL_FAMILY_PROPERTIES_KEY)) {
                             throw new SQLExceptionInfo.Builder(SQLExceptionCode.COLUMN_FAMILY_NOT_ALLOWED_TABLE_PROPERTY)
                             .setMessage("Column Family: " + family + ", Property: " + propName)
-                            .setSchemaName(table.getSchemaName().getString())
-                            .setTableName(table.getTableName().getString())
-                            .build()
-                            .buildException();
-                        }
-                        if (propName.equals(TableDescriptorBuilder.NORMALIZATION_ENABLED)
-                                && (Boolean)propValue == true
-                                && table.getPropertyValues().containsKey(PhoenixDatabaseMetaData.SALT_BUCKETS)
-                                && Integer.parseInt(table.getPropertyValues().get(PhoenixDatabaseMetaData.SALT_BUCKETS)) > 0) {
-                            throw new SQLExceptionInfo.Builder(SQLExceptionCode.NO_NORMALIZER_ON_SALTED_TABLE)
                             .setSchemaName(table.getSchemaName().getString())
                             .setTableName(table.getTableName().getString())
                             .build()

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -1662,12 +1662,6 @@ public class MetaDataClient {
             if (dataTable.getDefaultFamilyName() != null && dataTable.getType() != PTableType.VIEW && !allocateIndexId) {
                 statement.getProps().put("", new Pair<String,Object>(DEFAULT_COLUMN_FAMILY_NAME,dataTable.getDefaultFamilyName().getString()));
             }
-            // While SALT_BUCKETS would get copied in SYSCAT automatically, we need to add this
-            // explicitly so that the normalizer disabler logic can trigger later
-            if (dataTable.getBucketNum() != null && dataTable.getBucketNum() > 0
-                    && TableProperty.SALT_BUCKETS.getValue(tableProps) == null) {
-                tableProps.put(SALT_BUCKETS, dataTable.getBucketNum());
-            }
             PrimaryKeyConstraint pk = FACTORY.primaryKey(null, allPkColumns);
 
             tableProps.put(MetaDataUtil.DATA_TABLE_NAME_PROP_NAME, dataTable.getPhysicalName().getString());


### PR DESCRIPTION
Revert "PHOENIX-6616 Alter table command can be used to set normalization_enabled=true on salted tables" Revert "PHOENIX-6586 Set NORMALIZATION_ENABLED to false on salted tables"