### PR TITLE
PHOENIX-7363 Protect server side metadata cache updates for the given PTable

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -511,6 +511,15 @@ public interface QueryServices extends SQLCloseable {
     String PHOENIX_GET_METADATA_READ_LOCK_ENABLED = "phoenix.get.metadata.read.lock.enabled";
 
     /**
+     * If server side metadata cache is empty, take Phoenix writeLock for the given row
+     * and make sure we can acquire the writeLock within the configurable duration.
+     */
+    String PHOENIX_METADATA_CACHE_UPDATE_ROWLOCK_TIMEOUT =
+        "phoenix.metadata.update.rowlock.timeout";
+
+    long DEFAULT_PHOENIX_METADATA_CACHE_UPDATE_ROWLOCK_TIMEOUT = 60000;
+
+    /**
      * Get executor service used for parallel scans
      */
     public ThreadPoolExecutor getExecutor();

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -195,6 +195,7 @@ import org.apache.phoenix.expression.LiteralExpression;
 import org.apache.phoenix.expression.ProjectedColumnExpression;
 import org.apache.phoenix.expression.RowKeyColumnExpression;
 import org.apache.phoenix.expression.visitor.StatelessTraverseAllExpressionVisitor;
+import org.apache.phoenix.hbase.index.LockManager;
 import org.apache.phoenix.hbase.index.covered.update.ColumnReference;
 import org.apache.phoenix.hbase.index.util.GenericKeyValueBuilder;
 import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
@@ -325,6 +326,9 @@ public class MetaDataEndpointImpl extends MetaDataProtocol implements RegionCopr
     private static final byte[] CHILD_TABLE_BYTES = new byte[]{PTable.LinkType.CHILD_TABLE.getSerializedValue()};
     private static final byte[] PHYSICAL_TABLE_BYTES =
             new byte[]{PTable.LinkType.PHYSICAL_TABLE.getSerializedValue()};
+
+    private LockManager lockManager;
+    private long metadataCacheRowLockTimeout;
 
     // KeyValues for Table
     private static final Cell TABLE_TYPE_KV = createFirstOnRow(ByteUtil.EMPTY_BYTE_ARRAY,
@@ -640,8 +644,12 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
             throw new CoprocessorException("Must be loaded on a table region!");
         }
 
+        this.lockManager = new LockManager();
         phoenixAccessCoprocessorHost = new PhoenixMetaDataCoprocessorHost(this.env);
         Configuration config = env.getConfiguration();
+        this.metadataCacheRowLockTimeout =
+            config.getLong(QueryServices.PHOENIX_METADATA_CACHE_UPDATE_ROWLOCK_TIMEOUT,
+                QueryServices.DEFAULT_PHOENIX_METADATA_CACHE_UPDATE_ROWLOCK_TIMEOUT);
         this.accessCheckEnabled = config.getBoolean(QueryServices.PHOENIX_ACLS_ENABLED,
                 QueryServicesOptions.DEFAULT_PHOENIX_ACLS_ENABLED);
         this.blockWriteRebuildIndex = config.getBoolean(QueryServices.INDEX_FAILURE_BLOCK_WRITE,
@@ -762,6 +770,7 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
         Scan scan = MetaDataUtil.newTableRowsScan(key, MIN_TABLE_TIMESTAMP, clientTimeStamp);
         Cache<ImmutableBytesPtr, PMetaDataEntity> metaDataCache = GlobalCache.getInstance(this.env).getMetaDataCache();
         PTable newTable;
+        region.startRegionOperation();
         try (RegionScanner scanner = region.getScanner(scan)) {
             PTable oldTable = (PTable) metaDataCache.getIfPresent(cacheKey);
             long tableTimeStamp = oldTable == null ? MIN_TABLE_TIMESTAMP - 1 : oldTable.getTimeStamp();
@@ -779,6 +788,8 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                 }
                 metaDataCache.put(cacheKey, newTable);
             }
+        } finally {
+            region.closeRegionOperation();
         }
         return newTable;
     }
@@ -3900,14 +3911,13 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
          * Lock directly on key, though it may be an index table. This will just prevent a table
          * from getting rebuilt too often.
          */
