### PR TITLE
PHOENIX-7003 Harden hbase region inconsistencies check in CQSI#getAllTableRegions method

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -707,6 +707,7 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
     public byte[] getNextRegionStartKey(HRegionLocation regionLocation, byte[] currentKey) throws IOException {
         // in order to check the overlap/inconsistencies bad region info, we have to make sure
         // the current endKey always increasing(compare the previous endKey)
+        // note :- currentKey is the previous regions endKey
         if ((Bytes.compareTo(regionLocation.getRegion().getStartKey(), currentKey) != 0
                 || Bytes.compareTo(regionLocation.getRegion().getEndKey(), currentKey) <= 0)
                 && !Bytes.equals(currentKey, HConstants.EMPTY_START_ROW)

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -707,7 +707,8 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
     public byte[] getNextRegionStartKey(HRegionLocation regionLocation, byte[] currentKey) throws IOException {
         // in order to check the overlap/inconsistencies bad region info, we have to make sure
         // the current endKey always increasing(compare the previous endKey)
-        if (Bytes.compareTo(regionLocation.getRegion().getEndKey(), currentKey) <= 0
+        if ((Bytes.compareTo(regionLocation.getRegion().getStartKey(), currentKey) != 0
+                || Bytes.compareTo(regionLocation.getRegion().getEndKey(), currentKey) <= 0)
                 && !Bytes.equals(currentKey, HConstants.EMPTY_START_ROW)
                 && !Bytes.equals(regionLocation.getRegion().getEndKey(), HConstants.EMPTY_END_ROW)) {
             GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.increment();

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/ConnectionQueryServicesImplTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/ConnectionQueryServicesImplTest.java
@@ -168,6 +168,7 @@ public class ConnectionQueryServicesImplTest {
                 org.mockito.Mockito.CALLS_REAL_METHODS);
         byte[] corruptedStartAndEndKey = "0x3000".getBytes();
         byte[] corruptedDecreasingKey = "0x2999".getBytes();
+        byte[] corruptedNewEndKey = "0x3001".getBytes();
         byte[] notCorruptedStartKey = "0x2999".getBytes();
         byte[] notCorruptedEndKey = "0x3000".getBytes();
         byte[] notCorruptedNewKey = "0x3001".getBytes();
@@ -190,24 +191,24 @@ public class ConnectionQueryServicesImplTest {
         testGetNextRegionStartKey(mockCqsi, mockRegionLocation, corruptedStartAndEndKey, true);
 
         // comparing the current regionInfo endKey is greater than the previous endKey
-        // [0x3000,0x3000) vs 0x3001
+        // [0x2999,0x3001) vs 0x3000
         GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();
-        when(mockHRegionInfo.getStartKey()).thenReturn(notCorruptedStartKey);
-        when(mockHRegionInfo.getEndKey()).thenReturn(notCorruptedNewKey);
-        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, notCorruptedEndKey, true);
+        when(mockHRegionInfo.getStartKey()).thenReturn(corruptedDecreasingKey);
+        when(mockHRegionInfo.getEndKey()).thenReturn(corruptedNewEndKey);
+        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, corruptedStartAndEndKey, true);
 
         // comparing the current regionInfo startKey is greater than the previous endKey leading to a hole
         // [0x3000,0x3001) vs 0x2999
         GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();
         when(mockHRegionInfo.getStartKey()).thenReturn(corruptedStartAndEndKey);
-        when(mockHRegionInfo.getEndKey()).thenReturn(notCorruptedNewKey);
+        when(mockHRegionInfo.getEndKey()).thenReturn(corruptedNewEndKey);
         testGetNextRegionStartKey(mockCqsi, mockRegionLocation, corruptedDecreasingKey, true);
 
         // comparing the current regionInfo startKey is less than the previous endKey leading to an overlap
         // [0x2999,0x3001) vs 0x3000
         GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();
         when(mockHRegionInfo.getStartKey()).thenReturn(corruptedDecreasingKey);
-        when(mockHRegionInfo.getEndKey()).thenReturn(notCorruptedNewKey);
+        when(mockHRegionInfo.getEndKey()).thenReturn(corruptedNewEndKey);
         testGetNextRegionStartKey(mockCqsi, mockRegionLocation, corruptedStartAndEndKey, true);
 
         // comparing the current regionInfo startKey is equal to the previous endKey
@@ -215,7 +216,7 @@ public class ConnectionQueryServicesImplTest {
         GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();
         when(mockHRegionInfo.getStartKey()).thenReturn(corruptedStartAndEndKey);
         when(mockHRegionInfo.getEndKey()).thenReturn(notCorruptedNewKey);
-        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, corruptedStartAndEndKey, false);
+        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, notCorruptedEndKey, false);
 
         // test EMPTY_START_ROW
         GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/ConnectionQueryServicesImplTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/ConnectionQueryServicesImplTest.java
@@ -194,7 +194,28 @@ public class ConnectionQueryServicesImplTest {
         GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();
         when(mockHRegionInfo.getStartKey()).thenReturn(notCorruptedStartKey);
         when(mockHRegionInfo.getEndKey()).thenReturn(notCorruptedNewKey);
-        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, notCorruptedEndKey, false);
+        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, notCorruptedEndKey, true);
+
+        // comparing the current regionInfo startKey is greater than the previous endKey leading to a hole
+        // [0x3000,0x3001) vs 0x2999
+        GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();
+        when(mockHRegionInfo.getStartKey()).thenReturn(corruptedStartAndEndKey);
+        when(mockHRegionInfo.getEndKey()).thenReturn(notCorruptedNewKey);
+        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, corruptedDecreasingKey, true);
+
+        // comparing the current regionInfo startKey is less than the previous endKey leading to an overlap
+        // [0x2999,0x3001) vs 0x3000
+        GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();
+        when(mockHRegionInfo.getStartKey()).thenReturn(corruptedDecreasingKey);
+        when(mockHRegionInfo.getEndKey()).thenReturn(notCorruptedNewKey);
+        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, corruptedStartAndEndKey, true);
+
+        // comparing the current regionInfo startKey is equal to the previous endKey
+        // [0x3000,0x3001) vs 0x3000
+        GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();
+        when(mockHRegionInfo.getStartKey()).thenReturn(corruptedStartAndEndKey);
+        when(mockHRegionInfo.getEndKey()).thenReturn(notCorruptedNewKey);
+        testGetNextRegionStartKey(mockCqsi, mockRegionLocation, corruptedStartAndEndKey, false);
 
         // test EMPTY_START_ROW
         GlobalClientMetrics.GLOBAL_HBASE_COUNTER_METADATA_INCONSISTENCY.getMetric().reset();


### PR DESCRIPTION
Changing the region boundary detection conditions