### PR TITLE
PHOENIX-7005 Spark connector tests cannot compile with latest Phoenix

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/BaseAggregateIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/BaseAggregateIT.java
@@ -17,8 +17,6 @@
  */
 package org.apache.phoenix.end2end;
 
-import static org.apache.phoenix.end2end.ParallelStatsDisabledIT.executeQuery;
-import static org.apache.phoenix.end2end.ParallelStatsDisabledIT.executeQueryThrowsException;
 import static org.apache.phoenix.end2end.ParallelStatsDisabledIT.validateQueryPlan;
 import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
 import static org.junit.Assert.assertEquals;

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ParallelStatsDisabledIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ParallelStatsDisabledIT.java
@@ -67,7 +67,7 @@ public abstract class ParallelStatsDisabledIT extends BaseTest {
         BaseTest.freeResourcesIfBeyondThreshold();
     }
 
-    public static ResultSet executeQueryThrowsException(Connection conn, QueryBuilder queryBuilder,
+    protected ResultSet executeQueryThrowsException(Connection conn, QueryBuilder queryBuilder,
             String expectedPhoenixExceptionMsg, String expectedSparkExceptionMsg) {
         ResultSet rs = null;
         try {

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
@@ -749,7 +749,7 @@ public abstract class BaseTest {
         createTestTable(url, ddl, splits, ts);
     }
 
-    public static ResultSet executeQuery(Connection conn, QueryBuilder queryBuilder) throws SQLException {
+    protected ResultSet executeQuery(Connection conn, QueryBuilder queryBuilder) throws SQLException {
         PreparedStatement statement = conn.prepareStatement(queryBuilder.build());
         ResultSet rs = statement.executeQuery();
         return rs;


### PR DESCRIPTION
Revert the changes that break the child classes in the Phoenix-Spark test suite