### PR TITLE
PHOENIX-7393 Update transitive dependency of woodstox-core to 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1682,6 +1682,12 @@
         <artifactId>commons-collections</artifactId>
         <version>${collections.version}</version>
       </dependency>
+      <!-- Update transitive dependency to a one without CVEs -->
+      <dependency>
+          <groupId>com.fasterxml.woodstox</groupId>
+          <artifactId>woodstox-core</artifactId>
+          <version>5.4.0</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>


### PR DESCRIPTION
Update transitive dependency of woodstox-core to 5.4.0

This dependency is a transitive dependency of hadoop, which is using a
5.3.0 version which is currently flagged with 5 CVEs.