### PR TITLE
PHOENIX-7468 NPE in SchemaExtractionTool on salted table

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/tool/SchemaExtractionProcessor.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/tool/SchemaExtractionProcessor.java
@@ -517,7 +517,8 @@ public class SchemaExtractionProcessor implements SchemaProcessor {
     private String getColumnInfoStringForTable(PTable table) {
         StringBuilder colInfo = new StringBuilder();
         List<PColumn> columns = table.getBucketNum() == null ? table.getColumns() : table.getColumns().subList(1, table.getColumns().size());
-        List<PColumn> pkColumns = table.getBucketNum() == null ? table.getPKColumns() : table.getPKColumns().subList(1, table.getPKColumns().size());
+        List<PColumn> pkColumns = table.getBucketNum() == null ? table.getPKColumns()
+                : table.getPKColumns().subList(1, table.getPKColumns().size());
 
         return getColumnInfoString(table, colInfo, columns, pkColumns);
     }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/tool/SchemaExtractionProcessor.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/tool/SchemaExtractionProcessor.java
@@ -517,7 +517,7 @@ public class SchemaExtractionProcessor implements SchemaProcessor {
     private String getColumnInfoStringForTable(PTable table) {
         StringBuilder colInfo = new StringBuilder();
         List<PColumn> columns = table.getBucketNum() == null ? table.getColumns() : table.getColumns().subList(1, table.getColumns().size());
-        List<PColumn> pkColumns = table.getBucketNum() == null ? table.getPKColumns() : table.getColumns().subList(1, table.getPKColumns().size());
+        List<PColumn> pkColumns = table.getBucketNum() == null ? table.getPKColumns() : table.getPKColumns().subList(1, table.getPKColumns().size());
 
         return getColumnInfoString(table, colInfo, columns, pkColumns);
     }


### PR DESCRIPTION
A column which is a PK column was incorrectly classified as non PK column and calling `col.getFamilyName().getString()` will cause NPE because familyName is null for PK columns