### PR TITLE
PHOENIX-7140 Update Apache Parent and Maven Plugin Versions in Core

### DIFF
--- a/phoenix-tracing-webapp/src/main/config/checkstyle/checker.xml
+++ b/phoenix-tracing-webapp/src/main/config/checkstyle/checker.xml
@@ -27,8 +27,8 @@ limitations under the License.
 -->
 
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!-- Calcite customization of default Checkstyle behavior -->
 <module name="Checker">

--- a/phoenix-tracing-webapp/src/main/config/checkstyle/checker.xml
+++ b/phoenix-tracing-webapp/src/main/config/checkstyle/checker.xml
@@ -26,7 +26,9 @@ limitations under the License.
   http://checkstyle.sourceforge.net
 -->
 
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.1//EN" "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!-- Calcite customization of default Checkstyle behavior -->
 <module name="Checker">
@@ -55,6 +57,15 @@ limitations under the License.
   <!-- See http://checkstyle.sf.net/config_whitespace.html -->
     <!-- No tabs allowed! -->
   <module name="FileTabCharacter"/>
+
+  <!-- Checks for Size Violations.                    -->
+  <!-- See http://checkstyle.sf.net/config_sizes.html -->
+  <!-- Lines cannot exceed 100 chars, except if they are hyperlinks
+       or strings (possibly preceded by '+' and followed by say '),'. -->
+  <module name="LineLength">
+    <property name="max" value="100"/>
+    <property name="ignorePattern" value="^import|@see|@link|@BaseMessage|href|^[ +]*&quot;.*&quot;[);,]*$"/>
+  </module>
 
   <module name="TreeWalker">
 
@@ -216,14 +227,6 @@ limitations under the License.
       <property name="message" value="C-style comment"/>
     </module>
 
-    <!-- Checks for Size Violations.                    -->
-    <!-- See http://checkstyle.sf.net/config_sizes.html -->
-    <!-- Lines cannot exceed 100 chars, except if they are hyperlinks
-         or strings (possibly preceded by '+' and followed by say '),'. -->
-    <module name="LineLength">
-      <property name="max" value="100"/>
-      <property name="ignorePattern" value="^import|@see|@link|@BaseMessage|href|^[ +]*&quot;.*&quot;[);,]*$"/>
-    </module>
       <!-- Over time, we will revise this down -->
     <module name="MethodLength">
       <property name="max" value="390"/>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>30</version>
   </parent>
 
   <scm>
@@ -117,7 +117,6 @@
     <commons-compress.version>1.21</commons-compress.version>
     <sqlline.version>1.9.0</sqlline.version>
     <commons-configuration2.version>2.1.1</commons-configuration2.version>
-    <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
     <jcip-annotations.version>1.0-1</jcip-annotations.version>
     <jsr305.version>2.0.1</jsr305.version>
     <snappy.version>0.3</snappy.version>
@@ -142,19 +141,22 @@
     <hdrhistogram.version>2.1.12</hdrhistogram.version>
 
     <!-- Plugin versions -->
-    <maven-eclipse-plugin.version>2.9</maven-eclipse-plugin.version>
-    <maven-build-helper-plugin.version>1.9.1</maven-build-helper-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-    <restrict-imports.enforcer.version>1.1.0</restrict-imports.enforcer.version>
-    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+    <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
+    <maven-build-helper-plugin.version>3.5.0</maven-build-helper-plugin.version>
+    <restrict-imports.enforcer.version>2.4.0</restrict-imports.enforcer.version>
     <maven-antlr-eclipse-plugin.version>${antlr.version}</maven-antlr-eclipse-plugin.version>
-    <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
-    <!-- Override property in ASF parent -->
-    <surefire.version>3.0.0</surefire.version>
-    <spotbugs-maven-plugin.version>4.4.1</spotbugs-maven-plugin.version>
-    <spotbugs.version>4.4.1</spotbugs.version>
-    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
-    <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.8.1.0</spotbugs-maven-plugin.version>
+    <spotbugs.version>4.8.1</spotbugs.version>
+    <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+    <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
+    <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
+    <maven-owasp-plugin.version>8.4.0</maven-owasp-plugin.version>
+    <os.maven.version>1.7.1</os.maven.version>
+    <jasmine-maven-plugin.version>2.2</jasmine-maven-plugin.version>
+    <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
+    <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
+    <exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>
+    <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
 
     <!-- Plugin options -->
     <numForkedUT>8</numForkedUT>
@@ -207,9 +209,7 @@
     <jacoco.instruction.coverage.percentage>0.700</jacoco.instruction.coverage.percentage>
     <jacoco.branch.coverage.percentage>0.600</jacoco.branch.coverage.percentage>
 
-    <maven-owasp-plugin.version>6.5.3</maven-owasp-plugin.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
-    <os.maven.version>1.5.0.Final</os.maven.version>
     <!-- PHOENIX-6806 - Default protoc architecture to the detected one,
       but allow for profile overrides -->
     <protoc.arch>${os.detected.classifier}</protoc.arch>
@@ -231,7 +231,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>${maven-project-info-reports-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -245,7 +244,7 @@
         <plugin>
           <groupId>com.github.searls</groupId>
           <artifactId>jasmine-maven-plugin</artifactId>
-          <version>2.2</version>
+          <version>${jasmine-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>com.github.spotbugs</groupId>
@@ -269,7 +268,7 @@
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
+          <version>${lifecycle-mapping.version}</version>
           <configuration>
             <lifecycleMappingMetadata>
               <pluginExecutions>
@@ -401,6 +400,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.1.1</version>
           <configuration>
               <ignoredUnusedDeclaredDependencies>
                 <ignoredUnusedDeclaredDependency>
@@ -465,18 +465,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>${maven-shade-plugin.version}</version>
         </plugin>
         <plugin>
           <!-- Allows us to get the apache-ds bundle artifacts -->
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>${maven-bundle-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>1.6.0</version>
+          <version>${exec-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
@@ -486,7 +485,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>${maven-enforcer-plugin.version}</version>
           <dependencies>
             <dependency>
               <groupId>de.skuzzle.enforcer</groupId>
@@ -503,42 +501,42 @@
               </goals>
               <configuration>
                 <rules>
-                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                  <RestrictImports>
                     <includeTestCode>true</includeTestCode>
                     <reason>Use SLF4j for logging</reason>
                     <bannedImports>
                       <bannedImport>org.apache.commons.logging.Log</bannedImport>
                       <bannedImport>org.apache.commons.logging.LogFactory</bannedImport>
                     </bannedImports>
-                  </restrictImports>
-                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                  </RestrictImports>
+                  <RestrictImports>
                     <includeTestCode>true</includeTestCode>
                     <reason>Use shaded version in phoenix-thirdparty</reason>
                     <bannedImports>
                       <bannedImport>com.google.common.**</bannedImport>
                     </bannedImports>
-                  </restrictImports>
-                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                  </RestrictImports>
+                  <RestrictImports>
                     <includeTestCode>true</includeTestCode>
                     <reason>Use shaded version in phoenix-thirdparty</reason>
                     <bannedImports>
                       <bannedImport>org.apache.commons.cli.**</bannedImport>
                     </bannedImports>
-                  </restrictImports>
-                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                  </RestrictImports>
+                  <RestrictImports>
                     <includeTestCode>true</includeTestCode>
                     <reason>Use commons lang 3</reason>
                     <bannedImports>
                       <bannedImport>org.apache.commons.lang.**</bannedImport>
                     </bannedImports>
-                  </restrictImports>
-                  <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                  </RestrictImports>
+                  <RestrictImports>
                     <includeTestCode>true</includeTestCode>
                     <reason>Use edu.umd.cs.findbugs.annotations</reason>
                     <bannedImports>
                       <bannedImport>com.sun.istack.**</bannedImport>
                     </bannedImports>
-                  </restrictImports>
+                  </RestrictImports>
                 </rules>
               </configuration>
             </execution>
@@ -551,7 +549,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>${maven-checkstyle-plugin.version}</version>
         <configuration>
           <configLocation>${top.dir}/src/main/config/checkstyle/checker.xml</configLocation>
           <suppressionsLocation>${top.dir}/src/main/config/checkstyle/suppressions.xml</suppressionsLocation>

--- a/src/main/config/checkstyle/checker.xml
+++ b/src/main/config/checkstyle/checker.xml
@@ -27,8 +27,8 @@ limitations under the License.
 -->
 
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!-- Calcite customization of default Checkstyle behavior -->
 <module name="Checker">

--- a/src/main/config/checkstyle/checker.xml
+++ b/src/main/config/checkstyle/checker.xml
@@ -26,7 +26,9 @@ limitations under the License.
   http://checkstyle.sourceforge.net
 -->
 
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.1//EN" "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!-- Calcite customization of default Checkstyle behavior -->
 <module name="Checker">
@@ -55,6 +57,15 @@ limitations under the License.
   <!-- See http://checkstyle.sf.net/config_whitespace.html -->
     <!-- No tabs allowed! -->
   <module name="FileTabCharacter"/>
+
+  <!-- Checks for Size Violations.                    -->
+  <!-- See http://checkstyle.sf.net/config_sizes.html -->
+  <!-- Lines cannot exceed 100 chars, except if they are hyperlinks
+       or strings (possibly preceded by '+' and followed by say '),'. -->
+  <module name="LineLength">
+    <property name="max" value="100"/>
+    <property name="ignorePattern" value="^import|@see|@link|@BaseMessage|href|^[ +]*&quot;.*&quot;[);,]*$"/>
+  </module>
 
   <module name="TreeWalker">
 
@@ -216,14 +227,6 @@ limitations under the License.
       <property name="message" value="C-style comment"/>
     </module>
 
-    <!-- Checks for Size Violations.                    -->
-    <!-- See http://checkstyle.sf.net/config_sizes.html -->
-    <!-- Lines cannot exceed 100 chars, except if they are hyperlinks
-         or strings (possibly preceded by '+' and followed by say '),'. -->
-    <module name="LineLength">
-      <property name="max" value="100"/>
-      <property name="ignorePattern" value="^import|@see|@link|@BaseMessage|href|^[ +]*&quot;.*&quot;[);,]*$"/>
-    </module>
       <!-- Over time, we will revise this down -->
     <module name="MethodLength">
       <property name="max" value="390"/>


### PR DESCRIPTION
- Apache Parent pom updated to v30
- Versions for the following plugins removed as they are derived from parent pom:
  - maven-enforcer-plugin
  - maven-shade-plugin
  - maven-project-info-reports-plugin
- Unused property surefire.version has been removed
- Properties findbugs-annotations.version, maven-owasp-plugin.version, and os.maven.version have been relocated
- Versions for these plugins are now managed via properties:
  - jasmine-maven-plugin
  - lifecycle-mapping
  - maven-bundle-plugin
  - exec-maven-plugin
  - maven-checkstyle-plugin
- Upgraded versions for these plugins:
  - maven-eclipse-plugin to 2.10
  - maven-build-helper-plugin to 3.5.0
  - restrict-imports.enforcer to 2.4.0
  - spotbugs-maven-plugin to 4.8.1.0
  - spotbugs to 4.8.1
  - jacoco-maven-plugin to 0.8.11
  - sonar-maven-plugin to 3.10.0.2594
  - maven-owasp-plugin to 8.4.0
  - os.maven to 1.7.1
  - maven-bundle-plugin to 5.1.9
  - exec-maven-plugin to 3.1.1
  - maven-checkstyle-plugin to 3.3.0
- Updated checker.xml based on updated checkstyle, refer https://github.com/checkstyle/checkstyle/issues/2116
- Switched to <RestrictImports> as the old declaration variant no longer supported, refer https://github.com/skuzzle/restrict-imports-enforcer-rule/releases/tag/v2.0.0
- Temporarily retained old version of apache parent for maven-dependency-plugin as upgrading is causing build to fail