### PR TITLE
PHOENIX-7329 Change TTL column type to VARCHAR in syscat

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MoveTTLDuringUpgradeIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MoveTTLDuringUpgradeIT.java
@@ -79,7 +79,7 @@ public class MoveTTLDuringUpgradeIT extends ParallelStatsDisabledIT {
                 int ttl = tableTTLMap.get(table);
                 //Check if TTL is moved to SYSCAT.
                 if (ttl != HConstants.FOREVER) {
-                    assertEquals(ttl, rs.getInt(2));
+                    assertEquals(ttl, Integer.valueOf(rs.getString(2)).intValue());
                 } else {
                     assertEquals(ttl, TTL_NOT_DEFINED);
                 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/UpgradeIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/UpgradeIT.java
@@ -404,18 +404,21 @@ public class UpgradeIT extends ParallelStatsDisabledIT {
 
             String sql3 = "SELECT TTL FROM SYSTEM.CATALOG WHERE TABLE_NAME = '" + tableName + "'";
             ResultSet rs3 = conn.createStatement().executeQuery(sql3);
-            rs3.next();
-            assertEquals("Should have return one value for PHOENIX_TTL column",Integer.MAX_VALUE, rs3.getInt(1));
+            assertTrue(rs3.next());
+            int ttl = Integer.valueOf(rs3.getString(1));
+            assertEquals("Should have return one value for PHOENIX_TTL column",Integer.MAX_VALUE, ttl);
 
             String sql4 = "SELECT TTL FROM SYSTEM.CATALOG WHERE TABLE_NAME = '" + tableName1 + "'";
             ResultSet rs4 = conn.createStatement().executeQuery(sql4);
-            rs4.next();
-            assertEquals("Should have return one value for PHOENIX_TTL column",randomIntValue, rs4.getInt(1));
+            assertTrue(rs4.next());
+            ttl = Integer.valueOf(rs4.getString(1));
+            assertEquals("Should have return one value for PHOENIX_TTL column",randomIntValue, ttl);
 
             String sql5 = "SELECT TTL FROM SYSTEM.CATALOG WHERE TABLE_NAME = '" + tableName2 + "'";
             ResultSet rs5 = conn.createStatement().executeQuery(sql5);
-            rs5.next();
-            assertEquals("Should have return one value for PHOENIX_TTL column",Integer.MAX_VALUE, rs5.getInt(1));
+            assertTrue(rs5.next());
+            ttl = Integer.valueOf(rs5.getString(1));
+            assertEquals("Should have return one value for PHOENIX_TTL column",Integer.MAX_VALUE, ttl);
         }
     }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ViewTTLIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ViewTTLIT.java
@@ -205,7 +205,8 @@ public class ViewTTLIT extends ParallelStatsDisabledIT {
                     .format(TTL_HEADER_SQL, tenantClause, schemaName, tableName, tableType);
             stmt.execute(sql);
             ResultSet rs = stmt.getResultSet();
-            long actualTTLValueReturned = rs.next() ? rs.getLong(1) : 0;
+            String ttlStr = rs.next() ? rs.getString(1) : null;
+            long actualTTLValueReturned = ttlStr != null ? Integer.valueOf(ttlStr): 0;
 
             assertEquals(String.format("Expected rows do not match for schema = %s, table = %s",
                     schemaName, tableName), ttlValueExpected, actualTTLValueReturned);

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -1417,11 +1417,11 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
         Cell ttlKv = tableKeyValues[TTL_INDEX];
         int ttl = TTL_NOT_DEFINED;
         if (ttlKv != null) {
-            String ttlStr = (String)PVarchar.INSTANCE.toObject(
+            String ttlStr = (String) PVarchar.INSTANCE.toObject(
                     ttlKv.getValueArray(),
                     ttlKv.getValueOffset(),
                     ttlKv.getValueLength());
-            ttl = Integer.valueOf(ttlStr);
+            ttl = Integer.parseInt(ttlStr);
         }
         ttl = ttlKv != null ? ttl : oldTable != null
                 ? oldTable.getTTL() : TTL_NOT_DEFINED;
@@ -1657,9 +1657,9 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
             getVarChars(result.getRow(), 5, rowKeyMetaData);
             //Check if TTL is defined at the current given level
             if (result.getValue(TABLE_FAMILY_BYTES, TTL_BYTES) != null) {
-                String ttlStr = (String)PVarchar.INSTANCE.toObject(
+                String ttlStr = (String) PVarchar.INSTANCE.toObject(
                         result.getValue(DEFAULT_COLUMN_FAMILY_BYTES, TTL_BYTES));
-                return Integer.valueOf(ttlStr);
+                return Integer.parseInt(ttlStr);
             } else if (linkTypeBytes != null ) {
                 String parentSchema =SchemaUtil.getSchemaNameFromFullName(
                         rowKeyMetaData[PhoenixDatabaseMetaData.FAMILY_NAME_INDEX]);
@@ -1720,9 +1720,9 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                 return TTL_NOT_DEFINED;
             }
             if (result.getValue(TABLE_FAMILY_BYTES, TTL_BYTES) != null) {
-                String ttlStr = (String)PVarchar.INSTANCE.toObject(
+                String ttlStr = (String) PVarchar.INSTANCE.toObject(
                         result.getValue(DEFAULT_COLUMN_FAMILY_BYTES, TTL_BYTES));
-                return Integer.valueOf(ttlStr);
+                return Integer.parseInt(ttlStr);
             }
             result = scanner.next();
         } while (result != null);
@@ -3611,7 +3611,7 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                     Cell cell = cells.get(0);
                     String newTTLStr = (String) PVarchar.INSTANCE.toObject(cell.getValueArray(),
                             cell.getValueOffset(), cell.getValueLength());
-                    int newTTL = Integer.valueOf(newTTLStr);
+                    int newTTL = Integer.parseInt(newTTLStr);
                     return newTTL != TTL_NOT_DEFINED;
                 }
             }

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -1415,9 +1415,14 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
             oldTable != null ? oldTable.getStreamingTopicName() : null);
 
         Cell ttlKv = tableKeyValues[TTL_INDEX];
-        int ttl = ttlKv == null ? TTL_NOT_DEFINED : PInteger.INSTANCE
-                .getCodec().decodeInt(ttlKv.getValueArray(),
-                        ttlKv.getValueOffset(), SortOrder.getDefault());
+        int ttl = TTL_NOT_DEFINED;
+        if (ttlKv != null) {
+            String ttlStr = (String)PVarchar.INSTANCE.toObject(
+                    ttlKv.getValueArray(),
+                    ttlKv.getValueOffset(),
+                    ttlKv.getValueLength());
+            ttl = Integer.valueOf(ttlStr);
+        }
         ttl = ttlKv != null ? ttl : oldTable != null
                 ? oldTable.getTTL() : TTL_NOT_DEFINED;
         if (tableType == VIEW && viewType != MAPPED && ttl == TTL_NOT_DEFINED) {
@@ -1652,9 +1657,9 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
             getVarChars(result.getRow(), 5, rowKeyMetaData);
             //Check if TTL is defined at the current given level
             if (result.getValue(TABLE_FAMILY_BYTES, TTL_BYTES) != null) {
-                    return PInteger.INSTANCE.getCodec().decodeInt(
-                            result.getValue(DEFAULT_COLUMN_FAMILY_BYTES, TTL_BYTES),
-                            0, SortOrder.getDefault());
+                String ttlStr = (String)PVarchar.INSTANCE.toObject(
+                        result.getValue(DEFAULT_COLUMN_FAMILY_BYTES, TTL_BYTES));
+                return Integer.valueOf(ttlStr);
             } else if (linkTypeBytes != null ) {
                 String parentSchema =SchemaUtil.getSchemaNameFromFullName(
                         rowKeyMetaData[PhoenixDatabaseMetaData.FAMILY_NAME_INDEX]);
@@ -1715,9 +1720,9 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                 return TTL_NOT_DEFINED;
             }
             if (result.getValue(TABLE_FAMILY_BYTES, TTL_BYTES) != null) {
-                return PInteger.INSTANCE.getCodec().decodeInt(
-                        result.getValue(DEFAULT_COLUMN_FAMILY_BYTES, TTL_BYTES),
-                        0, SortOrder.getDefault());
+                String ttlStr = (String)PVarchar.INSTANCE.toObject(
+                        result.getValue(DEFAULT_COLUMN_FAMILY_BYTES, TTL_BYTES));
+                return Integer.valueOf(ttlStr);
             }
             result = scanner.next();
         } while (result != null);
@@ -3604,8 +3609,9 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                 List<Cell> cells = p.get(TABLE_FAMILY_BYTES, ttlBytes);
                 if (cells != null && cells.size() > 0) {
                     Cell cell = cells.get(0);
-                    int newTTL = (int) PInteger.INSTANCE.toObject(cell.getValueArray(),
+                    String newTTLStr = (String) PVarchar.INSTANCE.toObject(cell.getValueArray(),
                             cell.getValueOffset(), cell.getValueLength());
+                    int newTTL = Integer.valueOf(newTTLStr);
                     return newTTL != TTL_NOT_DEFINED;
                 }
             }

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/QueryConstants.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/QueryConstants.java
@@ -344,7 +344,7 @@ public interface QueryConstants {
             SCHEMA_VERSION + " VARCHAR, \n" +
             EXTERNAL_SCHEMA_ID + " VARCHAR, \n" +
             STREAMING_TOPIC_NAME + " VARCHAR, \n" +
-            TTL + " INTEGER, \n" +
+            TTL + " VARCHAR, \n" +
             ROW_KEY_MATCHER + " VARBINARY, \n" +
             INDEX_WHERE + " VARCHAR, \n" +
             // Column metadata (will be null for table row)

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -3254,9 +3254,9 @@ public class MetaDataClient {
             }
 
             if (ttl == null || ttl == TTL_NOT_DEFINED) {
-                tableUpsert.setNull(34, Types.INTEGER);
+                tableUpsert.setNull(34, Types.VARCHAR);
             } else {
-                tableUpsert.setInt(34, ttl);
+                tableUpsert.setString(34, String.valueOf(ttl));
             }
 
             if ((rowKeyMatcher == null) ||
@@ -3947,7 +3947,8 @@ public class MetaDataClient {
             mutateBooleanProperty(connection, tenantId, schemaName, tableName, USE_STATS_FOR_PARALLELIZATION, useStatsForParallelization);
         }
         if (ttl != null) {
-            mutateIntegerProperty(connection, tenantId, schemaName, tableName, TTL, ttl == TTL_NOT_DEFINED ? null : ttl);
+            mutateStringProperty(connection, tenantId, schemaName, tableName, TTL,
+                    ttl == TTL_NOT_DEFINED ? null : String.valueOf(ttl));
         }
         if (isChangeDetectionEnabled != null) {
             mutateBooleanProperty(connection, tenantId, schemaName, tableName, CHANGE_DETECTION_ENABLED, isChangeDetectionEnabled);

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/UpgradeUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/UpgradeUtil.java
@@ -1434,7 +1434,7 @@ public class UpgradeUtil {
                             result = Integer.MAX_VALUE;
                         }
                         put.addColumn(DEFAULT_COLUMN_FAMILY_BYTES, TTL_BYTES, rowTS,
-                                PInteger.INSTANCE.toBytes(result));
+                                PVarchar.INSTANCE.toBytes(String.valueOf(result)));
                         puts.add(put);
                     }
 
@@ -1540,7 +1540,7 @@ public class UpgradeUtil {
                                 put.addColumn(DEFAULT_COLUMN_FAMILY_BYTES, EMPTY_COLUMN_BYTES, rowTS,
                                         EMPTY_COLUMN_VALUE_BYTES);
                                 put.addColumn(DEFAULT_COLUMN_FAMILY_BYTES, TTL_BYTES, rowTS,
-                                        PInteger.INSTANCE.toBytes(ttl));
+                                        PVarchar.INSTANCE.toBytes(String.valueOf(ttl)));
                                 puts.add(put);
 
                                 //Set TTL to Default at CF level when Phoenix level ttl is enabled


### PR DESCRIPTION
This PR changes the TTL column data type in syscat to VARCHAR. The in-memory representation in PTable is still integer. That will change in a subsequent PR with PHOENIX-7170 