### PR TITLE
PHOENIX-7026 : Validate LAST_DDL_TIMESTAMP for write requests

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -953,10 +953,11 @@ public class MutationState implements SQLCloseable {
             long timestamp = result.getMutationTime();
             serverTimeStamp = timestamp;
 
-            //we don't know if this table's cache result was force updated during metadata validation
-            //so always validate columns
+            //we don't know if this table's cache result was force updated during metadata
+            //validation, so always validate columns
             List<PColumn> columns = Lists.newArrayListWithExpectedSize(table.getColumns().size());
-            for (Map.Entry<ImmutableBytesPtr, RowMutationState> rowEntry : rowKeyToColumnMap.entrySet()) {
+            for (Map.Entry<ImmutableBytesPtr, RowMutationState>
+                    rowEntry : rowKeyToColumnMap.entrySet()) {
                 RowMutationState valueEntry = rowEntry.getValue();
                 if (valueEntry != null) {
                     Map<PColumn, byte[]> colValues = valueEntry.getColumnValues();
@@ -969,8 +970,8 @@ public class MutationState implements SQLCloseable {
             }
             for (PColumn column : columns) {
                 if (column != null) {
-                    resolvedTable.getColumnFamily(column.getFamilyName().getString()).getPColumnForColumnName(
-                            column.getName().getString());
+                    resolvedTable.getColumnFamily(column.getFamilyName().getString())
+                            .getPColumnForColumnName(column.getName().getString());
                 }
             }
         } catch(Throwable e) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -956,27 +956,26 @@ public class MutationState implements SQLCloseable {
                         .setTableName(table.getTableName().getString()).build().buildException(); }
             }
             long timestamp = result.getMutationTime();
-            if (timestamp != QueryConstants.UNSET_TIMESTAMP) {
-                serverTimeStamp = timestamp;
-                if (result.wasUpdated()) {
-                    List<PColumn> columns = Lists.newArrayListWithExpectedSize(table.getColumns().size());
-                    for (Map.Entry<ImmutableBytesPtr, RowMutationState> rowEntry : rowKeyToColumnMap.entrySet()) {
-                        RowMutationState valueEntry = rowEntry.getValue();
-                        if (valueEntry != null) {
-                            Map<PColumn, byte[]> colValues = valueEntry.getColumnValues();
-                            if (colValues != PRow.DELETE_MARKER) {
-                                for (PColumn column : colValues.keySet()) {
-                                    if (!column.isDynamic()) columns.add(column);
-                                }
-                            }
+            serverTimeStamp = timestamp;
+
+            //we don't know if this table's cache result was force updated during metadata validation
+            //so always validate columns
+            List<PColumn> columns = Lists.newArrayListWithExpectedSize(table.getColumns().size());
+            for (Map.Entry<ImmutableBytesPtr, RowMutationState> rowEntry : rowKeyToColumnMap.entrySet()) {
+                RowMutationState valueEntry = rowEntry.getValue();
+                if (valueEntry != null) {
+                    Map<PColumn, byte[]> colValues = valueEntry.getColumnValues();
+                    if (colValues != PRow.DELETE_MARKER) {
+                        for (PColumn column : colValues.keySet()) {
+                            if (!column.isDynamic()) columns.add(column);
                         }
                     }
-                    for (PColumn column : columns) {
-                        if (column != null) {
-                            resolvedTable.getColumnFamily(column.getFamilyName().getString()).getPColumnForColumnName(
-                                    column.getName().getString());
-                        }
-                    }
+                }
+            }
+            for (PColumn column : columns) {
+                if (column != null) {
+                    resolvedTable.getColumnFamily(column.getFamilyName().getString()).getPColumnForColumnName(
+                            column.getName().getString());
                 }
             }
         } catch(Throwable e) {

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -953,14 +953,13 @@ public class MutationState implements SQLCloseable {
             long timestamp = result.getMutationTime();
             serverTimeStamp = timestamp;
 
-            /*
-             when last_ddl_timestamp validation is enabled,
+            /* when last_ddl_timestamp validation is enabled,
              we don't know if this table's cache result was force updated
-             during the validation, so always validate columns
-             */
+             during the validation, so always validate columns */
             if ((timestamp != QueryConstants.UNSET_TIMESTAMP && result.wasUpdated())
                     || this.validateLastDdlTimestamp) {
-                List<PColumn> columns = Lists.newArrayListWithExpectedSize(table.getColumns().size());
+                List<PColumn> columns
+                        = Lists.newArrayListWithExpectedSize(table.getColumns().size());
                 for (Map.Entry<ImmutableBytesPtr, RowMutationState>
                         rowEntry : rowKeyToColumnMap.entrySet()) {
                     RowMutationState valueEntry = rowEntry.getValue();
@@ -968,7 +967,9 @@ public class MutationState implements SQLCloseable {
                         Map<PColumn, byte[]> colValues = valueEntry.getColumnValues();
                         if (colValues != PRow.DELETE_MARKER) {
                             for (PColumn column : colValues.keySet()) {
-                                if (!column.isDynamic()) columns.add(column);
+                                if (!column.isDynamic()) {
+                                    columns.add(column);
+                                }
                             }
                         }
                     }
@@ -1219,9 +1220,9 @@ public class MutationState implements SQLCloseable {
             try {
                 ValidateLastDDLTimestampUtil.validateLastDDLTimestamp(
                         connection, tableRefs, true, true);
-            }
-            catch (StaleMetadataCacheException e) {
-                GlobalClientMetrics.GLOBAL_CLIENT_STALE_METADATA_CACHE_EXCEPTION_COUNTER.increment();
+            } catch (StaleMetadataCacheException e) {
+                GlobalClientMetrics
+                        .GLOBAL_CLIENT_STALE_METADATA_CACHE_EXCEPTION_COUNTER.increment();
                 MetaDataClient mc = new MetaDataClient(connection);
                 PName tenantId = connection.getTenantId();
                 LOGGER.debug("Force updating client metadata cache for {}",

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -393,7 +393,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                 //plan.getTableRef can be null in some cases like EXPLAIN <query>
                                 if (shouldValidateLastDdlTimestamp && plan.getTableRef() != null) {
                                     ValidateLastDDLTimestampUtil.validateLastDDLTimestamp(
-                                            connection, Arrays.asList(plan.getTableRef()), true);
+                                        connection, Arrays.asList(plan.getTableRef()), false, true);
                                 }
 
                                 // this will create its own trace internally, so we don't wrap this

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -296,7 +296,8 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
     public PhoenixStatement(PhoenixConnection connection) {
         this.connection = connection;
         this.queryTimeoutMillis = getDefaultQueryTimeoutMillis();
-        this.validateLastDdlTimestamp = getValidateLastDdlTimestampEnabled();
+        this.validateLastDdlTimestamp = ValidateLastDDLTimestampUtil
+                                            .getValidateLastDdlTimestampEnabled(this.connection);
     }
 
     /**
@@ -306,12 +307,6 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
     private int getDefaultQueryTimeoutMillis() {
         return connection.getQueryServices().getProps().getInt(QueryServices.THREAD_TIMEOUT_MS_ATTRIB, 
             QueryServicesOptions.DEFAULT_THREAD_TIMEOUT_MS);
-    }
-
-    private boolean getValidateLastDdlTimestampEnabled() {
-        return connection.getQueryServices().getProps()
-                .getBoolean(QueryServices.LAST_DDL_TIMESTAMP_VALIDATION_ENABLED,
-                        QueryServicesOptions.DEFAULT_LAST_DDL_TIMESTAMP_VALIDATION_ENABLED);
     }
 
     protected List<PhoenixResultSet> getResultSets() {

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -119,6 +119,7 @@ import org.apache.phoenix.log.QueryLogInfo;
 import org.apache.phoenix.log.QueryLogger;
 import org.apache.phoenix.log.QueryLoggerUtil;
 import org.apache.phoenix.log.QueryStatus;
+import org.apache.phoenix.monitoring.GlobalClientMetrics;
 import org.apache.phoenix.monitoring.TableMetricsManager;
 import org.apache.phoenix.optimize.Cost;
 import org.apache.phoenix.parse.AddColumnStatement;
@@ -448,6 +449,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                 }
                                 throw e;
                             } catch (StaleMetadataCacheException e) {
+                                GlobalClientMetrics.GLOBAL_CLIENT_STALE_METADATA_CACHE_EXCEPTION_COUNTER.increment();
                                 updateMetrics = false;
                                 PTable pTable = lastQueryPlan.getTableRef().getTable();
                                 String schemaN = pTable.getSchemaName().toString();

--- a/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -444,7 +444,9 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                 }
                                 throw e;
                             } catch (StaleMetadataCacheException e) {
-                                GlobalClientMetrics.GLOBAL_CLIENT_STALE_METADATA_CACHE_EXCEPTION_COUNTER.increment();
+                                GlobalClientMetrics
+                                        .GLOBAL_CLIENT_STALE_METADATA_CACHE_EXCEPTION_COUNTER
+                                        .increment();
                                 updateMetrics = false;
                                 PTable pTable = lastQueryPlan.getTableRef().getTable();
                                 String schemaN = pTable.getSchemaName().toString();

--- a/phoenix-core/src/main/java/org/apache/phoenix/monitoring/GlobalClientMetrics.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/monitoring/GlobalClientMetrics.java
@@ -39,6 +39,7 @@ import static org.apache.phoenix.monitoring.MetricType.SCAN_BYTES;
 import static org.apache.phoenix.monitoring.MetricType.SELECT_SQL_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.SPOOL_FILE_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.SPOOL_FILE_SIZE;
+import static org.apache.phoenix.monitoring.MetricType.STALE_METADATA_CACHE_EXCEPTION_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.TASK_END_TO_END_TIME;
 import static org.apache.phoenix.monitoring.MetricType.TASK_EXECUTED_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.TASK_EXECUTION_TIME;
@@ -159,7 +160,8 @@ public enum GlobalClientMetrics {
     GLOBAL_HA_PARALLEL_CONNECTION_CREATED_COUNTER(HA_PARALLEL_CONNECTION_CREATED_COUNTER),
 
     GLOBAL_CLIENT_METADATA_CACHE_MISS_COUNTER(CLIENT_METADATA_CACHE_MISS_COUNTER),
-    GLOBAL_CLIENT_METADATA_CACHE_HIT_COUNTER(CLIENT_METADATA_CACHE_HIT_COUNTER);
+    GLOBAL_CLIENT_METADATA_CACHE_HIT_COUNTER(CLIENT_METADATA_CACHE_HIT_COUNTER),
+    GLOBAL_CLIENT_STALE_METADATA_CACHE_EXCEPTION_COUNTER(STALE_METADATA_CACHE_EXCEPTION_COUNTER);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalClientMetrics.class);
     private static final boolean isGlobalMetricsEnabled = QueryServicesOptions.withDefaults().isGlobalMetricsEnabled();

--- a/phoenix-core/src/main/java/org/apache/phoenix/monitoring/MetricType.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/monitoring/MetricType.java
@@ -150,7 +150,7 @@ public enum MetricType {
     CLIENT_METADATA_CACHE_MISS_COUNTER("cmcm", "Number of cache misses for the CQSI cache.", LogLevel.DEBUG, PLong.INSTANCE),
     CLIENT_METADATA_CACHE_HIT_COUNTER("cmch", "Number of cache hits for the CQSI cache.", LogLevel.DEBUG, PLong.INSTANCE),
     PAGED_ROWS_COUNTER("prc", "Number of dummy rows returned to client due to paging.", LogLevel.DEBUG, PLong.INSTANCE),
-    STALE_METADATA_CACHE_EXCEPTION_COUNTER("smcem", "Number of StaleMetadataCacheException encountered.", LogLevel.DEBUG, PLong.INSTANCE),
+    STALE_METADATA_CACHE_EXCEPTION_COUNTER("smce", "Number of StaleMetadataCacheException encountered.", LogLevel.DEBUG, PLong.INSTANCE),
 
     // hbase metrics
     COUNT_RPC_CALLS("rp", "Number of RPC calls",LogLevel.DEBUG, PLong.INSTANCE),

--- a/phoenix-core/src/main/java/org/apache/phoenix/monitoring/MetricType.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/monitoring/MetricType.java
@@ -150,6 +150,7 @@ public enum MetricType {
     CLIENT_METADATA_CACHE_MISS_COUNTER("cmcm", "Number of cache misses for the CQSI cache.", LogLevel.DEBUG, PLong.INSTANCE),
     CLIENT_METADATA_CACHE_HIT_COUNTER("cmch", "Number of cache hits for the CQSI cache.", LogLevel.DEBUG, PLong.INSTANCE),
     PAGED_ROWS_COUNTER("prc", "Number of dummy rows returned to client due to paging.", LogLevel.DEBUG, PLong.INSTANCE),
+    STALE_METADATA_CACHE_EXCEPTION_COUNTER("smcem", "Number of StaleMetadataCacheException encountered.", LogLevel.DEBUG, PLong.INSTANCE),
 
     // hbase metrics
     COUNT_RPC_CALLS("rp", "Number of RPC calls",LogLevel.DEBUG, PLong.INSTANCE),

--- a/phoenix-core/src/main/java/org/apache/phoenix/monitoring/MetricType.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/monitoring/MetricType.java
@@ -150,7 +150,9 @@ public enum MetricType {
     CLIENT_METADATA_CACHE_MISS_COUNTER("cmcm", "Number of cache misses for the CQSI cache.", LogLevel.DEBUG, PLong.INSTANCE),
     CLIENT_METADATA_CACHE_HIT_COUNTER("cmch", "Number of cache hits for the CQSI cache.", LogLevel.DEBUG, PLong.INSTANCE),
     PAGED_ROWS_COUNTER("prc", "Number of dummy rows returned to client due to paging.", LogLevel.DEBUG, PLong.INSTANCE),
-    STALE_METADATA_CACHE_EXCEPTION_COUNTER("smce", "Number of StaleMetadataCacheException encountered.", LogLevel.DEBUG, PLong.INSTANCE),
+    STALE_METADATA_CACHE_EXCEPTION_COUNTER("smce",
+            "Number of StaleMetadataCacheException encountered.",
+            LogLevel.DEBUG, PLong.INSTANCE),
 
     // hbase metrics
     COUNT_RPC_CALLS("rp", "Number of RPC calls",LogLevel.DEBUG, PLong.INSTANCE),

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
@@ -17,6 +17,10 @@
  */
 package org.apache.phoenix.util;
 
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.Admin;
@@ -36,10 +40,6 @@ import org.apache.phoenix.schema.TableNotFoundException;
 import org.apache.phoenix.schema.TableRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.SQLException;
-import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Utility class for last ddl timestamp validation from the client.
@@ -136,7 +136,7 @@ public class ValidateLastDDLTimestampUtil {
      * @return ValidateLastDDLTimestampRequest for the table in tableRef
      */
     private static RegionServerEndpointProtos.ValidateLastDDLTimestampRequest
-    getValidateDDLTimestampRequest(PhoenixConnection conn, List<TableRef> tableRefs,
+        getValidateDDLTimestampRequest(PhoenixConnection conn, List<TableRef> tableRefs,
                                         boolean isWritePath) throws TableNotFoundException {
 
         RegionServerEndpointProtos.ValidateLastDDLTimestampRequest.Builder requestBuilder

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
@@ -61,9 +61,9 @@ public class ValidateLastDDLTimestampUtil {
     }
 
     /**
-     * Returns true if last ddl timestamp validation is enabled on the connection, false otherwise.
+     * Get whether last ddl timestamp validation is enabled on the connection
      * @param connection
-     * @return
+     * @return true if it is enabled, false otherwise
      */
     public static boolean getValidateLastDdlTimestampEnabled(PhoenixConnection connection) {
         return connection.getQueryServices().getProps()
@@ -180,7 +180,6 @@ public class ValidateLastDDLTimestampUtil {
                 }
             }
         }
-
         return requestBuilder.build();
     }
 

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
@@ -1,6 +1,6 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
@@ -45,6 +45,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * Utility class for last ddl timestamp validation from the client.
  */
 public class ValidateLastDDLTimestampUtil {
+
+    private ValidateLastDDLTimestampUtil() {}
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(ValidateLastDDLTimestampUtil.class);
@@ -122,9 +124,12 @@ public class ValidateLastDDLTimestampUtil {
 
     /**
      * Build a request for the validateLastDDLTimestamp RPC for the given tables.
-     * 1. For a view, we need to add all its ancestors to the request in case something changed in the hierarchy.
-     * 2. For an index, we need to add its parent table to the request in case the index was dropped.
-     * 3. On the write path, we need to add all indexes of a table/view in case index state was changed.
+     * 1. For a view, we need to add all its ancestors to the request
+     *    in case something changed in the hierarchy.
+     * 2. For an index, we need to add its parent table to the request
+     *    in case the index was dropped.
+     * 3. On the write path, we need to add all indexes of a table/view
+     *    in case index state was changed.
      * @param conn
      * @param tableRefs
      * @param isWritePath
@@ -153,7 +158,8 @@ public class ValidateLastDDLTimestampUtil {
 
             // add the tableRef to the request
             innerBuilder = RegionServerEndpointProtos.LastDDLTimestampRequest.newBuilder();
-            setLastDDLTimestampRequestParameters(innerBuilder, conn.getTenantId(), tableRef.getTable());
+            setLastDDLTimestampRequestParameters(
+                    innerBuilder, conn.getTenantId(), tableRef.getTable());
             requestBuilder.addLastDDLTimestampRequests(innerBuilder);
 
             //when querying a view, we need to validate last ddl timestamps for all its ancestors
@@ -164,7 +170,8 @@ public class ValidateLastDDLTimestampUtil {
                             pTable.getParentName().getString());
                     PTable parentTable = conn.getTable(key);
                     innerBuilder = RegionServerEndpointProtos.LastDDLTimestampRequest.newBuilder();
-                    setLastDDLTimestampRequestParameters(innerBuilder, conn.getTenantId(), parentTable);
+                    setLastDDLTimestampRequestParameters(
+                            innerBuilder, conn.getTenantId(), parentTable);
                     requestBuilder.addLastDDLTimestampRequests(innerBuilder);
                     pTable = parentTable;
                 }
@@ -175,7 +182,8 @@ public class ValidateLastDDLTimestampUtil {
             if (isWritePath) {
                 for (PTable idxPTable : tableRef.getTable().getIndexes()) {
                     innerBuilder = RegionServerEndpointProtos.LastDDLTimestampRequest.newBuilder();
-                    setLastDDLTimestampRequestParameters(innerBuilder, conn.getTenantId(), idxPTable);
+                    setLastDDLTimestampRequestParameters(
+                            innerBuilder, conn.getTenantId(), idxPTable);
                     requestBuilder.addLastDDLTimestampRequests(innerBuilder);
                 }
             }

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.phoenix.util;
 
 import org.apache.hadoop.hbase.HConstants;

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ValidateLastDDLTimestampUtil.java
@@ -1,0 +1,156 @@
+package org.apache.phoenix.util;
+
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
+import org.apache.hadoop.hbase.util.ByteStringer;
+import org.apache.phoenix.coprocessor.PhoenixRegionServerEndpoint;
+import org.apache.phoenix.coprocessor.generated.RegionServerEndpointProtos;
+import org.apache.phoenix.exception.StaleMetadataCacheException;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.schema.PName;
+import org.apache.phoenix.schema.PTable;
+import org.apache.phoenix.schema.PTableKey;
+import org.apache.phoenix.schema.PTableType;
+import org.apache.phoenix.schema.TableNotFoundException;
+import org.apache.phoenix.schema.TableRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Utility class for last ddl timestamp validation from the client.
+ */
+public class ValidateLastDDLTimestampUtil {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(ValidateLastDDLTimestampUtil.class);
+
+    public static String getInfoString(PName tenantId, List<TableRef> tableRefs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("Tenant: %s, ", tenantId));
+        for (TableRef tableRef : tableRefs) {
+            sb.append(String.format("{Schema: %s, Table: %s},",
+                    tableRef.getTable().getSchemaName(),
+                    tableRef.getTable().getTableName()));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Verifies that table metadata for given tables is up-to-date in client cache with server.
+     * A random live region server is picked for invoking the RPC to validate LastDDLTimestamp.
+     * Retry once if there was an error performing the RPC, otherwise throw the Exception.
+     * @param tableRefs
+     * @throws SQLException
+     */
+    public static void validateLastDDLTimestamp(
+            PhoenixConnection conn, List<TableRef> tableRefs, boolean doRetry) throws SQLException {
+
+        String infoString = getInfoString(conn.getTenantId(), tableRefs);
+        try (Admin admin = conn.getQueryServices().getAdmin()) {
+            // get all live region servers
+            List<ServerName> regionServers
+                    = conn.getQueryServices().getLiveRegionServers();
+            // pick one at random
+            ServerName regionServer
+                    = regionServers.get(ThreadLocalRandom.current().nextInt(regionServers.size()));
+
+            LOGGER.debug("Sending DDL timestamp validation request for {} to regionserver {}",
+                    infoString, regionServer);
+
+            // RPC
+            CoprocessorRpcChannel channel = admin.coprocessorService(regionServer);
+            PhoenixRegionServerEndpoint.BlockingInterface service
+                    = PhoenixRegionServerEndpoint.newBlockingStub(channel);
+            RegionServerEndpointProtos.ValidateLastDDLTimestampRequest request
+                    = getValidateDDLTimestampRequest(conn, tableRefs);
+            service.validateLastDDLTimestamp(null, request);
+        } catch (Exception e) {
+            SQLException parsedException = ServerUtil.parseServerException(e);
+            if (parsedException instanceof StaleMetadataCacheException) {
+                throw parsedException;
+            }
+            //retry once for any exceptions other than StaleMetadataCacheException
+            LOGGER.error("Error in validating DDL timestamp for {}", infoString, parsedException);
+            if (doRetry) {
+                // update the list of live region servers
+                conn.getQueryServices().refreshLiveRegionServers();
+                validateLastDDLTimestamp(conn, tableRefs, false);
+                return;
+            }
+            throw parsedException;
+        }
+    }
+
+    /**
+     * Build a request for the validateLastDDLTimestamp RPC for the given tables.
+     * 1. For a view, we need to add all its ancestors to the request in case something changed in the hierarchy.
+     * 2. For an index, we need to add its parent table to the request in case the index was dropped.
+     * @param tableRefs
+     * @return ValidateLastDDLTimestampRequest for the table in tableRef
+     */
+    private static RegionServerEndpointProtos.ValidateLastDDLTimestampRequest
+    getValidateDDLTimestampRequest(PhoenixConnection conn, List<TableRef> tableRefs)
+            throws TableNotFoundException {
+        RegionServerEndpointProtos.ValidateLastDDLTimestampRequest.Builder requestBuilder
+                = RegionServerEndpointProtos.ValidateLastDDLTimestampRequest.newBuilder();
+        RegionServerEndpointProtos.LastDDLTimestampRequest.Builder innerBuilder;
+        for (TableRef tableRef : tableRefs) {
+             innerBuilder = RegionServerEndpointProtos.LastDDLTimestampRequest.newBuilder();
+
+            //when querying an index, we need to validate its parent table
+            //in case the index was dropped
+            if (PTableType.INDEX.equals(tableRef.getTable().getType())) {
+                PTableKey key = new PTableKey(conn.getTenantId(),
+                        tableRef.getTable().getParentName().getString());
+                PTable parentTable = conn.getTable(key);
+                setLastDDLTimestampRequestParameters(innerBuilder, conn.getTenantId(), parentTable);
+                requestBuilder.addLastDDLTimestampRequests(innerBuilder);
+            }
+
+            // add the tableRef to the request
+            innerBuilder = RegionServerEndpointProtos.LastDDLTimestampRequest.newBuilder();
+            setLastDDLTimestampRequestParameters(innerBuilder, conn.getTenantId(), tableRef.getTable());
+            requestBuilder.addLastDDLTimestampRequests(innerBuilder);
+
+            //when querying a view, we need to validate last ddl timestamps for all its ancestors
+            if (PTableType.VIEW.equals(tableRef.getTable().getType())) {
+                PTable pTable = tableRef.getTable();
+                while (pTable.getParentName() != null) {
+                    PTableKey key = new PTableKey(conn.getTenantId(),
+                            pTable.getParentName().getString());
+                    PTable parentTable = conn.getTable(key);
+                    innerBuilder = RegionServerEndpointProtos.LastDDLTimestampRequest.newBuilder();
+                    setLastDDLTimestampRequestParameters(innerBuilder, conn.getTenantId(), parentTable);
+                    requestBuilder.addLastDDLTimestampRequests(innerBuilder);
+                    pTable = parentTable;
+                }
+            }
+        }
+
+        return requestBuilder.build();
+    }
+
+    /**
+     * For the given PTable, set the attributes on the LastDDLTimestampRequest.
+     */
+    private static void setLastDDLTimestampRequestParameters(
+            RegionServerEndpointProtos.LastDDLTimestampRequest.Builder builder,
+            PName tenantId, PTable pTable) {
+        byte[] tenantIDBytes = tenantId == null
+                ? HConstants.EMPTY_BYTE_ARRAY
+                : tenantId.getBytes();
+        byte[] schemaBytes = pTable.getSchemaName() == null
+                ?   HConstants.EMPTY_BYTE_ARRAY
+                : pTable.getSchemaName().getBytes();
+        builder.setTenantId(ByteStringer.wrap(tenantIDBytes));
+        builder.setSchemaName(ByteStringer.wrap(schemaBytes));
+        builder.setTableName(ByteStringer.wrap(pTable.getTableName().getBytes()));
+        builder.setLastDDLTimestamp(pTable.getLastDDLTimestamp());
+    }
+}


### PR DESCRIPTION
On the write path, if `phoenix.ddl.timestamp.validation.enabled` is set:
- Pick a random live region server and call the `validateLastDDLTimestamp` RPC for all the tables/views in the `mutationsMap`
    -  Include all indexes on the table/view in case their state had changed
    -  Include all ancestors of views
-  If `StaleMetadataCacheException` is encountered, force update client side cache for all the tables/views. 
    - ~~Replace the `PTable` object in all the `TableRefs` with the latest `PTable` for every table/view.~~
        - `MutationState#validateAndGetServerTimestamp` should take care of this.