### PR TITLE
PHOENIX-7187 Improvement of Integration test case with Explain Plan for Partial Index

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/PartialIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/PartialIndexIT.java
@@ -228,11 +228,19 @@ public class PartialIndexIT extends BaseTest {
             assertTrue(rs.next());
             assertEquals("b", rs.getString(1));
             assertFalse(rs.next());
+            //explain plan verify to check if partial index is used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertTrue(rs.getString(1).contains(indexTableName));
 
             selectSql = "SELECT  D from " + dataTableName + " WHERE A = 50";
             rs = conn.createStatement().executeQuery(selectSql);
             // Verify that the index table is not used
             assertPlan((PhoenixResultSet) rs,  "", dataTableName);
+            //explain plan verify to check if partial index is not used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertFalse(rs.getString(1).contains(indexTableName));
 
             // Add more rows to test the index write path
             conn.createStatement().execute("upsert into " + dataTableName +
@@ -269,6 +277,10 @@ public class PartialIndexIT extends BaseTest {
             assertPlan((PhoenixResultSet) rs,  "", dataTableName);
             assertTrue(rs.next());
             assertEquals("id2", rs.getString(1));
+            //explain plan verify to check if partial index is not used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertFalse(rs.getString(1).contains(indexTableName));
 
             // Test index verification and repair by IndexTool
             verifyIndex(dataTableName, indexTableName);
@@ -313,11 +325,19 @@ public class PartialIndexIT extends BaseTest {
             assertTrue(rs.next());
             assertEquals("a", rs.getString(1));
             assertFalse(rs.next());
+            //explain plan verify to check if partial index is used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertTrue(rs.getString(1).contains(indexTableName));
 
             selectSql = "SELECT  D from " + dataTableName + " WHERE A > 100";
             rs = conn.createStatement().executeQuery(selectSql);
             // Verify that the index table is not used
             assertPlan((PhoenixResultSet) rs,  "", dataTableName);
+            //explain plan verify to check if partial index is not used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertFalse(rs.getString(1).contains(indexTableName));
 
             // Add more rows to test the index write path
             conn.createStatement().execute("upsert into " + dataTableName +
@@ -395,6 +415,10 @@ public class PartialIndexIT extends BaseTest {
             assertEquals(70, rs.getInt(1));
             assertEquals("a", rs.getString(2));
             assertFalse(rs.next());
+            //explain plan verify to check if partial index is used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertTrue(rs.getString(1).contains(indexTableName));
 
             // Add more rows to test the index write path
             conn.createStatement().execute("upsert into " + dataTableName +
@@ -422,6 +446,10 @@ public class PartialIndexIT extends BaseTest {
             assertPlan((PhoenixResultSet) rs,  "", dataTableName);
             assertTrue(rs.next());
             assertEquals(5, rs.getInt(1));
+            //explain plan verify to check if partial index is not used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + "SELECT Count(*) from " + dataTableName);
+            assertTrue(rs.next());
+            assertFalse(rs.getString(1).contains(indexTableName));
 
             // Overwrite an existing row that satisfies the index WHERE clause such that
             // the new version of the row does not satisfy the index where clause anymore. This
@@ -477,6 +505,10 @@ public class PartialIndexIT extends BaseTest {
             assertTrue(rs.next());
             assertEquals("abcdef", rs.getString(1));
             assertFalse(rs.next());
+            //explain plan verify to check if partial index is used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertTrue(rs.getString(1).contains(indexTableName));
 
             // Add more rows to test the index write path
             conn.createStatement().execute("upsert into " + dataTableName +
@@ -502,6 +534,10 @@ public class PartialIndexIT extends BaseTest {
             assertPlan((PhoenixResultSet) rs,  "", dataTableName);
             assertTrue(rs.next());
             assertEquals(5, rs.getInt(1));
+            //explain plan verify to check if partial index is not used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertFalse(rs.getString(1).contains(indexTableName));
 
             // Overwrite an existing row that satisfies the index WHERE clause such that
             // the new version of the row does not satisfy the index where clause anymore. This
@@ -568,6 +604,10 @@ public class PartialIndexIT extends BaseTest {
             assertTrue(rs.next());
             assertEquals(70, rs.getInt(1));
             assertFalse(rs.next());
+            //explain plan verify to check if partial index is used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertTrue(rs.getString(1).contains(indexTableName));
 
             // Add more rows to test the index write path
             conn.createStatement().execute(
@@ -582,6 +622,10 @@ public class PartialIndexIT extends BaseTest {
             assertPlan((PhoenixResultSet) rs, "", dataTableName);
             assertTrue(rs.next());
             assertEquals(4, rs.getInt(1));
+            //explain plan verify to check if partial index is not used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + "SELECT Count(*) from " + dataTableName);
+            assertTrue(rs.next());
+            assertFalse(rs.getString(1).contains(indexTableName));
 
             rs = conn.createStatement().executeQuery("SELECT Count(*) from " + indexTableName);
             assertTrue(rs.next());
@@ -600,6 +644,10 @@ public class PartialIndexIT extends BaseTest {
             assertTrue(rs.next());
             assertEquals(0, rs.getInt(1));
             assertFalse(rs.next());
+            //explain plan verify to check if partial index is used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertTrue(rs.getString(1).contains(indexTableName));
 
             // Test index verification and repair by IndexTool
             verifyIndex(dataTableName, indexTableName);
@@ -754,6 +802,10 @@ public class PartialIndexIT extends BaseTest {
             assertTrue(rs.next());
             assertEquals("b", rs.getString(1));
             assertFalse(rs.next());
+            //explain plan verify to check if partial index is used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertTrue(rs.getString(1).contains(partialIndexTableName));
 
             selectSql = "SELECT  D from " + dataTableName + " WHERE A < 50";
             // Verify that the full index table is used
@@ -762,6 +814,10 @@ public class PartialIndexIT extends BaseTest {
             assertTrue(rs.next());
             assertEquals("a", rs.getString(1));
             assertFalse(rs.next());
+            //explain plan verify to check if full index is used
+            rs = conn.createStatement().executeQuery("EXPLAIN " + selectSql);
+            assertTrue(rs.next());
+            assertTrue(rs.getString(1).contains(fullIndexTableName));
         }
     }
 }


### PR DESCRIPTION
Currently in the integration test for partial index, partial index table obtained from result set is compared against expected schema and table name. But there is no test case to validate explain plan for partial index.

This PR adds query plan test case for partial index.