### PR TITLE
PHOENIX-7367 - Snapshot based mapreduce jobs fails after HBASE-28401

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/SnapshotScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/SnapshotScanner.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.regionserver.MemStoreLAB;
 import org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
@@ -143,6 +144,9 @@ public class SnapshotScanner extends AbstractClientScanner {
             String.valueOf(32 * 1024 * 1024L));
     // don't allow L2 bucket cache for non RS process to avoid unexpected disk usage.
     conf.unset(HConstants.BUCKET_CACHE_IOENGINE_KEY);
+    //PHOENIX-7367 - non RS process doesn't have MemstoreLab's ChunkCreator initialized
+    //so we disable it to avoid NPE while closing the memstore as part of region close
+    conf.setBoolean(MemStoreLAB.USEMSLAB_KEY, false);
     region.setBlockCache(BlockCacheFactory.createBlockCache(conf));
     // we won't initialize the MobFileCache when not running in RS process. so provided an
     // initialized cache. Consider the case: an CF was set from an mob to non-mob. if we only

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/TableSnapshotResultIterator.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/TableSnapshotResultIterator.java
@@ -176,19 +176,13 @@ public class TableSnapshotResultIterator implements ResultIterator {
     while (true) {
       if (!initSnapshotScanner())
         return null;
-      try {
-        lastTuple = scanIterator.next();
-        if (lastTuple != null) {
-          ImmutableBytesWritable ptr = new ImmutableBytesWritable();
-          lastTuple.getKey(ptr);
-          return lastTuple;
-        }
-      } finally {
-        if (lastTuple == null) {
-          scanIterator.close();
-          scanIterator = UNINITIALIZED_SCANNER;
-        }
+      lastTuple = scanIterator.next();
+      if (lastTuple != null) {
+        ImmutableBytesWritable ptr = new ImmutableBytesWritable();
+        lastTuple.getKey(ptr);
+        return lastTuple;
       }
+      //We are done, scanIterator would be explicitly closed by the record reader
     }
   }
 

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/TableSnapshotResultIterator.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/TableSnapshotResultIterator.java
@@ -176,13 +176,19 @@ public class TableSnapshotResultIterator implements ResultIterator {
     while (true) {
       if (!initSnapshotScanner())
         return null;
-      lastTuple = scanIterator.next();
-      if (lastTuple != null) {
-        ImmutableBytesWritable ptr = new ImmutableBytesWritable();
-        lastTuple.getKey(ptr);
-        return lastTuple;
+      try {
+        lastTuple = scanIterator.next();
+        if (lastTuple != null) {
+          ImmutableBytesWritable ptr = new ImmutableBytesWritable();
+          lastTuple.getKey(ptr);
+          return lastTuple;
+        }
+      } finally {
+        if (lastTuple == null) {
+          scanIterator.close();
+          scanIterator = UNINITIALIZED_SCANNER;
+        }
       }
-      //We are done, scanIterator would be explicitly closed by the record reader
     }
   }
 


### PR DESCRIPTION
Jira: PHOENIX-7367

1. Disable mslab for region created within snapshot (by setting hbase.hregion.memstore.mslab.enabled set to false)
2. In TableSnapshotResultIterator - Remove the the SnapshotScanner's close (via ScanningResultIterator) called within next method. It would anyways be closed by the mapper at the end while closing the record reader