### PR TITLE
PHOENIX-7160 Change the TSO default port to be compatible with Omid 1.1.1

### DIFF
--- a/bin/hbase-omid-client-config.yml
+++ b/bin/hbase-omid-client-config.yml
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#Omid TSO connection
+# Omid TSO connection
+# The default port from 54758 has changed to 24758 since Omid 1.1.1
 connectionType: !!org.apache.omid.tso.client.OmidClientConfiguration$ConnType DIRECT
-connectionString: "localhost:54758"
+connectionString: "localhost:24758"
 
 # When Omid is working in High Availability mode, two or more replicas of the TSO server are running in primary/backup
 # mode. When a TSO server replica is elected as master, it publishes its address through ZK. In order to configure


### PR DESCRIPTION
Since [Omid-247](https://github.com/apache/phoenix-omid/commit/7d3cf3e83586bc523e20277113ecb844172cefc0) has been merged, the default port has changed from 54758 to 24758. The TSO configuration in the Phoenix component also needs to be updated.