### PR TITLE
PHOENIX-7156 enabling category-wise integration test execution capability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,9 @@
     <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
 
     <!-- Plugin options -->
+    <skipParallelStatsEnabledTests>false</skipParallelStatsEnabledTests>
+    <skipParallelStatsDisabledTests>false</skipParallelStatsDisabledTests>
+    <skipNeedsOwnMiniClusterTests>false</skipNeedsOwnMiniClusterTests>
     <numForkedUT>8</numForkedUT>
     <numForkedIT>7</numForkedIT>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
@@ -366,6 +369,7 @@
             <execution>
               <id>ParallelStatsEnabledTest</id>
               <configuration>
+                <skip>${skipParallelStatsEnabledTests}</skip>
                 <reuseForks>true</reuseForks>
                 <groups>org.apache.phoenix.end2end.ParallelStatsEnabledTest</groups>
               </configuration>
@@ -378,6 +382,7 @@
               <id>ParallelStatsDisabledTest</id>
               <configuration>
                 <reuseForks>true</reuseForks>
+                <skip>${skipParallelStatsDisabledTests}</skip>
                 <groups>org.apache.phoenix.end2end.ParallelStatsDisabledTest</groups>
               </configuration>
               <goals>
@@ -389,6 +394,7 @@
               <id>NeedTheirOwnClusterTests</id>
               <configuration>
                  <reuseForks>false</reuseForks>
+                 <skip>${skipNeedsOwnMiniClusterTests}</skip>
                  <groups>org.apache.phoenix.end2end.NeedsOwnMiniClusterTest</groups>
               </configuration>
               <goals>


### PR DESCRIPTION
With the above change, we can select the integration tests which we want to run using following commands

- To run the integration tests only for ParallelStatsEnabledTests
`mvn integration-test -DskipParallelStatsDisabledTests=true -DskipNeedsOwnMiniClusterTests=true`

- To run the integration tests only for ParallelStatsDisabledTests
`mvn integration-test -DskipParallelStatsEnabledTests=true -DskipNeedsOwnMiniClusterTests=true`

- To run the integration tests only for ParallelStatsDisabledTests
`mvn integration-test -DskipParallelStatsEnabledTests=true -DskipParallelStatsDisabledTests=true`

- To run both ParallelStatsEnabledTests and ParallelStatsDisabledTests
`mvn integration-test -DskipNeedsOwnMiniClusterTests=true`