### PR TITLE
PHOENIX-7303 fix CVE-2024-29025 in netty package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
     <!-- Dependency versions -->
     <jackson-bom.version>2.14.1</jackson-bom.version>
-    <netty-bom.version>4.1.104.Final</netty-bom.version>
+    <netty-bom.version>4.1.108.Final</netty-bom.version>
     <antlr.version>3.5.2</antlr.version>
     <reload4j.version>1.2.24</reload4j.version>
     <!-- Only for Hbase 2.5 minicluster -->


### PR DESCRIPTION
This change will fix [CVE-2024-29025](https://github.com/advisories/GHSA-5jpm-x58v-624v)