### PR TITLE
PHOENIX-7299 (Addendum) :- ScanningResultIterator should not time out a query after receiving a valid result...

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/StatementContext.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/StatementContext.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
@@ -84,6 +85,7 @@ public class StatementContext {
     private QueryLogger queryLogger;
     private boolean isClientSideUpsertSelect;
     private boolean isUncoveredIndex;
+    private AtomicBoolean hasFirstValidResult;
     
     public StatementContext(PhoenixStatement statement) {
         this(statement, new Scan());
@@ -111,6 +113,7 @@ public class StatementContext {
         this.queryLogger = context.queryLogger;
         this.isClientSideUpsertSelect = context.isClientSideUpsertSelect;
         this.isUncoveredIndex = context.isUncoveredIndex;
+        this.hasFirstValidResult = new AtomicBoolean(context.getHasFirstValidResult());
     }
     /**
      *  Constructor that lets you override whether or not to collect request level metrics.
@@ -155,6 +158,7 @@ public class StatementContext {
         this.readMetricsQueue = new ReadMetricQueue(isRequestMetricsEnabled,connection.getLogLevel());
         this.overAllQueryMetrics = new OverAllQueryMetrics(isRequestMetricsEnabled,connection.getLogLevel());
         this.retryingPersistentCache = Maps.<Long, Boolean> newHashMap();
+        this.hasFirstValidResult = new AtomicBoolean(false);
     }
 
     /**
@@ -228,6 +232,14 @@ public class StatementContext {
 
     public TableRef getCurrentTable() {
         return currentTable;
+    }
+
+    public boolean getHasFirstValidResult() {
+        return hasFirstValidResult.get();
+    }
+
+    public void setHasFirstValidResult(boolean hasValidResult) {
+        hasFirstValidResult.set(hasValidResult);
     }
 
     public void setCurrentTable(TableRef table) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/iterate/ScanningResultIterator.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/iterate/ScanningResultIterator.java
@@ -85,8 +85,6 @@ public class ScanningResultIterator implements ResultIterator {
 
     private long dummyRowCounter = 0;
 
-    private boolean hasFirstValidResult = false;
-
     private final ScanningResultPostDummyResultCaller scanningResultPostDummyResultCaller;
     private final ScanningResultPostValidResultCaller scanningResultPostValidResultCaller;
 
@@ -207,7 +205,7 @@ public class ScanningResultIterator implements ResultIterator {
             while (result != null && (result.isEmpty() || isDummy(result))) {
                 dummyRowCounter += 1;
                 long timeOutForScan = maxQueryEndTime - EnvironmentEdgeManager.currentTimeMillis();
-                if (!hasFirstValidResult && timeOutForScan < 0) {
+                if (!context.getHasFirstValidResult() && timeOutForScan < 0) {
                     throw new SQLExceptionInfo.Builder(OPERATION_TIMED_OUT).setMessage(
                             ". Query couldn't be completed in the allotted time : "
                                     + context.getStatement().getQueryTimeoutInMillis() + " ms").build().buildException();
@@ -227,7 +225,7 @@ public class ScanningResultIterator implements ResultIterator {
                 close(); // Free up resources early
                 return null;
             }
-            hasFirstValidResult = true;
+            context.setHasFirstValidResult(true);
             // TODO: use ResultTuple.setResult(result)?
             // Need to create a new one if holding on to it (i.e. OrderedResultIterator)
             processAfterRetrievingValidResult();


### PR DESCRIPTION
…Moving valid result boolean variable at context level to prevent Multi threading (#1876)