### PR TITLE
PHOENIX-7387: SnapshotScanner's next method is ignoring the boolean value from hbase's nextRaw method

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/SnapshotScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/iterate/SnapshotScanner.java
@@ -160,14 +160,14 @@ public class SnapshotScanner extends AbstractClientScanner {
   @Override
   public Result next() throws IOException {
     values.clear();
-    scanner.nextRaw(values);
+    boolean hasMore = scanner.nextRaw(values);
     statisticsCollector.collectStatistics(values);
-    if (values.isEmpty()) {
+    if (hasMore || !values.isEmpty()) {
+      return Result.create(values);
+    } else {
       //we are done
       return null;
     }
-
-    return Result.create(values);
   }
 
   @Override


### PR DESCRIPTION
PHOENIX-7387  SnapshotScanner's next method is ignoring the boolean value from hbase's nextRaw method

The pr include the following changes
1) Now we are using the return type of hbase scanner, which is a boolean value to decide what resultset we should pass to the caller.

Tested in our local setup.
