### PR TITLE
PHOENIX-6982 Exclude Maven descriptors from shaded JARs

### DIFF
--- a/phoenix-client-parent/pom.xml
+++ b/phoenix-client-parent/pom.xml
@@ -76,6 +76,7 @@
               <filter>
                 <artifact>*:*</artifact>
                 <excludes>
+                  <exclude>META-INF/maven/**</exclude>
                   <exclude>META-INF/*.SF</exclude>
                   <exclude>META-INF/*.DSA</exclude>
                   <exclude>META-INF/*.RSA</exclude>

--- a/phoenix-mapreduce-byo-shaded-hbase/pom.xml
+++ b/phoenix-mapreduce-byo-shaded-hbase/pom.xml
@@ -76,6 +76,7 @@
               <filter>
                 <artifact>*:*</artifact>
                 <excludes>
+                  <exclude>META-INF/maven/**</exclude>
                   <exclude>META-INF/*.SF</exclude>
                   <exclude>META-INF/*.DSA</exclude>
                   <exclude>META-INF/*.RSA</exclude>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -78,6 +78,7 @@
               <filter>
                 <artifact>*:*</artifact>
                 <excludes>
+                  <exclude>META-INF/maven/**</exclude>
                   <exclude>META-INF/*.SF</exclude>
                   <exclude>META-INF/*.DSA</exclude>
                   <exclude>META-INF/*.RSA</exclude>


### PR DESCRIPTION
These descriptors are included in the dependencies, from which the shaded JARs are compiled, but they do not really describe the contents of those JARs - instead, they are information about *their* transitive dependencies. These descriptors would be included in the shaded JAR and misrepresent the actual contents of the JAR. Also, multiple dependencies may include the same descriptor from different versions of a particular transitive dependency, and the Shade plugin will pick one at random to include in the shaded JAR. Usually the one picked will be from a different version than we actually include in the JAR. For example, for `jackson-databind` we depend on version 2.12.6, but the Maven descriptor in the shaded JAR would be from version 2.4.0.

As an additional concern, these descriptors would confuse security scanners, which would flag the JAR as including an old, vulnerable version of a dependency even if that's not actually true.