### PR TITLE
PHOENIX-7418 SystemExitRule errors out because of SecurityManager dep…

### DIFF
--- a/phoenix-core/src/it/resources/scripts/execute_query.sh
+++ b/phoenix-core/src/it/resources/scripts/execute_query.sh
@@ -37,6 +37,7 @@ mvn -B dependency:copy -Dartifact=${client_group_id}:${client_artifact_id}:${cli
 -DoutputDirectory=$tmp_dir
 
 phoenix_client_jar=$tmp_dir/${client_artifact_id}-${client_version}.jar
-java -cp ".:$phoenix_client_jar" sqlline.SqlLine -d org.apache.phoenix.jdbc.PhoenixDriver \
--u jdbc:phoenix:$zk_url -n none -p none --color=false --fastConnect=true --outputformat=csv \
+java -cp ".:$phoenix_client_jar" "-Djava.security.manager=allow" sqlline.SqlLine \
+-d org.apache.phoenix.jdbc.PhoenixDriver -u jdbc:phoenix:$zk_url -n none -p none \
+--color=false --fastConnect=true --outputformat=csv \
 --silent=true --verbose=false --isolation=TRANSACTION_READ_COMMITTED --run=$sqlfile &> $resultfile

--- a/phoenix-core/src/test/java/org/apache/phoenix/SystemExitRule.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/SystemExitRule.java
@@ -20,6 +20,8 @@ package org.apache.phoenix;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test rule that prevents System.exit / JVM exit to error out the test runner, which manages
@@ -28,6 +30,7 @@ import org.junit.runners.model.Statement;
  */
 public class SystemExitRule implements TestRule {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemExitRule.class);
     private static final SecurityManager SECURITY_MANAGER = new TestSecurityManager();
 
     @Override
@@ -38,8 +41,15 @@ public class SystemExitRule implements TestRule {
                 try {
                     System.setSecurityManager(SECURITY_MANAGER);
                     s.evaluate();
+                } catch (UnsupportedOperationException e) {
+                    LOGGER.warn("Was unable to set SecurityManager, JVM exits in tests will not be"
+                            + "handled correctly ", e);
                 } finally {
-                    System.setSecurityManager(null);
+                    try {
+                        System.setSecurityManager(null);
+                    } catch (UnsupportedOperationException e) {
+                        //We have logged a warning above already
+                    }
                 }
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,10 @@
     </phoenix-surefire.jdk11.tuning.flags>
     <phoenix-surefire.jdk17.flags>--add-opens java.base/jdk.internal.util.random=ALL-UNNAMED</phoenix-surefire.jdk17.flags>
     <phoenix-surefire.jdk17.tuning.flags></phoenix-surefire.jdk17.tuning.flags>
+    <!-- This is needed for SystemExitRule to work correctly. This may mask related issues in
+    dependencies -->
+    <phoenix-surefire.jdk21.flags>-Djava.security.manager=allow</phoenix-surefire.jdk21.flags>
+
     <!-- Surefire argLine defaults for Linux + JDK8 -->
     <argLine>${phoenix-surefire.argLine} ${phoenix-surefire.jdk8.tuning.flags} @{jacocoArgLine}</argLine>
 
@@ -2159,11 +2163,25 @@
     <profile>
       <id>build-with-jdk17</id>
       <activation>
-        <jdk>[17,)</jdk>
+        <jdk>[17,21)</jdk>
       </activation>
       <properties>
         <argLine>${phoenix-surefire.jdk11.flags}
           ${phoenix-surefire.jdk17.flags}
+          ${phoenix-surefire.jdk17.tuning.flags}
+          ${phoenix-surefire.argLine}
+          @{jacocoArgLine}</argLine>
+      </properties>
+    </profile>
+    <profile>
+      <id>build-with-jdk21</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <properties>
+        <argLine>${phoenix-surefire.jdk11.flags}
+          ${phoenix-surefire.jdk17.flags}
+          ${phoenix-surefire.jdk21.flags}
           ${phoenix-surefire.jdk17.tuning.flags}
           ${phoenix-surefire.argLine}
           @{jacocoArgLine}</argLine>


### PR DESCRIPTION
…recation / removal

run tests with -Djava.security.manager=allow
Catch and log SecurityManager exceptions in SystemExitRule