### PR TITLE
PHOENIX-7432 getTable for PHYSICAL_TABLE link should use common utility

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -1572,11 +1572,19 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                     // in Phoenix, hence there is no point of calling getTable().
                     if (!famName.getString().startsWith(MetaDataUtil.VIEW_INDEX_TABLE_PREFIX)
                         && indexType != IndexType.LOCAL) {
-                        parentTable = doGetTable(null,
-                            SchemaUtil.getSchemaNameFromFullName(famName.getBytes())
-                                .getBytes(StandardCharsets.UTF_8),
-                            SchemaUtil.getTableNameFromFullName(famName.getBytes())
-                                .getBytes(StandardCharsets.UTF_8), clientTimeStamp, clientVersion);
+                        try {
+                            parentTable = doGetTable(null,
+                                SchemaUtil.getSchemaNameFromFullName(famName.getBytes())
+                                    .getBytes(StandardCharsets.UTF_8),
+                                SchemaUtil.getTableNameFromFullName(famName.getBytes())
+                                    .getBytes(StandardCharsets.UTF_8), clientTimeStamp,
+                                clientVersion);
+                        } catch (SQLException e) {
+                            if (e.getErrorCode()
+                                != SQLExceptionCode.GET_TABLE_ERROR.getErrorCode()) {
+                                throw e;
+                            }
+                        }
                         if (isSystemCatalogSplittable
                             && (parentTable == null || isTableDeleted(parentTable))) {
                             // parentTable is neither in the cache nor in the local region. Since

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -1582,6 +1582,9 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                         } catch (SQLException e) {
                             if (e.getErrorCode()
                                 != SQLExceptionCode.GET_TABLE_ERROR.getErrorCode()) {
+                                LOGGER.error(
+                                    "Error while retrieving getTable for PHYSICAL_TABLE link to {}",
+                                    famName, e);
                                 throw e;
                             }
                         }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -1074,17 +1074,6 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
         arguments.add(arg);
     }
 
-    private PTable getTable(byte[] tenantId, byte[] schemaName, byte[] tableName, long clientTimeStamp, int clientVersion)
-            throws IOException, SQLException {
-        byte[] tableKey = SchemaUtil.getTableKey(tenantId, schemaName, tableName);
-        ImmutableBytesPtr cacheKey = new ImmutableBytesPtr(tableKey);
-        // Get as of latest timestamp so we can detect if we have a newer table that already
-        // exists without making an additional query
-        PTable table = loadTable(env, tableKey, cacheKey, clientTimeStamp, HConstants.LATEST_TIMESTAMP,
-                clientVersion);
-        return table;
-    }
-
     private PName getPhysicalTableName(Region region, byte[] tenantId, byte[] schema, byte[] table, long timestamp) throws IOException {
         byte[] key = SchemaUtil.getTableKey(tenantId, schema, table);
         Scan scan = MetaDataUtil.newTableRowsScan(key, MetaDataProtocol.MIN_TABLE_TIMESTAMP,
@@ -1583,8 +1572,11 @@ TABLE_FAMILY_BYTES, TABLE_SEQ_NUM_BYTES);
                     // in Phoenix, hence there is no point of calling getTable().
                     if (!famName.getString().startsWith(MetaDataUtil.VIEW_INDEX_TABLE_PREFIX)
                         && indexType != IndexType.LOCAL) {
-                        parentTable = getTable(null, SchemaUtil.getSchemaNameFromFullName(famName.getBytes()).getBytes(StandardCharsets.UTF_8),
-                                SchemaUtil.getTableNameFromFullName(famName.getBytes()).getBytes(StandardCharsets.UTF_8), clientTimeStamp, clientVersion);
+                        parentTable = doGetTable(null,
+                            SchemaUtil.getSchemaNameFromFullName(famName.getBytes())
+                                .getBytes(StandardCharsets.UTF_8),
+                            SchemaUtil.getTableNameFromFullName(famName.getBytes())
+                                .getBytes(StandardCharsets.UTF_8), clientTimeStamp, clientVersion);
                         if (isSystemCatalogSplittable
                             && (parentTable == null || isTableDeleted(parentTable))) {
                             // parentTable is neither in the cache nor in the local region. Since


### PR DESCRIPTION
Jira: PHOENIX-7432

We have seen large GC spikes when some views under the same table -> view hierarchy get dropped concurrently. Upon analyzing in detail (@jpisaac's heap dump analysis), we found that multiple drop view threads are busy scanning the same table row for PHYSICAL_TABLE link. This recursive getTable is introduced by PHOENIX-6247 logical-physical table separation. We have also fixed a bug that has caused all active handlers on SYSTEM.CATALOG regionserver to get occupied due to recursive getTable call for view index table that does not exist in SYSTEM.CATALOG, we have fixed it with PHOENIX-7369.

However, with the current analysis, it is clear that getTable is trying to scan large row for the given table (family name for the PHYSICAL_TABLE link). Specifically, multiple threads can hold large num of Cells if the row is bigger and this can mean that GC is not able to clean up some of these large objects as they are too many.

We have found one noticeable difference b/ when recursive getTable() on physical link table and getTable() on given table tries to retrive PTable by scanning SYSTEM.CATALOG. getTable() uses a write lock to protect metadata cache update and by doing so it only allows single thread to scan SYSTEM.CATALOG for the given table entry (key: tenant id + schema name + table name). However, when recursive call to physical table link using getTable() has new implementation and it does not use any lock for the given table name and therefore multiple threads can scan SYSTEM.CATALOG rather than single thread doing it so that others can just get the object from metadata cache.

The proposal of this PR is to remove unnecessary getTable() internal implementation that tries to retrieve PTable object without any lock.