### PR TITLE
PHOENIX-7079 Omid 1.1.0 update breaks HBase 2.1-2.3 build because of …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -886,6 +886,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-hdfs</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -950,6 +956,10 @@
           <exclusion>
             <groupId>org.apache.htrace</groupId>
             <artifactId>htrace-core4</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
…Netty problems