-        final boolean wasLocked = (rowLock != null);
+        boolean wasLocked = (rowLock != null);
         try {
             if (!wasLocked) {
                 rowLock = acquireLock(region, key, null, true);
             }
             PTable table =
-                    getTableFromCache(cacheKey, clientTimeStamp, clientVersion);
-            table = modifyIndexStateForOldClient(clientVersion, table);
+                getTableFromCacheWithModifiedIndexState(clientTimeStamp, clientVersion, cacheKey);
             // We only cache the latest, so we'll end up building the table with every call if the
             // client connection has specified an SCN.
             // TODO: If we indicate to the client that we're returning an older version, but there's a
@@ -3920,22 +3930,57 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                 }
                 return table;
             }
-            // Query for the latest table first, since it's not cached
-            table =
-                    buildTable(key, cacheKey, region, HConstants.LATEST_TIMESTAMP, clientVersion);
-            if ((table != null && table.getTimeStamp() <= clientTimeStamp) ||
-                    (blockWriteRebuildIndex && table.getIndexDisableTimestamp() > 0)) {
-                return table;
+            if (!wasLocked && rowLock != null) {
+                // release the read-lock as the PTable could not be formed from the metadata cache
+                rowLock.release();
+                wasLocked = true;
             }
-            // Otherwise, query for an older version of the table - it won't be cached
-            table =
-                    buildTable(key, cacheKey, region, clientTimeStamp, clientVersion);
-            return table;
+            // take Phoenix row level write-lock as we need to protect metadata cache update
+            // after scanning SYSTEM.CATALOG to retrieve the PTable object
+            LockManager.RowLock phoenixRowLock =
+                lockManager.lockRow(key, this.metadataCacheRowLockTimeout);
+            try {
+                table = getTableFromCacheWithModifiedIndexState(clientTimeStamp, clientVersion,
+                    cacheKey);
+                if (table != null && table.getTimeStamp() < clientTimeStamp) {
+                    if (isTableDeleted(table)) {
+                        return null;
+                    }
+                    return table;
+                }
+
+                // take HBase row level read-lock as we need to scan SYSTEM.CATALOG to retrieve
+                // PTable object before updating the metadata cache
+                RowLock hbaseRowLock = acquireLock(region, key, null, true);
+                try {
+                    // Query for the latest table first, since it's not cached
+                    table = buildTable(key, cacheKey, region, HConstants.LATEST_TIMESTAMP,
+                        clientVersion);
+                    if ((table != null && table.getTimeStamp() <= clientTimeStamp) || (
+                        blockWriteRebuildIndex && table.getIndexDisableTimestamp() > 0)) {
+                        return table;
+                    }
+                    // Otherwise, query for an older version of the table - it won't be cached
+                    table = buildTable(key, cacheKey, region, clientTimeStamp, clientVersion);
+                    return table;
+                } finally {
+                    hbaseRowLock.release();
+                }
+            } finally {
+                phoenixRowLock.release();
+            }
         } finally {
             if (!wasLocked && rowLock != null) {
                 rowLock.release();
             }
         }
+    }
+
+    private PTable getTableFromCacheWithModifiedIndexState(long clientTimeStamp, int clientVersion,
+        ImmutableBytesPtr cacheKey) throws SQLException {
+        PTable table = getTableFromCache(cacheKey, clientTimeStamp, clientVersion);
+        table = modifyIndexStateForOldClient(clientVersion, table);
+        return table;
     }
 
     private List<PFunction> doGetFunctions(List<byte[]> keys, long clientTimeStamp) throws IOException, SQLException {


### PR DESCRIPTION
Jira: PHOENIX-7363

**All meta handlers on SYSTEM.CATALOG regionserver exhausted within CQSI#init**

After allowing readLock for getTable API at the server side ([PHOENIX-6066](https://issues.apache.org/jira/browse/PHOENIX-6066)), it seems that under heavy load, all meta handler threads can get exhausted within ConnectionQueryServicesImpl initialization as part of any of the MetaDataEndpointImpl coproc operations. When the table details are not present in the cache, MetaDataEndpointImpl coproc can attempt to create new connection on the server side in order to scan SYSTEM.CATALOG. Under heavy load, several (all of) meta handlers – which are dedicated for all metadata (system table) operations – could attempt to create server side connection, which can further lead into creating new PhoenixConnection to execute CREATE TABLE DDL for SYSTEM.CATALOG in order to ensure that the System tables exist.

Only one thread should update the metadata cache for a given table at a given time.