### PR TITLE
PHOENIX-7411 Atomic Delete: PhoenixStatement API to return row if single row is atomically deleted

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -495,6 +495,10 @@ public class MutationState implements SQLCloseable {
         return this.result;
     }
 
+    public void clearResult() {
+        this.result = null;
+    }
+
     private MultiRowMutationState getLastMutationBatch(Map<TableRef, List<MultiRowMutationState>> mutations, TableRef tableRef) {
         List<MultiRowMutationState> mutationBatches = mutations.get(tableRef);
         if (mutationBatches == null || mutationBatches.isEmpty()) {
@@ -839,6 +843,14 @@ public class MutationState implements SQLCloseable {
                     // Set the source of operation attribute.
                     for (Mutation mutation: rowMutations) {
                         mutation.setAttribute(SOURCE_OPERATION_ATTRIB, sourceOfDeleteBytes);
+                    }
+                }
+                if (this.returnResult != null) {
+                    if (this.returnResult == ReturnResult.ROW) {
+                        for (Mutation mutation : rowMutations) {
+                            mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
+                                    PhoenixIndexBuilderHelper.RETURN_RESULT_ROW);
+                        }
                     }
                 }
                 // The DeleteCompiler already generates the deletes for indexes, so no need to do it again

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -647,13 +647,16 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                         lastState.getUpdateCount());
                                 Result result = null;
                                 if (connection.getAutoCommit()) {
-                                    state.setReturnResult(returnResult);
+                                    if (isSingleRowUpdate(isUpsert, isDelete, plan)) {
+                                        state.setReturnResult(returnResult);
+                                    }
                                     connection.commit();
                                     if (isAtomicUpsert) {
                                         lastUpdateCount = connection.getMutationState()
                                                 .getNumUpdatedRowsForAutoCommit();
                                     }
                                     result = connection.getMutationState().getResult();
+                                    connection.getMutationState().clearResult();
                                 }
                                 setLastQueryPlan(null);
                                 setLastUpdateCount(lastUpdateCount);
@@ -753,6 +756,18 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
             Throwables.propagate(e);
             throw new IllegalStateException(); // Can't happen as Throwables.propagate() always throws
         }
+    }
+
+    private static boolean isSingleRowUpdate(boolean isUpsert, boolean isDelete,
+                                             MutationPlan plan) {
+        boolean isSingleRowUpdate = false;
+        if (isUpsert) {
+            isSingleRowUpdate = true;
+        } else if (isDelete) {
+            isSingleRowUpdate =
+                    plan.getContext().getScanRanges().isPointLookup();
+        }
+        return isSingleRowUpdate;
     }
 
     protected static interface CompilableStatement extends BindableStatement {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -647,7 +647,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                         lastState.getUpdateCount());
                                 Result result = null;
                                 if (connection.getAutoCommit()) {
-                                    if (isSingleRowUpdate(isUpsert, isDelete, plan)) {
+                                    if (isPointLookupPlan(isUpsert, isDelete, plan)) {
                                         state.setReturnResult(returnResult);
                                     }
                                     connection.commit();
@@ -758,7 +758,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         }
     }
 
