### PR TITLE
PHOENIX-7434 Extend atomic support to single row delete with condition on non-pk columns

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/coprocessorclient/BaseScannerRegionObserverConstants.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/coprocessorclient/BaseScannerRegionObserverConstants.java
@@ -58,6 +58,7 @@ public class BaseScannerRegionObserverConstants {
     public static final String TOPN = "_TopN";
     public static final String UNGROUPED_AGG = "_UngroupedAgg";
     public static final String DELETE_AGG = "_DeleteAgg";
+    public static final String SINGLE_ROW_DELETE = "_SingleRowDelete";
     public static final String UPSERT_SELECT_TABLE = "_UpsertSelectTable";
     public static final String UPSERT_SELECT_EXPRS = "_UpsertSelectExprs";
     public static final String DELETE_CQ = "_DeleteCQ";

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/UngroupedAggregateRegionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/UngroupedAggregateRegionScanner.java
@@ -738,10 +738,7 @@ public class UngroupedAggregateRegionScanner extends BaseRegionScanner {
     }
 
     private void annotateAndCommit(UngroupedAggregateRegionObserver.MutationList mutations) throws IOException {
-        annotateDataMutations(mutations, scan);
-        if (isDelete || isUpsert) {
-            annotateDataMutationsWithExternalSchemaId(mutations, scan);
-        }
+        annotateMutations(mutations);
         ungroupedAggregateRegionObserver.commit(region, mutations, indexUUID, blockingMemStoreSize, indexMaintainersPtr, txState,
             targetHTable, useIndexProto, isPKChanging, clientVersionBytes);
         mutations.clear();
@@ -758,15 +755,24 @@ public class UngroupedAggregateRegionScanner extends BaseRegionScanner {
      */
     private Result annotateCommitAndReturnResult(
             UngroupedAggregateRegionObserver.MutationList mutations) throws IOException {
-        annotateDataMutations(mutations, scan);
-        if (isDelete || isUpsert) {
-            annotateDataMutationsWithExternalSchemaId(mutations, scan);
-        }
+        annotateMutations(mutations);
         Result result = ungroupedAggregateRegionObserver.commitWithResultReturned(mutations,
                 indexUUID, indexMaintainersPtr, txState, targetHTable,
                 useIndexProto, clientVersionBytes);
         mutations.clear();
         return result;
+    }
+
+    /**
+     * Annotate the give mutations as per the scan attributes.
+     *
+     * @param mutations The mutations that need to be annotated.
+     */
+    private void annotateMutations(UngroupedAggregateRegionObserver.MutationList mutations) {
+        annotateDataMutations(mutations, scan);
+        if (isDelete || isUpsert) {
+            annotateDataMutationsWithExternalSchemaId(mutations, scan);
+        }
     }
 
     @Override


### PR DESCRIPTION
Jira: PHOENIX-7434

PHOENIX-7411 introduces Atomic Delete support for the single row deletion. It returns result (row) back to the client (using new API) only if the given client initiated Delete operation deleted the row when the row was alive. In the context of atomicity, this means that the delete operation is already idempotent and will continue to be idempotent, however only the client that was able to successfully delete the row by taking lock on the live row (row without delete marker) is the only one that can return the old row result back.

PHOENIX-7411 support includes only single row if the WHERE clause contains only pk columns as single row point lookup plan. However, user can also add additional non-pk columns in the WHERE clause in addition to all pk columns, this also makes the Delete as single row delete only, but due to addition of non-pk columns, server side delete plan is used with auto-commit connections.

The sever side delete plans goes from DeleteCompiler initiating the Scan with attribute "_DeleteAgg" which allows UngroupedAggregateRegionObserver to execute Delete Mutations on the rows read by the UngroupedAggregateRegionScanner. This Mutation is used by IndexRegionObserver to perform the mutation at the server side.

Given that IndexRegionObserver already has the support for atomic single row delete as part of PHOENIX-7411, the proposal for this Jira is to introduce single row delete with condition on non-pk columns such that atomic delete returning the result can be used by UngroupedAggregateRegionObserver and then sent back to DeleteCompiler which can later on be consumed by the PhoenixStatement API similar to PHOENIX-7411.