### PR TITLE
PHOENIX-7398 New PhoenixStatement API to return row for Atomic/Conditional Upserts

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
@@ -632,6 +632,8 @@ public enum SQLExceptionCode {
     STALE_METADATA_CACHE_EXCEPTION(915, "43M26", "Stale metadata cache exception",
         info -> new StaleMetadataCacheException(info.getMessage())),
 
+    AUTO_COMMIT_NOT_ENABLED(916, "43M27", "Connection does not have auto-commit enabled"),
+
     //SQLCode for testing exceptions
     FAILED_KNOWINGLY_FOR_TEST(7777, "TEST", "Exception was thrown to test something");
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -187,6 +187,12 @@ public class MutationState implements SQLCloseable {
 
     private final boolean indexRegionObserverEnabledAllTables;
 
+    /**
+     * Return result back to client. To be used when client needs to read the whole row
+     * or some specific attributes of the row back. As of PHOENIX-7398, returning whole
+     * row is supported. This is used to allow client to set Mutation attribute that is read
+     * by server for it to atomically read the row and return it back.
+     */
     private ReturnResult returnResult;
     private Result result;
 
@@ -2027,6 +2033,7 @@ public class MutationState implements SQLCloseable {
         estimatedSize = 0;
         this.mutationsMap.clear();
         phoenixTransactionContext = PhoenixTransactionContext.NULL_CONTEXT;
+        this.returnResult = null;
     }
 
     private void resetTransactionalState() {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilderHelper.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilderHelper.java
@@ -38,6 +38,10 @@ public final class PhoenixIndexBuilderHelper {
     private static final byte[] ON_DUP_KEY_IGNORE_BYTES = new byte[] {1}; // boolean true
     private static final int ON_DUP_KEY_HEADER_BYTE_SIZE = Bytes.SIZEOF_SHORT + Bytes.SIZEOF_BOOLEAN;
     public static final String ATOMIC_OP_ATTRIB = "_ATOMIC_OP_ATTRIB";
+
+    public static final String RETURN_RESULT = "_RETURN_RESULT";
+    public static final byte[] RETURN_RESULT_ROW = new byte[]{0};
+
     public static byte[] serializeOnDupKeyIgnore() {
         return ON_DUP_KEY_IGNORE_BYTES;
     }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -227,6 +227,10 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
      * @throws SQLException If the statement cannot be executed.
      */
     public Pair<Integer, Tuple> executeUpdateReturnRow() throws SQLException {
+        if (!connection.getAutoCommit()) {
+            throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()
+                    .buildException();
+        }
         preExecuteUpdate();
         return executeMutation(statement, createAuditQueryLogger(statement, query),
                 MutationState.ReturnResult.ROW);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -46,7 +46,6 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.compile.BindManager;
 import org.apache.phoenix.compile.MutationPlan;
@@ -58,6 +57,7 @@ import org.apache.phoenix.execute.MutationState;
 import org.apache.phoenix.schema.ExecuteQueryNotApplicableException;
 import org.apache.phoenix.schema.ExecuteUpdateNotApplicableException;
 import org.apache.phoenix.schema.Sequence;
+import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.util.DateUtil;
 import org.apache.phoenix.util.SQLCloseable;
@@ -222,11 +222,11 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
      * If the row is successfully updated, return the updated row, otherwise if the row
      * cannot be updated, return non-updated row.
      *
-     * @return The pair of int and Result, where int represents value 1 for successful row update
-     * and 0 for non-successful row update, and Result represents the state of the row.
+     * @return The pair of int and Tuple, where int represents value 1 for successful row update
+     * and 0 for non-successful row update, and Tuple represents the state of the row.
      * @throws SQLException If the statement cannot be executed.
      */
-    public Pair<Integer, Result> executeUpdateReturnRow() throws SQLException {
+    public Pair<Integer, Tuple> executeUpdateReturnRow() throws SQLException {
         preExecuteUpdate();
         return executeMutation(statement, createAuditQueryLogger(statement, query),
                 MutationState.ReturnResult.ROW);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -46,12 +46,15 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.compile.BindManager;
 import org.apache.phoenix.compile.MutationPlan;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.compile.StatementPlan;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.exception.SQLExceptionInfo;
+import org.apache.phoenix.execute.MutationState;
 import org.apache.phoenix.schema.ExecuteQueryNotApplicableException;
 import org.apache.phoenix.schema.ExecuteUpdateNotApplicableException;
 import org.apache.phoenix.schema.Sequence;
@@ -197,6 +200,11 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
 
     @Override
     public int executeUpdate() throws SQLException {
+        preExecuteUpdate();
+        return executeMutation(statement, createAuditQueryLogger(statement,query));
+    }
+
+    private void preExecuteUpdate() throws SQLException {
         throwIfUnboundParameters();
         if (!statement.getOperation().isMutation()) {
             throw new ExecuteUpdateNotApplicableException(statement.getOperation());
@@ -205,7 +213,23 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
             throw new SQLExceptionInfo.Builder(SQLExceptionCode.EXECUTE_UPDATE_WITH_NON_EMPTY_BATCH)
             .build().buildException();
         }
-        return executeMutation(statement, createAuditQueryLogger(statement,query));
+    }
+
+    /**
+     * Executes the given SQL statement similar to JDBC API executeUpdate() but also returns the
+     * updated or non-updated row as Result object back to the client. This must be used with
+     * auto-commit Connection. This makes the operation atomic.
+     * If the row is successfully updated, return the updated row, otherwise if the row
+     * cannot be updated, return non-updated row.
+     *
+     * @return The pair of int and Result, where int represents value 1 for successful row update
+     * and 0 for non-successful row update, and Result represents the state of the row.
+     * @throws SQLException If the statement cannot be executed.
+     */
+    public Pair<Integer, Result> executeUpdateReturnRow() throws SQLException {
+        preExecuteUpdate();
+        return executeMutation(statement, createAuditQueryLogger(statement, query),
+                MutationState.ReturnResult.ROW);
     }
 
     public QueryPlan optimizeQuery() throws SQLException {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -2413,6 +2413,10 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
      * @throws SQLException If the statement cannot be executed.
      */
     public Pair<Integer, Tuple> executeUpdateReturnRow(String sql) throws SQLException {
+        if (!connection.getAutoCommit()) {
+            throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()
+                    .buildException();
+        }
         CompilableStatement stmt = preExecuteUpdate(sql);
         Pair<Integer, Tuple> result =
                 executeMutation(stmt, createAuditQueryLogger(stmt, sql), ReturnResult.ROW);

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -587,7 +587,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
                   cells.add(PhoenixKeyValueUtil.newKeyValue(m.getRow(), Bytes.toBytes(UPSERT_CF),
                           Bytes.toBytes(UPSERT_STATUS_CQ), 0, retVal, 0, retVal.length));
 
-                  if (miniBatchOp.size() == 1 && context.returnResult) {
+                  if (context.returnResult) {
                       context.currColumnCellExprMap.forEach(
                               (key, value) -> cells.add(value.getFirst()));
                       cells.sort(CellComparator.getInstance());
@@ -1155,7 +1155,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
                                               BatchMutateContext context) {
         for (int i = 0; i < miniBatchOp.size(); i++) {
             Mutation m = miniBatchOp.getOperation(i);
-            if (this.builder.returnResult(m)) {
+            if (this.builder.returnResult(m) && miniBatchOp.size() == 1) {
                 context.returnResult = true;
             }
             if (this.builder.isAtomicOp(m) || this.builder.returnResult(m)) {
@@ -1700,7 +1700,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
         if (opBytes == null) {
             mutations.add(atomicPut);
             updateCurrColumnCellExpr(atomicPut, currColumnCellExprMap);
-            if (miniBatchOp.size() == 1 && context.returnResult) {
+            if (context.returnResult) {
                 context.currColumnCellExprMap = currColumnCellExprMap;
             }
             return mutations;
@@ -1714,7 +1714,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
           } else {
               updateCurrColumnCellExpr(currentDataRowState, currColumnCellExprMap);
           }
-          if (miniBatchOp.size() == 1 && context.returnResult) {
+          if (context.returnResult) {
               context.currColumnCellExprMap = currColumnCellExprMap;
           }
           return mutations;
@@ -1746,7 +1746,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
                   // clause which is ignored because the row doesn't exist so
                   // simply use the values in UPSERT VALUES
                   mutations.add(atomicPut);
-                  if (miniBatchOp.size() == 1 && context.returnResult) {
+                  if (context.returnResult) {
                       context.currColumnCellExprMap = currColumnCellExprMap;
                   }
                   return mutations;
@@ -1764,7 +1764,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
           updateCurrColumnCellExpr(currentDataRowState, currColumnCellExprMap);
       }
 
-        if (miniBatchOp.size() == 1 && context.returnResult) {
+        if (context.returnResult) {
             context.currColumnCellExprMap = currColumnCellExprMap;
         }
 

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -1699,7 +1699,8 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
         // perform the mutation and return the result.
         if (opBytes == null) {
             mutations.add(atomicPut);
-            updateCurrColumnCellExpr(atomicPut, currColumnCellExprMap);
+            updateCurrColumnCellExpr(currentDataRowState != null ? currentDataRowState : atomicPut,
+                    currColumnCellExprMap);
             if (context.returnResult) {
                 context.currColumnCellExprMap = currColumnCellExprMap;
             }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/builder/BaseIndexBuilder.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/builder/BaseIndexBuilder.java
@@ -132,6 +132,11 @@ public abstract class BaseIndexBuilder implements IndexBuilder {
         return null;
     }
 
+    @Override
+    public boolean returnResult(Mutation m) {
+        return false;
+    }
+
     public RegionCoprocessorEnvironment getEnv() {
         return this.env;
     }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/builder/IndexBuildManager.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/builder/IndexBuildManager.java
@@ -180,4 +180,9 @@ public class IndexBuildManager implements Stoppable {
   public ReplayWrite getReplayWrite(Mutation m) throws IOException {
     return this.delegate.getReplayWrite(m);
   }
+
+  public boolean returnResult(Mutation m) {
+    return delegate.returnResult(m);
+  }
+
 }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/builder/IndexBuilder.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/builder/IndexBuilder.java
@@ -150,4 +150,12 @@ public interface IndexBuilder extends Stoppable {
   public List<Mutation> executeAtomicOp(Increment inc) throws IOException;
 
   public ReplayWrite getReplayWrite(Mutation m);
+
+  /**
+   * True if mutation needs to return result.
+   *
+   * @param m Mutation object.
+   * @return True if mutation needs to return result, False otherwise.
+   */
+  boolean returnResult(Mutation m);
 }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilder.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilder.java
@@ -102,7 +102,8 @@ public class PhoenixIndexBuilder extends NonTxIndexBuilder {
     
     @Override
     public boolean isAtomicOp(Mutation m) {
-        return m.getAttribute(PhoenixIndexBuilderHelper.ATOMIC_OP_ATTRIB) != null;
+        return m.getAttribute(PhoenixIndexBuilderHelper.ATOMIC_OP_ATTRIB) != null ||
+                m.getAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT) != null;
     }
 
     private static void transferCells(Mutation source, Mutation target) {
@@ -274,5 +275,9 @@ public class PhoenixIndexBuilder extends NonTxIndexBuilder {
     public ReplayWrite getReplayWrite(Mutation m) {
         return PhoenixIndexMetaData.getReplayWrite(m.getAttributesMap());
     }
-    
+
+    @Override
+    public boolean returnResult(Mutation m) {
+        return m.getAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT) != null;
+    }
 }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilder.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilder.java
@@ -102,8 +102,7 @@ public class PhoenixIndexBuilder extends NonTxIndexBuilder {
     
     @Override
     public boolean isAtomicOp(Mutation m) {
-        return m.getAttribute(PhoenixIndexBuilderHelper.ATOMIC_OP_ATTRIB) != null ||
-                m.getAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT) != null;
+        return m.getAttribute(PhoenixIndexBuilderHelper.ATOMIC_OP_ATTRIB) != null;
     }
 
     private static void transferCells(Mutation source, Mutation target) {

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/NonAggregateRegionScannerFactory.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/NonAggregateRegionScannerFactory.java
@@ -226,20 +226,12 @@ public class NonAggregateRegionScannerFactory extends RegionScannerFactory {
         if (serverParsedArrayFuncRefs != null) {
             Collections.addAll(resultList, serverParsedArrayFuncRefs);
         }
-        Expression[] serverParsedJsonValueFuncRefs = null;
-        if (scan.getAttribute(BaseScannerRegionObserverConstants.JSON_VALUE_FUNCTION) != null) {
-            serverParsedJsonValueFuncRefs =
-                    deserializeServerParsedPositionalExpressionInfoFromScan(scan,
-                            BaseScannerRegionObserverConstants.JSON_VALUE_FUNCTION, serverParsedKVRefs);
-        }
-        if (scan.getAttribute(BaseScannerRegionObserverConstants.BSON_VALUE_FUNCTION) != null) {
-            serverParsedJsonValueFuncRefs =
-                deserializeServerParsedPositionalExpressionInfoFromScan(scan,
-                    BaseScannerRegionObserverConstants.BSON_VALUE_FUNCTION, serverParsedKVRefs);
-        }
-        if (serverParsedJsonValueFuncRefs != null) {
-            Collections.addAll(resultList, serverParsedJsonValueFuncRefs);
-        }
+        deserializeAndAddComplexDataTypeFunctions(scan,
+                BaseScannerRegionObserverConstants.JSON_VALUE_FUNCTION, serverParsedKVRefs,
+                resultList);
+        deserializeAndAddComplexDataTypeFunctions(scan,
+                BaseScannerRegionObserverConstants.BSON_VALUE_FUNCTION, serverParsedKVRefs,
+                resultList);
         Expression[] serverParsedJsonQueryFuncRefs = null;
         if (scan.getAttribute(BaseScannerRegionObserverConstants.JSON_QUERY_FUNCTION) != null) {
             serverParsedJsonQueryFuncRefs =
@@ -250,6 +242,21 @@ public class NonAggregateRegionScannerFactory extends RegionScannerFactory {
             Collections.addAll(resultList, serverParsedJsonQueryFuncRefs);
         }
         return resultList;
+    }
+
+    private void deserializeAndAddComplexDataTypeFunctions(Scan scan,
+                                                           String functionName,
+                                                           Set<KeyValueColumnExpression>
+                                                                   serverParsedKVRefs,
+                                                           List<Expression> resultList) {
+        if (scan.getAttribute(functionName) != null) {
+            Expression[] serverParsedJsonValueFuncRefs =
+                    deserializeServerParsedPositionalExpressionInfoFromScan(scan,
+                            functionName, serverParsedKVRefs);
+            if (serverParsedJsonValueFuncRefs != null) {
+                Collections.addAll(resultList, serverParsedJsonValueFuncRefs);
+            }
+        }
     }
 
     @VisibleForTesting

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
@@ -31,9 +31,18 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
 
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.util.Pair;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.query.QueryConstants;
+import org.apache.phoenix.schema.PTable;
+import org.apache.phoenix.schema.types.PBson;
+import org.apache.phoenix.schema.types.PDouble;
 import org.bson.BsonArray;
 import org.bson.BsonBinary;
 import org.bson.BsonDocument;
+import org.bson.BsonDouble;
 import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.RawBsonDocument;
@@ -134,22 +143,8 @@ public class Bson4IT extends ParallelStatsDisabledIT {
       BsonDocument bsonDocument2 = RawBsonDocument.parse(sample2);
       BsonDocument bsonDocument3 = RawBsonDocument.parse(sample3);
 
-      PreparedStatement stmt =
-              conn.prepareStatement("UPSERT INTO " + tableName + " VALUES (?,?,?)");
-      stmt.setString(1, "pk0001");
-      stmt.setString(2, "0002");
-      stmt.setObject(3, bsonDocument1);
-      stmt.executeUpdate();
-
-      stmt.setString(1, "pk1010");
-      stmt.setString(2, "1010");
-      stmt.setObject(3, bsonDocument2);
-      stmt.executeUpdate();
-
-      stmt.setString(1, "pk1011");
-      stmt.setString(2, "1011");
-      stmt.setObject(3, bsonDocument3);
-      stmt.executeUpdate();
+      upsertRows(conn, tableName, bsonDocument1, bsonDocument2, bsonDocument3);
+      PreparedStatement stmt;
 
       conn.commit();
 
@@ -252,6 +247,264 @@ public class Bson4IT extends ParallelStatsDisabledIT {
 
       validateIndexUsed(ps, indexName2);
     }
+  }
+
+  @Test
+  public void testConditionalUpsertReturnRow() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String tableName = generateUniqueName();
+    try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+      conn.setAutoCommit(true);
+      String ddl = "CREATE TABLE " + tableName
+              + " (PK1 VARCHAR NOT NULL, C1 VARCHAR, COL BSON"
+              + " CONSTRAINT pk PRIMARY KEY(PK1))";
+      conn.createStatement().execute(ddl);
+
+      String sample1 = getJsonString("json/sample_01.json");
+      String sample2 = getJsonString("json/sample_02.json");
+      String sample3 = getJsonString("json/sample_03.json");
+      BsonDocument bsonDocument1 = RawBsonDocument.parse(sample1);
+      BsonDocument bsonDocument2 = RawBsonDocument.parse(sample2);
+      BsonDocument bsonDocument3 = RawBsonDocument.parse(sample3);
+
+      upsertRows(conn, tableName, bsonDocument1, bsonDocument2, bsonDocument3);
+      PreparedStatement stmt;
+
+      String conditionExpression =
+              "press = :press AND track[0].shot[2][0].city.standard[50] = :softly";
+
+      BsonDocument conditionDoc = new BsonDocument();
+      conditionDoc.put("$EXPR", new BsonString(conditionExpression));
+      conditionDoc.put("$VAL", new BsonDocument()
+              .append(":press", new BsonString("beat"))
+              .append(":softly", new BsonString("softly")));
+
+      String query = "SELECT * FROM " + tableName +
+              " WHERE PK1 = 'pk0001' AND C1 = '0002' AND NOT BSON_CONDITION_EXPRESSION(COL, '"
+              + conditionDoc.toJson() + "')";
+      ResultSet rs = conn.createStatement().executeQuery(query);
+
+      assertTrue(rs.next());
+      assertEquals("pk0001", rs.getString(1));
+      assertEquals("0002", rs.getString(2));
+      BsonDocument document1 = (BsonDocument) rs.getObject(3);
+      assertEquals(bsonDocument1, document1);
+
+      assertFalse(rs.next());
+
+      conditionExpression =
+              "press = :press AND track[0].shot[2][0].city.standard[5] = :softly";
+
+      conditionDoc = new BsonDocument();
+      conditionDoc.put("$EXPR", new BsonString(conditionExpression));
+      conditionDoc.put("$VAL", new BsonDocument()
+              .append(":press", new BsonString("beat"))
+              .append(":softly", new BsonString("softly")));
+
+      query = "SELECT * FROM " + tableName +
+              " WHERE PK1 = 'pk0001' AND C1 = '0002' AND BSON_CONDITION_EXPRESSION(COL, '"
+              + conditionDoc.toJson() + "')";
+      rs = conn.createStatement().executeQuery(query);
+
+      assertTrue(rs.next());
+      assertEquals("pk0001", rs.getString(1));
+      assertEquals("0002", rs.getString(2));
+      document1 = (BsonDocument) rs.getObject(3);
+      assertEquals(bsonDocument1, document1);
+
+      assertFalse(rs.next());
+
+      BsonDocument updateExp = new BsonDocument()
+              .append("$SET", new BsonDocument()
+                      .append("browserling",
+                              new BsonBinary(PDouble.INSTANCE.toBytes(-505169340.54880095)))
+                      .append("track[0].shot[2][0].city.standard[5]", new BsonString("soft"))
+                      .append("track[0].shot[2][0].city.problem[2]",
+                              new BsonString("track[0].shot[2][0].city.problem[2] + 529.435")))
+              .append("$UNSET", new BsonDocument()
+                      .append("track[0].shot[2][0].city.flame", new BsonNull()));
+
+      stmt = conn.prepareStatement("UPSERT INTO " + tableName
+              + " VALUES (?) ON DUPLICATE KEY UPDATE COL = CASE WHEN"
+              + " BSON_CONDITION_EXPRESSION(COL, '" + conditionDoc.toJson() + "')"
+              + " THEN BSON_UPDATE_EXPRESSION(COL, '" + updateExp + "') ELSE COL END,"
+              + " C1 = ?");
+      stmt.setString(1, "pk0001");
+      stmt.setString(2, "0003");
+
+      // Conditional Upsert successful
+      assertReturnedRowResult(stmt, conn, tableName, "json/sample_updated_01.json", true);
+
+      updateExp = new BsonDocument()
+              .append("$ADD", new BsonDocument()
+                      .append("new_samples",
+                              new BsonDocument().append("$set",
+                                      new BsonArray(Arrays.asList(
+                                              new BsonBinary(Bytes.toBytes("Sample10")),
+                                              new BsonBinary(Bytes.toBytes("Sample12")),
+                                              new BsonBinary(Bytes.toBytes("Sample13")),
+                                              new BsonBinary(Bytes.toBytes("Sample14"))
+                                      )))))
+              .append("$DELETE_FROM_SET", new BsonDocument()
+                      .append("new_samples",
+                              new BsonDocument().append("$set",
+                                      new BsonArray(Arrays.asList(
+                                              new BsonBinary(Bytes.toBytes("Sample02")),
+                                              new BsonBinary(Bytes.toBytes("Sample03"))
+                                      )))))
+              .append("$SET", new BsonDocument()
+                      .append("newrecord", ((BsonArray) (document1.get("track"))).get(0)))
+              .append("$UNSET", new BsonDocument()
+                      .append("rather[3].outline.halfway.so[2][2]", new BsonNull()));
+
+      conditionExpression =
+              "field_not_exists(newrecord) AND field_exists(rather[3].outline.halfway.so[2][2])";
+
+      conditionDoc = new BsonDocument();
+      conditionDoc.put("$EXPR", new BsonString(conditionExpression));
+      conditionDoc.put("$VAL", new BsonDocument());
+
+      stmt = conn.prepareStatement("UPSERT INTO " + tableName
+              + " VALUES (?) ON DUPLICATE KEY UPDATE COL = CASE WHEN"
+              + " BSON_CONDITION_EXPRESSION(COL, '" + conditionDoc.toJson() + "')"
+              + " THEN BSON_UPDATE_EXPRESSION(COL, '" + updateExp + "') ELSE COL END");
+
+      stmt.setString(1, "pk1010");
+
+      // Conditional Upsert successful
+      assertReturnedRowResult(stmt, conn, tableName, "json/sample_updated_02.json", true);
+
+      updateExp = new BsonDocument()
+              .append("$SET", new BsonDocument()
+                      .append("result[1].location.state", new BsonString("AK")))
+              .append("$UNSET", new BsonDocument()
+                      .append("result[4].emails[1]", new BsonNull()));
+
+      conditionExpression =
+              "result[2].location.coordinates.latitude > :latitude OR "
+                      + "(field_exists(result[1].location) AND result[1].location.state != :state" +
+                      " AND field_exists(result[4].emails[1]))";
+
+      conditionDoc = new BsonDocument();
+      conditionDoc.put("$EXPR", new BsonString(conditionExpression));
+      conditionDoc.put("$VAL", new BsonDocument()
+              .append(":latitude", new BsonDouble(0))
+              .append(":state", new BsonString("AK")));
+
+      stmt = conn.prepareStatement("UPSERT INTO " + tableName
+              + " VALUES (?) ON DUPLICATE KEY UPDATE COL = CASE WHEN"
+              + " BSON_CONDITION_EXPRESSION(COL, '" + conditionDoc.toJson() + "')"
+              + " THEN BSON_UPDATE_EXPRESSION(COL, '" + updateExp + "') ELSE COL END");
+
+      stmt.setString(1, "pk1011");
+
+      // Conditional Upsert successful
+      assertReturnedRowResult(stmt, conn, tableName, "json/sample_updated_03.json", true);
+
+      conditionExpression =
+              "press = :press AND track[0].shot[2][0].city.standard[5] = :softly";
+
+      conditionDoc = new BsonDocument();
+      conditionDoc.put("$EXPR", new BsonString(conditionExpression));
+      conditionDoc.put("$VAL", new BsonDocument()
+              .append(":press", new BsonString("incorrect_value"))
+              .append(":softly", new BsonString("incorrect_value")));
+
+      updateExp = new BsonDocument()
+              .append("$SET", new BsonDocument()
+                      .append("new_field1",
+                              new BsonBinary(PDouble.INSTANCE.toBytes(-505169340.54880095)))
+                      .append("track[0].shot[2][0].city.standard[5]", new BsonString(
+                              "soft_new_val"))
+                      .append("track[0].shot[2][0].city.problem[2]",
+                              new BsonString("track[0].shot[2][0].city.problem[2] + 123")));
+
+      stmt = conn.prepareStatement("UPSERT INTO " + tableName
+              + " VALUES (?) ON DUPLICATE KEY UPDATE COL = CASE WHEN"
+              + " BSON_CONDITION_EXPRESSION(COL, '" + conditionDoc.toJson() + "')"
+              + " THEN BSON_UPDATE_EXPRESSION(COL, '" + updateExp + "') ELSE COL END");
+      stmt.setString(1, "pk0001");
+
+      // Conditional Upsert not successful
+      assertReturnedRowResult(stmt, conn, tableName, "json/sample_updated_01.json", false);
+
+      verifyRows(tableName, conn);
+    }
+  }
+
+  private static void upsertRows(Connection conn, String tableName, BsonDocument bsonDocument1,
+                                BsonDocument bsonDocument2, BsonDocument bsonDocument3)
+          throws SQLException {
+    PreparedStatement stmt =
+            conn.prepareStatement("UPSERT INTO " + tableName + " VALUES (?,?,?)");
+    stmt.setString(1, "pk0001");
+    stmt.setString(2, "0002");
+    stmt.setObject(3, bsonDocument1);
+    stmt.executeUpdate();
+
+    stmt.setString(1, "pk1010");
+    stmt.setString(2, "1010");
+    stmt.setObject(3, bsonDocument2);
+    stmt.executeUpdate();
+
+    stmt.setString(1, "pk1011");
+    stmt.setString(2, "1011");
+    stmt.setObject(3, bsonDocument3);
+    stmt.executeUpdate();
+  }
+
+  private static void verifyRows(String tableName, Connection conn)
+          throws SQLException, IOException {
+    String query;
+    ResultSet rs;
+    BsonDocument document1;
+    query = "SELECT * FROM " + tableName;
+    rs = conn.createStatement().executeQuery(query);
+
+    assertTrue(rs.next());
+    assertEquals("pk0001", rs.getString(1));
+    assertEquals("0003", rs.getString(2));
+    document1 = (BsonDocument) rs.getObject(3);
+
+    String updatedJson = getJsonString("json/sample_updated_01.json");
+    assertEquals(RawBsonDocument.parse(updatedJson), document1);
+
+    assertTrue(rs.next());
+    assertEquals("pk1010", rs.getString(1));
+    assertEquals("1010", rs.getString(2));
+    BsonDocument document2 = (BsonDocument) rs.getObject(3);
+
+    updatedJson = getJsonString("json/sample_updated_02.json");
+    assertEquals(RawBsonDocument.parse(updatedJson), document2);
+
+    assertTrue(rs.next());
+    assertEquals("pk1011", rs.getString(1));
+    assertEquals("1011", rs.getString(2));
+    BsonDocument document3 = (BsonDocument) rs.getObject(3);
+
+    updatedJson = getJsonString("json/sample_updated_03.json");
+    assertEquals(RawBsonDocument.parse(updatedJson), document3);
+
+    assertFalse(rs.next());
+  }
+
+  private static void assertReturnedRowResult(PreparedStatement stmt,
+                                              Connection conn,
+                                              String tableName,
+                                              String jsonPath,
+                                              boolean success)
+          throws SQLException, IOException {
+    Pair<Integer, Result> resultPair =
+            stmt.unwrap(PhoenixPreparedStatement.class).executeUpdateReturnRow();
+    assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
+    Result result = resultPair.getSecond();
+    PTable table = conn.unwrap(PhoenixConnection.class).getTable(tableName);
+
+    Cell cell = result.getColumnLatestCell(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+            table.getColumns().get(2).getColumnQualifierBytes());
+    assertEquals(RawBsonDocument.parse(getJsonString(jsonPath)),
+            PBson.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
+                    cell.getValueLength()));
   }
 
   private static void validateIndexUsed(PreparedStatement ps, String indexName)

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
@@ -32,11 +32,11 @@ import java.util.Collection;
 import java.util.Properties;
 
 import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.schema.PTable;
+import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PBson;
 import org.apache.phoenix.schema.types.PDouble;
 import org.bson.BsonArray;
@@ -494,13 +494,13 @@ public class Bson4IT extends ParallelStatsDisabledIT {
                                               String jsonPath,
                                               boolean success)
           throws SQLException, IOException {
-    Pair<Integer, Result> resultPair =
+    Pair<Integer, Tuple> resultPair =
             stmt.unwrap(PhoenixPreparedStatement.class).executeUpdateReturnRow();
     assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
-    Result result = resultPair.getSecond();
+    Tuple result = resultPair.getSecond();
     PTable table = conn.unwrap(PhoenixConnection.class).getTable(tableName);
 
-    Cell cell = result.getColumnLatestCell(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+    Cell cell = result.getValue(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
             table.getColumns().get(2).getColumnQualifierBytes());
     assertEquals(RawBsonDocument.parse(getJsonString(jsonPath)),
             PBson.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
@@ -21,8 +21,13 @@ import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -33,21 +38,32 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.util.VersionInfo;
 import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
+import org.apache.phoenix.jdbc.PhoenixStatement;
 import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTableKey;
+import org.apache.phoenix.schema.types.PBson;
+import org.apache.phoenix.schema.types.PDouble;
+import org.apache.phoenix.schema.types.PInteger;
+import org.apache.phoenix.schema.types.PVarchar;
 import org.apache.phoenix.util.EncodedColumnsUtil;
 import org.apache.phoenix.util.PhoenixRuntime;
 import org.apache.phoenix.util.PropertiesUtil;
+import org.bson.BsonDocument;
+import org.bson.RawBsonDocument;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -116,6 +132,124 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
         assertEquals(0, actualReturnValue);
 
         conn.close();
+    }
+
+    @Test
+    public void testReturnRowResult() throws Exception {
+        Assume.assumeTrue("Set correct result to RegionActionResult on hbase versions " +
+                "2.4.18+, 2.5.9+, and 2.6.0+", isSetCorrectResultEnabledOnHBase());
+
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        String sample1 = getJsonString("json/sample_01.json");
+        String sample2 = getJsonString("json/sample_02.json");
+        BsonDocument bsonDocument1 = RawBsonDocument.parse(sample1);
+        BsonDocument bsonDocument2 = RawBsonDocument.parse(sample2);
+        try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+            conn.setAutoCommit(true);
+            String tableName = generateUniqueName();
+            String ddl = " create table " + tableName +
+                    "(PK VARCHAR PRIMARY KEY, COUNTER1 DOUBLE, COUNTER2 VARCHAR, COL3 BSON, COL4 " +
+                    "INTEGER)";
+            conn.createStatement().execute(ddl);
+            createIndex(conn, tableName);
+
+            String upsertSql = "UPSERT INTO " + tableName + " (PK, COUNTER1, COL3, COL4) VALUES(" +
+                    "'pk000', 1011.202, ?, 123) ON DUPLICATE KEY IGNORE";
+            validateReturnedRowAfterUpsert(conn, upsertSql, tableName, 1011.202, null, true,
+                    bsonDocument1, bsonDocument1, 123);
+
+            upsertSql =
+                    "UPSERT INTO " + tableName + " (PK, COUNTER1) VALUES('pk000', 0) ON DUPLICATE"
+                            + " KEY IGNORE";
+            validateReturnedRowAfterUpsert(conn, upsertSql, tableName, 1011.202, null, false,
+                    null, bsonDocument1, 123);
+
+            upsertSql =
+                    "UPSERT INTO " + tableName +
+                            " (PK, COUNTER1, COUNTER2) VALUES('pk000', 234, 'col2_000')";
+            validateReturnedRowAfterUpsert(conn, upsertSql, tableName, 234d, "col2_000", true,
+                    null, null, null);
+
+            upsertSql = "UPSERT INTO " + tableName
+                    + " (PK) VALUES('pk000') ON DUPLICATE KEY UPDATE "
+                    + "COUNTER1 = CASE WHEN COUNTER1 < 2000 THEN COUNTER1 + 1999.99 ELSE COUNTER1"
+                    + " END, "
+                    + "COUNTER2 = CASE WHEN COUNTER2 = 'col2_000' THEN 'col2_001' ELSE COUNTER2 "
+                    + "END, "
+                    + "COL3 = ?, "
+                    + "COL4 = 234";
+            validateReturnedRowAfterUpsert(conn, upsertSql, tableName, 2233.99, "col2_001", true,
+                    bsonDocument2, bsonDocument2, 234);
+
+            upsertSql = "UPSERT INTO " + tableName
+                    + " (PK) VALUES('pk000') ON DUPLICATE KEY UPDATE "
+                    + "COUNTER1 = CASE WHEN COUNTER1 < 2000 THEN COUNTER1 + 1999.99 ELSE COUNTER1"
+                    + " END,"
+                    + "COUNTER2 = CASE WHEN COUNTER2 = 'col2_000' THEN 'col2_001' ELSE COUNTER2 "
+                    + "END";
+            validateReturnedRowAfterUpsert(conn, upsertSql, tableName, 2233.99, "col2_001", false
+                    , null, bsonDocument2, 234);
+        }
+    }
+
+    private static void validateReturnedRowAfterUpsert(Connection conn,
+                                                       String upsertSql,
+                                                       String tableName,
+                                                       Double col1,
+                                                       String col2,
+                                                       boolean success,
+                                                       BsonDocument inputDoc,
+                                                       BsonDocument expectedDoc,
+                                                       Integer col4)
+            throws SQLException {
+        final Pair<Integer, Result> resultPair;
+        if (inputDoc != null) {
+            PhoenixPreparedStatement ps =
+                    conn.prepareStatement(upsertSql).unwrap(PhoenixPreparedStatement.class);
+            ps.setObject(1, inputDoc);
+            resultPair = ps.executeUpdateReturnRow();
+        } else {
+            resultPair = conn.createStatement().unwrap(PhoenixStatement.class)
+                    .executeUpdateReturnRow(upsertSql);
+        }
+        assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
+        Result result = resultPair.getSecond();
+        PTable table = conn.unwrap(PhoenixConnection.class).getTable(tableName);
+
+        Cell cell = result.getColumnLatestCell(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+                table.getColumns().get(1).getColumnQualifierBytes());
+        assertEquals(col1,
+                PDouble.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
+                        cell.getValueLength()));
+        cell = result.getColumnLatestCell(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+                table.getColumns().get(2).getColumnQualifierBytes());
+        if (col2 != null) {
+            assertEquals(col2,
+                    PVarchar.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
+                            cell.getValueLength()));
+        } else {
+            assertNull(cell);
+        }
+
+        cell = result.getColumnLatestCell(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+                table.getColumns().get(3).getColumnQualifierBytes());
+        if (expectedDoc != null) {
+            assertEquals(expectedDoc,
+                    PBson.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
+                            cell.getValueLength()));
+        } else {
+            assertNull(cell);
+        }
+
+        cell = result.getColumnLatestCell(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+                table.getColumns().get(4).getColumnQualifierBytes());
+        if (col4 != null) {
+            assertEquals(col4,
+                    PInteger.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
+                            cell.getValueLength()));
+        } else {
+            assertNull(cell);
+        }
     }
 
     @Test
@@ -642,5 +776,10 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
             return patchVersion >= 18;
         }
         return patchVersion >= 9;
+    }
+
+    private static String getJsonString(String jsonFilePath) throws IOException {
+        URL fileUrl = OnDuplicateKey2IT.class.getClassLoader().getResource(jsonFilePath);
+        return FileUtils.readFileToString(new File(fileUrl.getFile()), Charset.defaultCharset());
     }
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
@@ -177,7 +177,7 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
                             + " (PK1, PK2, PK3, COUNTER1, COUNTER2) VALUES('pk000', -123.98, "
                             + "'pk003', 234, 'col2_000')";
             validateReturnedRowAfterUpsert(conn, upsertSql, tableName, 234d, "col2_000", true,
-                    null, null, null);
+                    null, bsonDocument1, 123);
 
             upsertSql = "UPSERT INTO " + tableName
                     + " (PK1, PK2, PK3) VALUES('pk000', -123.98, 'pk003') ON DUPLICATE KEY UPDATE "


### PR DESCRIPTION
Jira: PHOENIX-7398

Phoenix supports Atomic Conditional Upserts with ON DUPLICATE KEY clause, allowing clients to either ignore the update if the row with the given primary key(s) already exist or conditionally update the row with the given primary key(s). Phoenix also supports returning 0 or 1 as updated status code for the given Atomic/Conditional Upserts, where 0 represents no updates to the row and 1 represents the updated row (when the condition is satisfied by the atomic upsert).

While standard JDBC APIs support Upserts with the status code returned as integer values 0 or 1, some client applications also require returning the current row state back to the client depending on whether the row is successfully updated. If the condition is satisfied by the atomic upsert and the row is updated, the client application should be able to get the updated row status as HBase Result object. Similarly, if the condition is not satisfied for the given atomic upsert and therefore, row is not updated, the client application should be able to get the old/current row status as HBase Result object.

This support is somewhat similar in nature to what HBase provides for Increment and Append mutations. Both operations return updated row as Result object. For instance,

```
/**
 * Appends values to one or more columns within a single row.
 * <p>
 * This operation guaranteed atomicity to readers. Appends are done under a single row lock, so
 * write operations to a row are synchronized, and readers are guaranteed to see this operation
 * fully completed.
 * @param append object that specifies the columns and values to be appended
 * @throws IOException e
 * @return values of columns after the append operation (maybe null)
 */
default Result append(final Append append) throws IOException {
```

HBase does not provide API to return row state for atomic updates with Put and Delete mutations. HBase API checkAndMutate() also supports returning Result for Append and Increment mutations only, not for Put and Delete mutations.

Phoenix supports batchMutate() with Put mutation(s) by making it Atomic. Hence, for client applications using Phoenix provided atomic upserts, it would be really beneficial to also provide new API at PhoenixStatement and PhoenixPreparedStatement layer that can return the row as Result object back to the client.

The proposed API signature:

```
/**
 * Executes the given SQL statement similar to JDBC API executeUpdate() but also returns the
 * updated or non-updated row as Result object back to the client. This must be used with
 * auto-commit Connection. This makes the operation atomic.
 * If the row is successfully updated, return the updated row, otherwise if the row
 * cannot be updated, return non-updated row.
 *
 * @param sql The SQL DML statement, UPSERT or DELETE for Phoenix.
 * @return The pair of int and Tuple, where int represents value 1 for successful row
 * update and 0 for non-successful row update, and Tuple represents the state of the row.
 * @throws SQLException If the statement cannot be executed.
 */
public Pair<Integer, Tuple> executeUpdateReturnRow(String sql) throws SQLException {
```