### PR TITLE
PHOENIX-6973 Add option to CREATE TABLE to skip verification of HBase table

### DIFF
--- a/phoenix-core/src/main/antlr3/PhoenixSQL.g
+++ b/phoenix-core/src/main/antlr3/PhoenixSQL.g
@@ -153,6 +153,7 @@ tokens
     SHOW = 'show';
     UNCOVERED = 'uncovered';
     REGIONS = 'regions';
+    NOVERIFY = 'noverify';
 }
 
 
@@ -286,7 +287,7 @@ package org.apache.phoenix.parse;
     public void resetBindCount() {
         anonBindNum = 0;
     }
-    
+
     public String nextBind() {
         return Integer.toString(++anonBindNum);
     }
@@ -468,10 +469,11 @@ explain_node returns [BindableStatement ret]
 create_table_node returns [CreateTableStatement ret]
     :   CREATE (im=IMMUTABLE)? TABLE (IF NOT ex=EXISTS)? t=from_table_name 
         (LPAREN c=column_defs (pk=pk_constraint)? RPAREN)
+        (noverify=NOVERIFY)?
         (p=fam_properties)?
         (SPLIT ON s=value_expression_list)?
         (COLUMN_QUALIFIER_COUNTER LPAREN cqc=initializiation_list RPAREN)?
-        {ret = factory.createTable(t, p, c, pk, s, PTableType.TABLE, ex!=null, null, null, getBindCount(), im!=null ? true : null,  cqc); }
+        {ret = factory.createTable(t, p, c, pk, s, PTableType.TABLE, ex!=null, null, null, getBindCount(), im!=null ? true : null, cqc, noverify!=null); }
     ;
    
 // Parse a create schema statement.

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -272,7 +272,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         public String toString() {
             return toString;
         }
-    };
+    }
 
     protected final PhoenixConnection connection;
     private static final int NO_UPDATE = -1;
@@ -1044,8 +1044,10 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         ExecutableCreateTableStatement(TableName tableName, ListMultimap<String,Pair<String,Object>> props, List<ColumnDef> columnDefs,
                                        PrimaryKeyConstraint pkConstraint, List<ParseNode> splitNodes, PTableType tableType, boolean ifNotExists,
                                        TableName baseTableName, ParseNode tableTypeIdNode, int bindCount, Boolean immutableRows,
-                                       Map<String, Integer> familyCounters) {
-            super(tableName, props, columnDefs, pkConstraint, splitNodes, tableType, ifNotExists, baseTableName, tableTypeIdNode, bindCount, immutableRows, familyCounters);
+                                       Map<String, Integer> familyCounters, boolean noVerify) {
+            super(tableName, props, columnDefs, pkConstraint, splitNodes, tableType, ifNotExists,
+                    baseTableName, tableTypeIdNode, bindCount, immutableRows, familyCounters,
+                    noVerify);
         }
 
         @SuppressWarnings("unchecked")
@@ -1817,14 +1819,36 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         }
 
         @Override
