### PR TITLE
PHOENIX-7015: Serialize DataTable info as a CDC scan attribute

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
@@ -155,6 +155,7 @@ abstract public class BaseScannerRegionObserver implements RegionObserver {
     public static final String CDC_INCLUDE_SCOPES = "_CdcIncludeScopes";
     public static final String DATA_COL_QUALIFIER_TO_NAME_MAP = "_DataColQualToNameMap";
     public static final String DATA_COL_QUALIFIER_TO_TYPE_MAP = "_DataColQualToTypeMap";
+    public static final String DATA_CDC_DATA_TABLE_DEF = "_DataCDCDataTableDef";
 
     public final static byte[] REPLAY_TABLE_AND_INDEX_WRITES = PUnsignedTinyint.INSTANCE.toBytes(1);
     public final static byte[] REPLAY_ONLY_INDEX_WRITES = PUnsignedTinyint.INSTANCE.toBytes(2);

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/CDCGlobalIndexRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/CDCGlobalIndexRegionScanner.java
@@ -32,10 +32,13 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.util.Pair;
+import org.apache.phoenix.coprocessor.generated.PTableProtos;
 import org.apache.phoenix.execute.TupleProjector;
 import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
 import org.apache.phoenix.index.IndexMaintainer;
 import org.apache.phoenix.query.QueryConstants;
+import org.apache.phoenix.schema.PTable;
+import org.apache.phoenix.schema.PTableImpl;
 import org.apache.phoenix.schema.tuple.ResultTuple;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.util.CDCUtil;
@@ -63,6 +66,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_JSON_COL_QUALIFIER;
+import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.DATA_CDC_DATA_TABLE_DEF;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.DATA_COL_QUALIFIER_TO_NAME_MAP;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.DATA_COL_QUALIFIER_TO_TYPE_MAP;
 
@@ -94,6 +98,8 @@ public class CDCGlobalIndexRegionScanner extends UncoveredGlobalIndexRegionScann
                 scan.getAttribute(DATA_COL_QUALIFIER_TO_NAME_MAP));
         dataColQualTypeMap = ScanUtil.deserializeColumnQualifierToTypeMap(
                 scan.getAttribute(DATA_COL_QUALIFIER_TO_TYPE_MAP));
+        PTable dataTableDef = PTableImpl.createFromCDCProto(
+                PTableProtos.CDCTableDef.parseFrom(scan.getAttribute(DATA_CDC_DATA_TABLE_DEF)));
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/ScanUtil.java
@@ -23,6 +23,7 @@ import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_DATA_
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_INCLUDE_SCOPES;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_JSON_COL_QUALIFIER;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CUSTOM_ANNOTATIONS;
+import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.DATA_CDC_DATA_TABLE_DEF;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.DATA_COL_QUALIFIER_TO_NAME_MAP;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.DATA_COL_QUALIFIER_TO_TYPE_MAP;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.SCAN_ACTUAL_START_ROW;
@@ -1345,6 +1346,8 @@ public class ScanUtil {
                     serializeColumnQualifierToNameMap(dataColQualNameMap));
             scan.setAttribute(DATA_COL_QUALIFIER_TO_TYPE_MAP,
                     serializeColumnQualifierToTypeMap(dataColTypeMap));
+            scan.setAttribute(DATA_CDC_DATA_TABLE_DEF,
+                    PTableImpl.toCDCProto(dataTable).toByteArray());
         }
     }
 

--- a/phoenix-core/src/main/protobuf/PTable.proto
+++ b/phoenix-core/src/main/protobuf/PTable.proto
@@ -53,6 +53,14 @@ message PColumn {
   optional bool derived = 17 [default = false];
 }
 
+message CDCColumnDef {
+  required bytes columnNameBytes = 1;
+  optional bytes familyNameBytes = 2;
+  optional string dataType = 3;
+  optional bytes columnQualifierBytes = 4;
+  optional int32 sortOrder = 5;
+}
+
 message PTableStats {
   required bytes key = 1;
   repeated bytes values = 2;
@@ -120,6 +128,13 @@ message PTable {
   optional bytes streamingTopicName=52;
   optional bytes indexWhere=53;
   optional string CDCIncludeScopes=54;
+}
+
+message CDCTableDef {
+  required bytes schemaNameBytes = 1;
+  required bytes tableNameBytes = 2;
+  optional bytes defaultFamilyName = 3;
+  repeated CDCColumnDef columns = 4;
 }
 
 message EncodedCQCounter {


### PR DESCRIPTION
This change serializes a light version of the datatable definition using a new protobuf message and deserializes it in CDC scanner. This change doesn't actually make use of it as part of this PR.