-    private static boolean isSingleRowUpdate(boolean isUpsert, boolean isDelete,
+    private static boolean isPointLookupPlan(boolean isUpsert, boolean isDelete,
                                              MutationPlan plan) {
         boolean isSingleRowUpdate = false;
         if (isUpsert) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -647,7 +647,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                         lastState.getUpdateCount());
                                 Result result = null;
                                 if (connection.getAutoCommit()) {
-                                    if (isPointLookupPlan(isUpsert, isDelete, plan)) {
+                                    if (isSingleRowUpdatePlan(isUpsert, isDelete, plan)) {
                                         state.setReturnResult(returnResult);
                                     }
                                     connection.commit();
@@ -758,14 +758,13 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         }
     }
 
-    private static boolean isPointLookupPlan(boolean isUpsert, boolean isDelete,
-                                             MutationPlan plan) {
+    private static boolean isSingleRowUpdatePlan(boolean isUpsert, boolean isDelete,
+                                                 MutationPlan plan) {
         boolean isSingleRowUpdate = false;
         if (isUpsert) {
             isSingleRowUpdate = true;
         } else if (isDelete) {
-            isSingleRowUpdate =
-                    plan.getContext().getScanRanges().isPointLookup();
+            isSingleRowUpdate = plan.getContext().getScanRanges().getPointLookupCount() == 1;
         }
         return isSingleRowUpdate;
     }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -198,37 +199,85 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
                     + "END";
             validateReturnedRowAfterUpsert(conn, upsertSql, tableName, 2233.99, "col2_001", false
                     , null, bsonDocument2, 234);
+
+            PhoenixPreparedStatement ps =
+                    conn.prepareStatement(
+                            "DELETE FROM " + tableName + " WHERE PK1 = ? AND PK2 " +
+                                    "= ? AND PK3 = ?").unwrap(PhoenixPreparedStatement.class);
+            ps.setString(1, "pk000");
+            ps.setDouble(2, -123.98);
+            ps.setString(3, "pk003");
+            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", true,
+                    bsonDocument2, 234);
+            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", false,
+                    bsonDocument2, 234);
+
+            upsertSql =
+                    "UPSERT INTO " + tableName
+                            + " (PK1, PK2, PK3, COUNTER1, COUNTER2) VALUES('pk001', 122.34, "
+                            + "'pk004', 23, 'col2_001')";
+            conn.createStatement().execute(upsertSql);
+            upsertSql =
+                    "UPSERT INTO " + tableName
+                            + " (PK1, PK2, PK3, COUNTER1, COUNTER2) VALUES('pk001', 122.34, "
+                            + "'pk005', 23, 'col2_001')";
+            conn.createStatement().execute(upsertSql);
+            upsertSql =
+                    "UPSERT INTO " + tableName
+                            + " (PK1, PK2, PK3, COUNTER1, COUNTER2) VALUES('pk003', 122.34, "
+                            + "'pk005', 23, 'col2_001')";
+            conn.createStatement().execute(upsertSql);
+
+            ps = conn.prepareStatement(
+                    "DELETE FROM " + tableName + " WHERE PK1 = ? AND PK2 = ?")
+                    .unwrap(PhoenixPreparedStatement.class);
+            ps.setString(1, "pk001");
+            ps.setDouble(2, 122.34);
+            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", false,
+                    bsonDocument2, 234);
+
+            ps = conn.prepareStatement(
+                            "DELETE FROM " + tableName).unwrap(PhoenixPreparedStatement.class);
+            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", false,
+                    bsonDocument2, 234);
+
+            ResultSet rs = conn.createStatement().executeQuery("SELECT * FROM " + tableName);
+            assertFalse(rs.next());
         }
     }
 
