### PR TITLE
Phoenix CSV BulkloadTool fails with "Global tag is not allowed" error on transactional table

### DIFF
--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -183,10 +183,6 @@
                       <shadedPattern>${shaded.package}.org.apache.tephra</shadedPattern>
                     </relocation>
                     <relocation>
-                        <pattern>org.apache.omid</pattern>
-                        <shadedPattern>${shaded.package}.org.apache.omid</shadedPattern>
-                    </relocation>
-                    <relocation>
                         <pattern>org.apache.commons-collections4</pattern>
                         <shadedPattern>${shaded.package}.org.apache.commons-collections4</shadedPattern>
                     </relocation>


### PR DESCRIPTION
This changes removes the shading of `org.apache.omid` and hence trusted lists defines in OMID goes through successfully and don't error out.