-        public CreateTableStatement createTable(TableName tableName, ListMultimap<String,Pair<String,Object>> props, List<ColumnDef> columns, PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType, boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode, int bindCount, Boolean immutableRows, Map<String, Integer> cqCounters) {
-            return new ExecutableCreateTableStatement(tableName, props, columns, pkConstraint, splits, tableType, ifNotExists, baseTableName, tableTypeIdNode, bindCount, immutableRows, cqCounters);
+        public CreateTableStatement createTable(TableName tableName,
+                ListMultimap<String, Pair<String, Object>> props, List<ColumnDef> columns,
+                PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType,
+                boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode,
+                int bindCount, Boolean immutableRows, Map<String, Integer> cqCounters,
+                boolean noVerify) {
+            return new ExecutableCreateTableStatement(tableName, props, columns, pkConstraint,
+                    splits, tableType, ifNotExists, baseTableName, tableTypeIdNode, bindCount,
+                    immutableRows, cqCounters, noVerify);
         }
 
         @Override
-        public CreateTableStatement createTable(TableName tableName, ListMultimap<String,Pair<String,Object>> props, List<ColumnDef> columns, PrimaryKeyConstraint pkConstraint,
-                List<ParseNode> splits, PTableType tableType, boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode, int bindCount, Boolean immutableRows) {
-            return new ExecutableCreateTableStatement(tableName, props, columns, pkConstraint, splits, tableType, ifNotExists, baseTableName, tableTypeIdNode, bindCount, immutableRows, null);
+        public CreateTableStatement createTable(TableName tableName,
+                ListMultimap<String, Pair<String, Object>> props, List<ColumnDef> columns,
+                PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType,
+                boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode,
+                int bindCount, Boolean immutableRows, Map<String, Integer> cqCounters) {
+            return createTable(tableName, props, columns, pkConstraint, splits, tableType,
+                    ifNotExists, baseTableName, tableTypeIdNode, bindCount, immutableRows,
+                    cqCounters, false);
+        }
+
+        @Override
+        public CreateTableStatement createTable(TableName tableName,
+                ListMultimap<String, Pair<String, Object>> props, List<ColumnDef> columns,
+                PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType,
+                boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode,
+                int bindCount, Boolean immutableRows) {
+            return createTable(tableName, props, columns, pkConstraint, splits, tableType,
+                    ifNotExists, baseTableName, tableTypeIdNode, bindCount, immutableRows, null);
         }
 
         @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/CreateTableStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/CreateTableStatement.java
@@ -43,6 +43,7 @@ public class CreateTableStatement extends MutableStatement {
     // TODO change this to boolean at the next major release and remove TableProperty.IMMUTABLE_ROWS and QueryServiceOptions.IMMUTABLE_ROWS_ATTRIB
     private final Boolean immutableRows;
     private final Map<String, Integer> familyCQCounters;
+    private final boolean noVerify;
     
     public CreateTableStatement(CreateTableStatement createTable, List<ColumnDef> columns) {
         this.tableName = createTable.tableName;
@@ -57,6 +58,7 @@ public class CreateTableStatement extends MutableStatement {
         this.whereClause = createTable.whereClause;
         this.immutableRows = createTable.immutableRows;
         this.familyCQCounters = createTable.familyCQCounters;
+        this.noVerify = createTable.noVerify;
     }
 
     public CreateTableStatement(CreateTableStatement createTable, PrimaryKeyConstraint pkConstraint,
@@ -73,6 +75,7 @@ public class CreateTableStatement extends MutableStatement {
         this.whereClause = createTable.whereClause;
         this.immutableRows = createTable.immutableRows;
         this.familyCQCounters = createTable.familyCQCounters;
+        this.noVerify = createTable.noVerify;
     }
 
     public CreateTableStatement(CreateTableStatement createTable, ListMultimap<String,Pair<String,Object>>  props, List<ColumnDef> columns) {
@@ -88,12 +91,13 @@ public class CreateTableStatement extends MutableStatement {
         this.whereClause = createTable.whereClause;
         this.immutableRows = createTable.immutableRows;
         this.familyCQCounters = createTable.familyCQCounters;
+        this.noVerify = createTable.noVerify;
     }
 
     protected CreateTableStatement(TableName tableName, ListMultimap<String,Pair<String,Object>> props, List<ColumnDef> columns, PrimaryKeyConstraint pkConstraint,
                                    List<ParseNode> splitNodes, PTableType tableType, boolean ifNotExists,
                                    TableName baseTableName, ParseNode whereClause, int bindCount, Boolean immutableRows,
-                                   Map<String, Integer> familyCounters) {
+                                   Map<String, Integer> familyCounters, boolean noVerify) {
         this.tableName = tableName;
         this.props = props == null ? ImmutableListMultimap.<String,Pair<String,Object>>of() : props;
         this.tableType = PhoenixDatabaseMetaData.SYSTEM_CATALOG_SCHEMA.equals(tableName.getSchemaName()) ? PTableType.SYSTEM : tableType;
@@ -106,6 +110,7 @@ public class CreateTableStatement extends MutableStatement {
         this.whereClause = whereClause;
         this.immutableRows = immutableRows;
         this.familyCQCounters = familyCounters;
+        this.noVerify = noVerify;
     }
 
     public ParseNode getWhereClause() {
@@ -155,5 +160,9 @@ public class CreateTableStatement extends MutableStatement {
 
     public Map<String, Integer> getFamilyCQCounters() {
         return familyCQCounters;
+    }
+
+    public boolean isNoVerify() {
+        return noVerify;
     }
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
@@ -327,16 +327,36 @@ public class ParseNodeFactory {
         return new PrimaryKeyConstraint(name, columnDefs);
     }
     
-    public IndexKeyConstraint indexKey( List<Pair<ParseNode, SortOrder>> parseNodeAndSortOrder) {
+    public IndexKeyConstraint indexKey(List<Pair<ParseNode, SortOrder>> parseNodeAndSortOrder) {
         return new IndexKeyConstraint(parseNodeAndSortOrder);
     }
 
-    public CreateTableStatement createTable(TableName tableName, ListMultimap<String,Pair<String,Object>> props, List<ColumnDef> columns, PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType, boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode, int bindCount, Boolean immutableRows, Map<String, Integer> cqCounters) {
-        return new CreateTableStatement(tableName, props, columns, pkConstraint, splits, tableType, ifNotExists, baseTableName, tableTypeIdNode, bindCount, immutableRows, cqCounters);
+    public CreateTableStatement createTable(TableName tableName,
+            ListMultimap<String, Pair<String, Object>> props, List<ColumnDef> columns,
+            PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType,
+            boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode, int bindCount,
+            Boolean immutableRows, Map<String, Integer> cqCounters, boolean noVerify) {
+        return new CreateTableStatement(tableName, props, columns, pkConstraint, splits, tableType,
+                ifNotExists, baseTableName, tableTypeIdNode, bindCount, immutableRows, cqCounters,
+                noVerify);
     }
 
-    public CreateTableStatement createTable(TableName tableName, ListMultimap<String,Pair<String,Object>> props, List<ColumnDef> columns, PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType, boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode, int bindCount, Boolean immutableRows) {
-        return new CreateTableStatement(tableName, props, columns, pkConstraint, splits, tableType, ifNotExists, baseTableName, tableTypeIdNode, bindCount, immutableRows, null);
+    public CreateTableStatement createTable(TableName tableName,
+            ListMultimap<String, Pair<String, Object>> props, List<ColumnDef> columns,
+            PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType,
+            boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode, int bindCount,
+            Boolean immutableRows, Map<String, Integer> cqCounters) {
+        return createTable(tableName, props, columns, pkConstraint, splits, tableType, ifNotExists,
+                baseTableName, tableTypeIdNode, bindCount, immutableRows, cqCounters, false);
+    }
+
+    public CreateTableStatement createTable(TableName tableName,
+            ListMultimap<String, Pair<String, Object>> props, List<ColumnDef> columns,
+            PrimaryKeyConstraint pkConstraint, List<ParseNode> splits, PTableType tableType,
+            boolean ifNotExists, TableName baseTableName, ParseNode tableTypeIdNode, int bindCount,
+            Boolean immutableRows) {
+        return createTable(tableName, props, columns, pkConstraint, splits, tableType, ifNotExists,
+                baseTableName, tableTypeIdNode, bindCount, immutableRows, null, false);
     }
 
     public CreateSchemaStatement createSchema(String schemaName, boolean ifNotExists) {
@@ -445,15 +465,15 @@ public class ParseNodeFactory {
     }
     
     public NamedTableNode namedTable(String alias, TableName name, List<ColumnDef> dyn_columns, LiteralParseNode tableSampleNode) {
-    	Double tableSamplingRate;
-    	if(tableSampleNode==null||tableSampleNode.getValue()==null){
-    		tableSamplingRate=ConcreteTableNode.DEFAULT_TABLE_SAMPLING_RATE;
-    	}else if(tableSampleNode.getValue() instanceof Integer){
-    		tableSamplingRate=(double)((int)tableSampleNode.getValue());
-    	}else{
-    		tableSamplingRate=((BigDecimal) tableSampleNode.getValue()).doubleValue();
-    	}
-    	return new NamedTableNode(alias, name, dyn_columns, tableSamplingRate);
+        Double tableSamplingRate;
+        if (tableSampleNode == null || tableSampleNode.getValue() == null) {
+            tableSamplingRate = ConcreteTableNode.DEFAULT_TABLE_SAMPLING_RATE;
+        } else if (tableSampleNode.getValue() instanceof Integer) {
+            tableSamplingRate = (double)((int) tableSampleNode.getValue());
+        } else {
+            tableSamplingRate = ((BigDecimal) tableSampleNode.getValue()).doubleValue();
+        }
+        return new NamedTableNode(alias, name, dyn_columns, tableSamplingRate);
     }
 
     public BindTableNode bindTable(String alias, TableName name) {
@@ -519,7 +539,7 @@ public class ParseNodeFactory {
         args.addAll(valueNodes);
 
         BuiltInFunctionInfo info = getInfo(name, args);
-        if(info==null) {
+        if (info == null) {
             return new UDFParseNode(name,args,info);
         }
         Constructor<? extends FunctionParseNode> ctor = info.getNodeCtor();

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -290,7 +290,6 @@ import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 import org.apache.phoenix.thirdparty.com.google.common.collect.Sets;
 import org.apache.phoenix.thirdparty.com.google.common.primitives.Ints;
 
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
 public class MetaDataClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataClient.class);
@@ -1022,7 +1021,8 @@ public class MetaDataClient {
         }
         table = createTableInternal(statement, splits, parent, viewStatement, viewType, viewIndexIdType, viewColumnConstants, isViewColumnReferenced, false, null, null, tableProps, commonFamilyProps);
 
-        if (table == null || table.getType() == PTableType.VIEW /*|| table.isTransactional()*/) {
+        if (table == null || table.getType() == PTableType.VIEW
+                || statement.isNoVerify() /*|| table.isTransactional()*/) {
             return new MutationState(0, 0, connection);
         }
         // Hack to get around the case when an SCN is specified on the connection.

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixPreparedStatementTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixPreparedStatementTest.java
@@ -25,7 +25,6 @@ import java.util.Properties;
 
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.query.BaseConnectionlessQueryTest;
-import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.query.QueryServicesOptions;
 import org.junit.Test;


### PR DESCRIPTION
This Pull Request introduces a NOVERIFY option for CREATE TABLE that allows skipping the verification the existence of columns with empty qualifier.