### PR TITLE
PHOENIX-7397 Optimize ClientAggregatePlan/ClientScanPlan when inner q…

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/CompiledOffset.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/CompiledOffset.java
@@ -23,6 +23,7 @@ import org.apache.phoenix.thirdparty.com.google.common.base.Optional;
  * CompiledOffset represents the result of the Compiler on the OFFSET clause.
  */
 public class CompiledOffset {
+    public static final CompiledOffset EMPTY_COMPILED_OFFSET = new CompiledOffset(Optional.<Integer>absent(), Optional.<byte[]>absent());
     private final Optional<Integer> integerOffset;
     private final Optional<byte[]> byteOffset;
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/CompiledOffset.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/CompiledOffset.java
@@ -23,7 +23,8 @@ import org.apache.phoenix.thirdparty.com.google.common.base.Optional;
  * CompiledOffset represents the result of the Compiler on the OFFSET clause.
  */
 public class CompiledOffset {
-    public static final CompiledOffset EMPTY_COMPILED_OFFSET = new CompiledOffset(Optional.<Integer>absent(), Optional.<byte[]>absent());
+    public static final CompiledOffset EMPTY_COMPILED_OFFSET =
+            new CompiledOffset(Optional.<Integer>absent(), Optional.<byte[]>absent());
     private final Optional<Integer> integerOffset;
     private final Optional<byte[]> byteOffset;
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/OffsetCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/OffsetCompiler.java
@@ -80,7 +80,9 @@ public class OffsetCompiler {
 
     public CompiledOffset compile(StatementContext context, FilterableStatement statement, boolean inJoin, boolean inUnion) throws SQLException {
         OffsetNode offsetNode = statement.getOffset();
-        if (offsetNode == null) { return CompiledOffset.EMPTY_COMPILED_OFFSET; }
+        if (offsetNode == null) {
+            return CompiledOffset.EMPTY_COMPILED_OFFSET;
+        }
         if (offsetNode.isIntegerOffset()) {
             OffsetParseNodeVisitor visitor = new OffsetParseNodeVisitor(context);
             offsetNode.getOffsetParseNode().accept(visitor);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/OffsetCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/OffsetCompiler.java
@@ -80,7 +80,7 @@ public class OffsetCompiler {
 
     public CompiledOffset compile(StatementContext context, FilterableStatement statement, boolean inJoin, boolean inUnion) throws SQLException {
         OffsetNode offsetNode = statement.getOffset();
-        if (offsetNode == null) { return new CompiledOffset(Optional.<Integer>absent(), Optional.<byte[]>absent()); }
+        if (offsetNode == null) { return CompiledOffset.EMPTY_COMPILED_OFFSET; }
         if (offsetNode.isIntegerOffset()) {
             OffsetParseNodeVisitor visitor = new OffsetParseNodeVisitor(context);
             offsetNode.getOffsetParseNode().accept(visitor);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/OrderByCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/OrderByCompiler.java
@@ -153,12 +153,12 @@ public class OrderByCompiler {
         LinkedHashSet<OrderByExpression> orderByExpressions = Sets.newLinkedHashSetWithExpectedSize(orderByNodes.size());
         for (OrderByNode node : orderByNodes) {
             Expression expression = null;
-            if (node.isLiteral()) {
+            if (node.isIntegerLiteral()) {
                 if (rowProjector == null) {
                     throw new IllegalStateException(
                             "rowProjector is null when there is LiteralParseNode in orderByNodes");
                 }
-                Integer index = node.getIntValueIfLiteral();
+                Integer index = node.getValueIfIntegerLiteral();
                 assert index != null;
                 int size = rowProjector.getColumnProjectors().size();
                 if (index > size || index <= 0 ) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/OrderByCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/OrderByCompiler.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderPreservingTracker.Ordering;
 import org.apache.phoenix.exception.SQLExceptionCode;
@@ -32,16 +33,13 @@ import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.expression.OrderByExpression;
 import org.apache.phoenix.iterate.OrderedResultIterator;
 import org.apache.phoenix.parse.HintNode.Hint;
-import org.apache.phoenix.parse.LiteralParseNode;
 import org.apache.phoenix.parse.OrderByNode;
-import org.apache.phoenix.parse.ParseNode;
 import org.apache.phoenix.parse.SelectStatement;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.PTableType;
 import org.apache.phoenix.schema.RowValueConstructorOffsetNotAllowedInQueryException;
 import org.apache.phoenix.schema.RowValueConstructorOffsetNotCoercibleException;
-import org.apache.phoenix.schema.types.PInteger;
 
 import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.phoenix.thirdparty.com.google.common.collect.Lists;
@@ -155,9 +153,10 @@ public class OrderByCompiler {
         LinkedHashSet<OrderByExpression> orderByExpressions = Sets.newLinkedHashSetWithExpectedSize(orderByNodes.size());
         for (OrderByNode node : orderByNodes) {
             Expression expression = null;
-            if (node.isLiteral()){
+            if (node.isLiteral()) {
                 if (rowProjector == null) {
-                    throw new IllegalStateException("rowProjector is null when there is LiteralParseNode in orderByNodes.");
+                    throw new IllegalStateException(
+                            "rowProjector is null when there is LiteralParseNode in orderByNodes");
                 }
                 Integer index = node.getIntValueIfLiteral();
                 assert index != null;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
@@ -23,17 +23,22 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
+import java.util.function.Supplier;
 import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
+import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.exception.SQLExceptionInfo;
 import org.apache.phoenix.execute.TupleProjectionPlan;
 import org.apache.phoenix.execute.TupleProjector;
+import org.apache.phoenix.execute.UnionPlan;
 import org.apache.phoenix.expression.CoerceExpression;
 import org.apache.phoenix.expression.Expression;
 import org.apache.phoenix.jdbc.PhoenixStatement;
 import org.apache.phoenix.parse.AliasedNode;
+import org.apache.phoenix.parse.OrderByNode;
+import org.apache.phoenix.parse.SelectStatement;
 import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PColumnImpl;
 import org.apache.phoenix.schema.PName;
@@ -225,5 +230,93 @@ public class UnionCompiler {
             plans.set(i, subPlan);
         }
         return plans;
+    }
+
+    /**
+     * If every subquery in {@link UnionPlan} is ordered, and {@link QueryPlan#getOutputOrderBys}
+     * of each subquery are equal(absolute equality or the same column name is unnecessary, just
+     * column types are compatible and columns count is same), and at the same time the outer
+     * query of {@link UnionPlan} has group by or order by, we would further examine whether
+     * maintaining this order for the entire {@link UnionPlan} can compile out the outer query's
+     * group by or order by. If it is sure, then {@link UnionPlan} just to perform a simple
+     * merge on the output of each subquery to ensure the overall order of the union all;
+     * otherwise, {@link UnionPlan} would not perform any special processing on the output
+     * of the subqueries.
+     */
+    static void optimizeUnionOrderByIfPossible(
+            UnionPlan innerUnionPlan,
+            SelectStatement outerSelectStatement,
+            Supplier<StatementContext> statementContextCreator) throws SQLException {
+        innerUnionPlan.enableCheckSupportOrderByOptimize();
+        if (!innerUnionPlan.isSupportOrderByOptimize()) {
+            return;
+        }
+
+        if (!isOptimizeUnionOrderByDeserved(
+                innerUnionPlan, outerSelectStatement, statementContextCreator)) {
+            // If maintain the order for the entire UnionPlan(by merge on the output of each
+            // subquery) could not compile out the outer query's group by or order by, we would
+            // not perform any special processing on the output of the subqueries.
+            innerUnionPlan.disableSupportOrderByOptimize();
+        }
+    }
+
+    /**
+     * If group by or order by in outerSelectStatement could be compiled out,
+     * this optimization is deserved.
+     */
+    private static boolean isOptimizeUnionOrderByDeserved(
+            UnionPlan innerUnionPlan,
+            SelectStatement outerSelectStatement,
+            Supplier<StatementContext> statementContextCreator) throws SQLException {
+        if (!outerSelectStatement.haveGroupBy() && !outerSelectStatement.haveOrderBy()) {
+            return false;
+        }
+
+        // Just to avoid additional ProjectionCompiler.compile, make the compilation of order by
+        // as simple as possible.
+        if (!outerSelectStatement.haveGroupBy()
+                && outerSelectStatement.getOrderBy().stream().anyMatch(OrderByNode::isLiteral)) {
+            return false;
+        }
+        StatementContext statementContext = statementContextCreator.get();
+        ColumnResolver columResover = innerUnionPlan.getContext().getResolver();
+        TableRef tableRef = innerUnionPlan.getTableRef();
+        statementContext.setResolver(columResover);
+        statementContext.setCurrentTable(tableRef);
+
+        if (outerSelectStatement.haveGroupBy()) {
+            // For outer query has group by, we check whether groupBy.isOrderPreserving is true.
+            GroupBy groupBy = GroupByCompiler.compile(statementContext, outerSelectStatement);
+            outerSelectStatement =
+                    HavingCompiler.rewrite(statementContext, outerSelectStatement, groupBy);
+            Expression where = WhereCompiler.compile(
+                    statementContext,
+                    outerSelectStatement,
+                    null,
+                    null,
+                    CompiledOffset.EMPTY_COMPILED_OFFSET.getByteOffset());
+            groupBy = groupBy.compile(statementContext, innerUnionPlan, where);
+            return groupBy.isOrderPreserving();
+        }
+
+        assert outerSelectStatement.haveOrderBy();
+        Expression where = WhereCompiler.compile(
+                statementContext,
+                outerSelectStatement,
+                null,
+                null,
+                CompiledOffset.EMPTY_COMPILED_OFFSET.getByteOffset());
+        // For outer query has order by, we check whether orderBy is OrderBy.FWD_ROW_KEY_ORDER_BY.
+        OrderBy orderBy = OrderByCompiler.compile(
+                statementContext,
+                outerSelectStatement,
+                GroupBy.EMPTY_GROUP_BY,
+                null,
+                CompiledOffset.EMPTY_COMPILED_OFFSET,
+                null,
+                innerUnionPlan,
+                where);
+        return orderBy == OrderBy.FWD_ROW_KEY_ORDER_BY;
     }
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
@@ -277,7 +277,7 @@ public class UnionCompiler {
         // Just to avoid additional ProjectionCompiler.compile, make the compilation of order by
         // as simple as possible.
         if (!outerSelectStatement.haveGroupBy()
-                && outerSelectStatement.getOrderBy().stream().anyMatch(OrderByNode::isLiteral)) {
+                && outerSelectStatement.getOrderBy().stream().anyMatch(OrderByNode::isIntegerLiteral)) {
             return false;
         }
         StatementContext statementContext = statementContextCreator.get();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
-import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableList;
+
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
@@ -52,6 +52,8 @@ import org.apache.phoenix.schema.SortOrder;
 import org.apache.phoenix.schema.TableRef;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.util.SchemaUtil;
+
+import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableList;
 
 public class UnionCompiler {
     private static final PName UNION_FAMILY_NAME = PNameFactory.newName("unionFamilyName");

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
@@ -214,7 +214,9 @@ public class UnionCompiler {
     }
 
     static List<QueryPlan> convertToTupleProjectionPlan(
-            List<QueryPlan> plans, TableRef tableRef, StatementContext statementContext) throws SQLException {
+            List<QueryPlan> plans,
+            TableRef tableRef,
+            StatementContext statementContext) throws SQLException {
         List<PColumn> columns =  tableRef.getTable().getColumns();
         for (int i = 0; i < plans.size(); i++) {
             QueryPlan subPlan = plans.get(i);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UnionCompiler.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.OrderByCompiler.OrderBy;
@@ -52,8 +53,6 @@ import org.apache.phoenix.schema.SortOrder;
 import org.apache.phoenix.schema.TableRef;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.util.SchemaUtil;
-
-import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableList;
 
 public class UnionCompiler {
     private static final PName UNION_FAMILY_NAME = PNameFactory.newName("unionFamilyName");

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientAggregatePlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientAggregatePlan.java
@@ -236,8 +236,8 @@ public class ClientAggregatePlan extends ClientProcessingPlan {
             planSteps.add("CLIENT AGGREGATE INTO SINGLE ROW");
             newBuilder.setClientAggregate("CLIENT AGGREGATE INTO SINGLE ROW");
         } else if (groupBy.isOrderPreserving()) {
-            planSteps.add("CLIENT AGGREGATE INTO DISTINCT ROWS BY " + groupBy.getExpressions().toString());
-            newBuilder.setClientAggregate("CLIENT AGGREGATE INTO DISTINCT ROWS BY "
+            planSteps.add("CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY " + groupBy.getExpressions().toString());
+            newBuilder.setClientAggregate("CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY "
                 + groupBy.getExpressions().toString());
         } else if (useHashAgg) {
             planSteps.add("CLIENT HASH AGGREGATE INTO DISTINCT ROWS BY " + groupBy.getExpressions().toString());

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientAggregatePlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientAggregatePlan.java
@@ -236,7 +236,9 @@ public class ClientAggregatePlan extends ClientProcessingPlan {
             planSteps.add("CLIENT AGGREGATE INTO SINGLE ROW");
             newBuilder.setClientAggregate("CLIENT AGGREGATE INTO SINGLE ROW");
         } else if (groupBy.isOrderPreserving()) {
-            planSteps.add("CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY " + groupBy.getExpressions().toString());
+            planSteps.add(
+                    "CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY "
+                    + groupBy.getExpressions().toString());
             newBuilder.setClientAggregate("CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY "
                 + groupBy.getExpressions().toString());
         } else if (useHashAgg) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientAggregatePlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientAggregatePlan.java
@@ -236,9 +236,8 @@ public class ClientAggregatePlan extends ClientProcessingPlan {
             planSteps.add("CLIENT AGGREGATE INTO SINGLE ROW");
             newBuilder.setClientAggregate("CLIENT AGGREGATE INTO SINGLE ROW");
         } else if (groupBy.isOrderPreserving()) {
-            planSteps.add(
-                    "CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY "
-                    + groupBy.getExpressions().toString());
+            planSteps.add("CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY "
+                + groupBy.getExpressions().toString());
             newBuilder.setClientAggregate("CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY "
                 + groupBy.getExpressions().toString());
         } else if (useHashAgg) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
@@ -360,6 +360,9 @@ public class UnionPlan implements QueryPlan {
         }
     }
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+            value="EI_EXPOSE_REP",
+            justification="getOutputOrderBys designed to work this way.")
     @Override
     public List<OrderBy> getOutputOrderBys() {
         if (this.outputOrderBys != null) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
+import java.util.stream.Collectors;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.phoenix.compile.ExplainPlan;
 import org.apache.phoenix.compile.ExplainPlanAttributes
@@ -38,6 +38,7 @@ import org.apache.phoenix.compile.RowProjector;
 import org.apache.phoenix.compile.ScanRanges;
 import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.execute.visitor.QueryPlanVisitor;
+import org.apache.phoenix.expression.OrderByExpression;
 import org.apache.phoenix.iterate.ConcatResultIterator;
 import org.apache.phoenix.iterate.DefaultParallelScanGrouper;
 import org.apache.phoenix.iterate.LimitingResultIterator;
@@ -51,7 +52,6 @@ import org.apache.phoenix.optimize.Cost;
 import org.apache.phoenix.parse.FilterableStatement;
 import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.schema.TableRef;
-import org.apache.phoenix.util.ExpressionUtil;
 
 import org.apache.phoenix.thirdparty.com.google.common.collect.Sets;
 
@@ -75,6 +75,8 @@ public class UnionPlan implements QueryPlan {
     private Long estimatedBytes;
     private Long estimateInfoTs;
     private boolean getEstimatesCalled;
+    private boolean supportOrderByOptimize = false;
+    private List<OrderBy> outputOrderBys = null;
 
     public UnionPlan(StatementContext context, FilterableStatement statement, TableRef table, RowProjector projector,
             Integer limit, Integer offset, OrderBy orderBy, GroupBy groupBy, List<QueryPlan> plans, ParameterMetaData paramMetaData) throws SQLException {
@@ -95,7 +97,53 @@ public class UnionPlan implements QueryPlan {
                 break;
             }
         }
-        this.isDegenerate = isDegen;     
+        this.isDegenerate = isDegen;
+    }
+
+    /**
+     * If every subquery in {@link UnionPlan} is ordered, and {@link QueryPlan#getOutputOrderBys}
+     * of each subquery are equal(absolute equality or the same column name is unnecessary, just
+     * column types are compatible and columns count is same), then it just needs to perform a
+     * simple merge on the subquery results to ensure the overall order of the union all, see
+     * comments on {@link QueryCompiler#optimizeUnionOrderByIfPossible}.
+     */
+    private boolean checkIfSupportOrderByOptimize() {
+        if (!this.orderBy.isEmpty()) {
+            return false;
+        }
+        if (plans.isEmpty()) {
+            return false;
+        }
+        OrderBy prevOrderBy = null;
+        for (QueryPlan queryPlan : plans) {
+            List<OrderBy> orderBys = queryPlan.getOutputOrderBys();
+            if (orderBys.isEmpty() || orderBys.size() > 1) {
+                return false;
+            }
+            OrderBy orderBy = orderBys.get(0);
+            if (prevOrderBy != null && !OrderBy.equalsForOutputOrderBy(prevOrderBy, orderBy)) {
+                return false;
+            }
+            prevOrderBy = orderBy;
+        }
+        return true;
+    }
+
+    public boolean isSupportOrderByOptimize() {
+        return this.supportOrderByOptimize;
+    }
+
+    public void enableCheckSupportOrderByOptimize() {
+        this.supportOrderByOptimize = checkIfSupportOrderByOptimize();
+        this.outputOrderBys = null;
+    }
+
+    public void disableSupportOrderByOptimize() {
+        if (!this.supportOrderByOptimize) {
+            return;
+        }
+        this.outputOrderBys = null;
+        this.supportOrderByOptimize = false;
     }
 
     @Override
@@ -165,10 +213,12 @@ public class UnionPlan implements QueryPlan {
     public final ResultIterator iterator(ParallelScanGrouper scanGrouper, Scan scan) throws SQLException {
         this.iterators = new UnionResultIterators(plans, parentContext);
         ResultIterator scanner;      
-        boolean isOrdered = !orderBy.getOrderByExpressions().isEmpty();
 
-        if (isOrdered) { // TopN
+        if (!orderBy.isEmpty()) { // TopN
             scanner = new MergeSortTopNResultIterator(iterators, limit, offset, orderBy.getOrderByExpressions());
+        } else if (this.supportOrderByOptimize) {
+            //Every subquery is ordered
+            scanner = new MergeSortTopNResultIterator(iterators, limit, offset, getOrderByExpressionsWhenSupportOrderByOptimize());
         } else {
             scanner = new ConcatResultIterator(iterators);
             if (offset != null) {
@@ -310,13 +360,36 @@ public class UnionPlan implements QueryPlan {
 
     @Override
     public List<OrderBy> getOutputOrderBys() {
+        if (this.outputOrderBys != null) {
+            return this.outputOrderBys;
+        }
+        return this.outputOrderBys = convertToOutputOrderBys();
+    }
+
+    private List<OrderBy> convertToOutputOrderBys() {
         assert this.groupBy == GroupBy.EMPTY_GROUP_BY;
         assert this.orderBy != OrderBy.FWD_ROW_KEY_ORDER_BY && this.orderBy != OrderBy.REV_ROW_KEY_ORDER_BY;
         if(!this.orderBy.isEmpty()) {
             return Collections.<OrderBy> singletonList(
                     OrderBy.convertCompiledOrderByToOutputOrderBy(this.orderBy));
         }
+        if (this.supportOrderByOptimize) {
+            assert this.plans.size() > 0;
+            return this.plans.get(0).getOutputOrderBys();
+        }
         return Collections.<OrderBy> emptyList();
+    }
+
+    private List<OrderByExpression> getOrderByExpressionsWhenSupportOrderByOptimize() {
+        assert this.supportOrderByOptimize;
+        assert this.plans.size() > 0;
+        assert this.orderBy.isEmpty();
+        List<OrderBy> outputOrderBys = this.plans.get(0).getOutputOrderBys();
+        assert outputOrderBys != null && outputOrderBys.size() == 1;
+        List<OrderByExpression> orderByExpressions = outputOrderBys.get(0).getOrderByExpressions();
+        assert orderByExpressions != null && orderByExpressions.size() > 0;
+        return orderByExpressions.stream().map(OrderByExpression::convertIfExpressionSortOrderDesc)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
@@ -361,8 +361,8 @@ public class UnionPlan implements QueryPlan {
     }
 
     @edu.umd.cs.findbugs.annotations.SuppressWarnings(
-            value="EI_EXPOSE_REP",
-            justification="getOutputOrderBys designed to work this way.")
+            value = "EI_EXPOSE_REP",
+            justification = "getOutputOrderBys designed to work this way.")
     @Override
     public List<OrderBy> getOutputOrderBys() {
         if (this.outputOrderBys != null) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.phoenix.compile.ExplainPlan;
 import org.apache.phoenix.compile.ExplainPlanAttributes
@@ -218,7 +219,8 @@ public class UnionPlan implements QueryPlan {
             scanner = new MergeSortTopNResultIterator(iterators, limit, offset, orderBy.getOrderByExpressions());
         } else if (this.supportOrderByOptimize) {
             //Every subquery is ordered
-            scanner = new MergeSortTopNResultIterator(iterators, limit, offset, getOrderByExpressionsWhenSupportOrderByOptimize());
+            scanner = new MergeSortTopNResultIterator(
+                    iterators, limit, offset, getOrderByExpressionsWhenSupportOrderByOptimize());
         } else {
             scanner = new ConcatResultIterator(iterators);
             if (offset != null) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/expression/OrderByExpression.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/expression/OrderByExpression.java
@@ -50,15 +50,18 @@ public class OrderByExpression implements Writable {
     }
 
     /**
-     * If {@link Expression#getSortOrder()} is {@link SortOrder#DESC},the isAscending of returned new is reversed,but isNullsLast is untouched.
+     * If {@link Expression#getSortOrder()} is {@link SortOrder#DESC}, reverse the isAscending, but isNullsLast is untouched.
      * @param orderByExpression
      * @return
      */
     public static OrderByExpression convertIfExpressionSortOrderDesc(OrderByExpression orderByExpression) {
-        return createByCheckIfExpressionSortOrderDesc(
+        if (orderByExpression.getExpression().getSortOrder() != SortOrder.DESC) {
+            return orderByExpression;
+        }
+        return new OrderByExpression(
                 orderByExpression.getExpression(),
                 orderByExpression.isNullsLast(),
-                orderByExpression.isAscending());
+                !orderByExpression.isAscending());
     }
 
     /**

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/parse/OrderByNode.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/parse/OrderByNode.java
@@ -87,14 +87,14 @@ public final class OrderByNode {
     }
 
     public boolean isLiteral() {
-        return child instanceof LiteralParseNode &&
-                ((LiteralParseNode)child).getType() == PInteger.INSTANCE;
+        return child instanceof LiteralParseNode
+                && ((LiteralParseNode) child).getType() == PInteger.INSTANCE;
     }
 
     public Integer getIntValueIfLiteral() {
         if (!isLiteral()) {
             return null;
         }
-        return (Integer)((LiteralParseNode)child).getValue();
+        return (Integer) ((LiteralParseNode) child).getValue();
     }
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/parse/OrderByNode.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/parse/OrderByNode.java
@@ -86,13 +86,13 @@ public final class OrderByNode {
         if (nullsLast) buf.append(" NULLS LAST ");
     }
 
-    public boolean isLiteral() {
+    public boolean isIntegerLiteral() {
         return child instanceof LiteralParseNode
                 && ((LiteralParseNode) child).getType() == PInteger.INSTANCE;
     }
 
-    public Integer getIntValueIfLiteral() {
-        if (!isLiteral()) {
+    public Integer getValueIfIntegerLiteral() {
+        if (!isIntegerLiteral()) {
             return null;
         }
         return (Integer) ((LiteralParseNode) child).getValue();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/parse/OrderByNode.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/parse/OrderByNode.java
@@ -18,6 +18,7 @@
 package org.apache.phoenix.parse;
 
 import org.apache.phoenix.compile.ColumnResolver;
+import org.apache.phoenix.schema.types.PInteger;
 
 
 /**
@@ -83,5 +84,17 @@ public final class OrderByNode {
         child.toSQL(resolver, buf);
         if (!orderAscending) buf.append(" DESC");
         if (nullsLast) buf.append(" NULLS LAST ");
+    }
+
+    public boolean isLiteral() {
+        return child instanceof LiteralParseNode &&
+                ((LiteralParseNode)child).getType() == PInteger.INSTANCE;
+    }
+
+    public Integer getIntValueIfLiteral() {
+        if (!isLiteral()) {
+            return null;
+        }
+        return (Integer)((LiteralParseNode)child).getValue();
     }
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/parse/SelectStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/parse/SelectStatement.java
@@ -384,4 +384,13 @@ public class SelectStatement implements FilterableStatement {
         return offset;
     }
 
+    public boolean haveGroupBy() {
+        return (this.getGroupBy() != null && this.getGroupBy().size() > 0) ||
+                (!this.isAggregate()&& this.isDistinct() && this.getSelect() != null && this.getSelect().size() > 0);
+    }
+
+    public boolean haveOrderBy() {
+        return this.getOrderBy() != null && this.getOrderBy().size() > 0;
+    }
+
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/parse/SelectStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/parse/SelectStatement.java
@@ -385,8 +385,11 @@ public class SelectStatement implements FilterableStatement {
     }
 
     public boolean haveGroupBy() {
-        return (this.getGroupBy() != null && this.getGroupBy().size() > 0) ||
-                (!this.isAggregate()&& this.isDistinct() && this.getSelect() != null && this.getSelect().size() > 0);
+        return this.getGroupBy() != null && this.getGroupBy().size() > 0
+                || !this.isAggregate()
+                        && this.isDistinct()
+                        && this.getSelect() != null
+                        && this.getSelect().size() > 0;
     }
 
     public boolean haveOrderBy() {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/ExpressionUtil.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/ExpressionUtil.java
@@ -244,7 +244,7 @@ public class ExpressionUtil {
 
     /**
      * <pre>
-     * Infer OrderBys from the rowkey columns of {@link PTable},for projected table may be there is no rowkey columns,
+     * Infer OrderBys from the rowkey columns of {@link PTable}, for projected table may be no rowkey columns,
      * so we should move forward to inspect {@link ProjectedColumn} by {@link #getOrderByFromProjectedTable}.
      * The second part of the return pair is the rowkey column offset we must skip when we create OrderBys, because for table with salted/multiTenant/viewIndexId,
      * some leading rowkey columns should be skipped.
@@ -302,7 +302,7 @@ public class ExpressionUtil {
     }
 
     /**
-     * For projected table may be there is no rowkey columns,
+     * For projected table may be no rowkey columns,
      * so we should move forward to inspect {@link ProjectedColumn} to check if the source column is rowkey column.
      * The second part of the return pair is the rowkey column offset we must skip when we create OrderBys, because for table with salted/multiTenant/viewIndexId,
      * some leading rowkey columns should be skipped.

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DerivedTableIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DerivedTableIT.java
@@ -129,7 +129,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                 "CLIENT PARALLEL 1-WAY FULL SCAN OVER "+dynamicTableName+"_DERIVED_IDX \n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [\"A_STRING\", \"B_STRING\"]\n" +
                         "CLIENT MERGE SORT\n" +
-                        "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
+                        "CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY [A]\n" +
                         "CLIENT DISTINCT ON [COLLECTDISTINCT(B)]\n" +
                         "CLIENT SORTED BY [A DESC]"}});
         testCases.add(new String[][] {
@@ -145,7 +145,7 @@ public class DerivedTableIT extends ParallelStatsDisabledIT {
                 "CLIENT PARALLEL 4-WAY FULL SCAN OVER "+dynamicTableName+" \n" +
                         "    SERVER AGGREGATE INTO DISTINCT ROWS BY [A_STRING, B_STRING]\n" +
                         "CLIENT MERGE SORT\n" +
-                        "CLIENT AGGREGATE INTO DISTINCT ROWS BY [A]\n" +
+                        "CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY [A]\n" +
                         "CLIENT DISTINCT ON [COLLECTDISTINCT(B)]\n" +
                         "CLIENT SORTED BY [A DESC]"}});
         return testCases;

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/SortMergeJoinMoreIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/SortMergeJoinMoreIT.java
@@ -443,7 +443,7 @@ public class SortMergeJoinMoreIT extends ParallelStatsDisabledIT {
                         "        SERVER AGGREGATE INTO ORDERED DISTINCT ROWS BY [BUCKET, \"TIMESTAMP\", SRC_LOCATION, DST_LOCATION]\n" +
                         "    CLIENT MERGE SORT\n" +
                         "    CLIENT SORTED BY [BUCKET, \"TIMESTAMP\"]\n" +
-                        "CLIENT AGGREGATE INTO DISTINCT ROWS BY [E.BUCKET, E.TIMESTAMP]"
+                        "CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY [E.BUCKET, E.TIMESTAMP]"
                         :
                         "SORT-MERGE-JOIN (INNER) TABLES\n" +
                         "    CLIENT PARALLEL 2-WAY SKIP SCAN ON 2 RANGES OVER " + eventCountTableName + " [X'00','5SEC',~1462993520000000000,'Tr/Bal'] - [X'01','5SEC',~1462993420000000000,'Tr/Bal']\n" +
@@ -458,7 +458,7 @@ public class SortMergeJoinMoreIT extends ParallelStatsDisabledIT {
                         "        SERVER DISTINCT PREFIX FILTER OVER [BUCKET, \"TIMESTAMP\", SRC_LOCATION, DST_LOCATION]\n" +
                         "        SERVER AGGREGATE INTO ORDERED DISTINCT ROWS BY [BUCKET, \"TIMESTAMP\", SRC_LOCATION, DST_LOCATION]\n" +
                         "    CLIENT MERGE SORT\n" +
-                        "CLIENT AGGREGATE INTO DISTINCT ROWS BY [E.BUCKET, E.TIMESTAMP]";
+                        "CLIENT AGGREGATE INTO ORDERED DISTINCT ROWS BY [E.BUCKET, E.TIMESTAMP]";
                 
                 ResultSet rs = conn.createStatement().executeQuery("explain " + q);
                 assertEquals(p, QueryUtil.getExplainPlan(rs));


### PR DESCRIPTION
…uery is UnionPlan


The main modifications are as follows: 
In the `QueryCompiler.compileSingleQuery` method, if it is found that the inner subquery compilation results is a `UnionPlan`, the `UnionCompiler.optimizeUnionOrderByIfPossible `method is introduced to determine whether the inner `UnionPlan` meets the conditions for optimizing the sorting of the outer query：

-  If every subquery in `UnionPlan` is ordered, and `QueryPlan.getOutputOrderBys` of each subquery are equal(absolute equality or the same column name is unnecessary, just column types are compatible and columns count is same), and at the same time the outer query of `UnionPlan` has group by or order by, we would further examine whether
maintaining this order for the entire `UnionPlan` can compile out the outer query's group by or order by. 

- If it is sure, then `UnionPlan` just to perform a simple merge on the output of each subquery to ensure the overall order of the union all;
- otherwise, `UnionPlan` would not perform any special processing on the output of the subqueries.