-    private static void validateReturnedRowAfterUpsert(Connection conn,
-                                                       String upsertSql,
+    private static void validateReturnedRowAfterDelete(Connection conn,
+                                                       PhoenixPreparedStatement ps,
                                                        String tableName,
                                                        Double col1,
                                                        String col2,
                                                        boolean success,
-                                                       BsonDocument inputDoc,
                                                        BsonDocument expectedDoc,
                                                        Integer col4)
             throws SQLException {
-        final Pair<Integer, Tuple> resultPair;
-        if (inputDoc != null) {
-            PhoenixPreparedStatement ps =
-                    conn.prepareStatement(upsertSql).unwrap(PhoenixPreparedStatement.class);
-            ps.setObject(1, inputDoc);
-            resultPair = ps.executeUpdateReturnRow();
-        } else {
-            resultPair = conn.createStatement().unwrap(PhoenixStatement.class)
-                    .executeUpdateReturnRow(upsertSql);
-        }
-        assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
+        final Pair<Integer, Tuple> resultPair = ps.executeUpdateReturnRow();
         ResultTuple result = (ResultTuple) resultPair.getSecond();
+
         PTable table = conn.unwrap(PhoenixConnection.class).getTable(tableName);
 
+        if (!success && result.getResult() == null) {
+            return;
+        }
         Cell cell =
                 result.getResult()
                         .getColumnLatestCell(table.getColumns().get(3).getFamilyName().getBytes(),
                                 table.getColumns().get(3).getColumnQualifierBytes());
+        if (!success) {
+            assertNull(cell);
+            return;
+        }
+
+        validateReturnedRowResult(col1, col2, expectedDoc, col4, table, cell, result);
+    }
+
+    private static void validateReturnedRowResult(Double col1, String col2,
+                                                  BsonDocument expectedDoc, Integer col4,
+                                                  PTable table, Cell cell, ResultTuple result) {
         ImmutableBytesPtr ptr = new ImmutableBytesPtr();
         table.getRowKeySchema().iterator(cell.getRowArray(), ptr, 1);
         assertEquals("pk000",
@@ -279,6 +328,37 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
         } else {
             assertNull(cell);
         }
+    }
+
+    private static void validateReturnedRowAfterUpsert(Connection conn,
+                                                       String upsertSql,
+                                                       String tableName,
+                                                       Double col1,
+                                                       String col2,
+                                                       boolean success,
+                                                       BsonDocument inputDoc,
+                                                       BsonDocument expectedDoc,
+                                                       Integer col4)
+            throws SQLException {
+        final Pair<Integer, Tuple> resultPair;
+        if (inputDoc != null) {
+            PhoenixPreparedStatement ps =
+                    conn.prepareStatement(upsertSql).unwrap(PhoenixPreparedStatement.class);
+            ps.setObject(1, inputDoc);
+            resultPair = ps.executeUpdateReturnRow();
+        } else {
+            resultPair = conn.createStatement().unwrap(PhoenixStatement.class)
+                    .executeUpdateReturnRow(upsertSql);
+        }
+        assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
+        ResultTuple result = (ResultTuple) resultPair.getSecond();
+        PTable table = conn.unwrap(PhoenixConnection.class).getTable(tableName);
+
+        Cell cell =
+                result.getResult()
+                        .getColumnLatestCell(table.getColumns().get(3).getFamilyName().getBytes(),
+                                table.getColumns().get(3).getColumnQualifierBytes());
+        validateReturnedRowResult(col1, col2, expectedDoc, col4, table, cell, result);
     }
 
     @Test


### PR DESCRIPTION
Jira: PHOENIX-7411

PHOENIX-7398 introduces new PhoenixStatement API to return row for Atomic/Conditional Upserts. Phoenix already supports Upserts as Atomic operation by using ON DUPLICATE KEY clause. However, Deletes are not supported as atomic and single Delete query can also delete multiple rows based on the WHERE clause used.

HBase does not provide API to return row state for atomic updates with Put and Delete mutations. HBase API checkAndMutate() also supports returning Result for Append and Increment mutations only, not for Put and Delete mutations.

The purpose of this Jira is to introduce support for atomic delete of single row that can return the row only if it existed before executing the Delete mutation. If the row is already deleted, the API support is not expected to return any row. For single row delete to be atomic, IndexRegionObserver needs to take row lock for to be deleted row and also scan the row, similar to Atomic Put mutation(s).

 

PhoenixStatement API signature is same as of PHOENIX-7398:

```
/**
 * Executes the given SQL statement similar to JDBC API executeUpdate() but also returns the
 * updated or non-updated row as Result object back to the client. This must be used with
 * auto-commit Connection. This makes the operation atomic.
 * If the row is successfully updated, return the updated row, otherwise if the row
 * cannot be updated, return non-updated row.
 *
 * @param sql The SQL DML statement, UPSERT or DELETE for Phoenix.
 * @return The pair of int and Tuple, where int represents value 1 for successful row
 * update and 0 for non-successful row update, and Tuple represents the state of the row.
 * @throws SQLException If the statement cannot be executed.
 */
public Pair<Integer, Tuple> executeUpdateReturnRow(String sql) throws SQLException {
```