### PR TITLE
PHOENIX-7409: Fix CDC data table salt bucket bug

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -681,7 +681,7 @@ public class MutationState implements SQLCloseable {
                 };
                 ImmutableBytesPtr key = new ImmutableBytesPtr(maintainer.buildRowKey(
                         getter, ptr, null, null, mutationTimestamp));
-                PRow row = table.newRow(
+                PRow row = index.newRow(
                         connection.getKeyValueBuilder(), mutationTimestamp, key, false);
                 row.delete();
                 indexMutations.addAll(row.toRowMutations());

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/index/CDCTableInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/index/CDCTableInfo.java
@@ -164,7 +164,6 @@ public class CDCTableInfo {
         if (cdcDataTableRef.getTable().isImmutableRows() &&
                 cdcDataTableRef.getTable().getImmutableStorageScheme() ==
                         PTable.ImmutableStorageScheme.SINGLE_CELL_ARRAY_WITH_OFFSETS) {
-
             List<ColumnRef> dataColumns = new ArrayList<ColumnRef>();
             PTable table = cdcDataTableRef.getTable();
             for (PColumn column : table.getColumns()) {

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
@@ -1380,10 +1380,6 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
                             // CDC Index needs two delete markers one for deleting the index row,
                             // and the other for referencing the data table delete mutation with
                             // the right index row key, that is, the index row key starting with ts
-                            Put cdcDataRowState = new Put(currentDataRowState.getRow());
-                            cdcDataRowState.addColumn(indexMaintainer.getDataEmptyKeyValueCF(),
-                                    indexMaintainer.getEmptyKeyValueQualifierForDataTable(), ts,
-                                    ByteUtil.EMPTY_BYTE_ARRAY);
                             indexMutations.add(IndexRegionObserver.getDeleteIndexMutation(
                                     currentDataRowState, indexMaintainer, ts, rowKeyPtr));
                         }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -1038,7 +1038,6 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
                         context.indexUpdates.put(hTableInterfaceReference,
                                 new Pair<Mutation, byte[]>(getDeleteIndexMutation(cdcDataRowState,
                                         indexMaintainer, ts, rowKeyPtr), rowKeyPtr.get()));
-
                     }
                 }
             }


### PR DESCRIPTION
Fix the bug that is causing incorrect salt bucket number to be used for mutations generated in CDC index.

- Revamped the time range test and included the coverage for special CDC DF markers. Also refactored some debug code.
- Fix issues with debug logging code
- Uncomment debug code to help diagnose the occasional flappers we are seeing