### PR TITLE
PHOENIX-7473 Eliminating index maintenance for CDC index

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/UncoveredIndexRegionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/UncoveredIndexRegionScanner.java
@@ -303,8 +303,9 @@ public abstract class UncoveredIndexRegionScanner extends BaseRegionScanner {
         if (indexMaintainer.isCDCIndex()) {
             // A CDC index row key is PARTITION_ID() + PHOENIX_ROW_TIMESTAMP() + data row key. The
             // only necessary check is the row timestamp check since the data row key is extracted
-            // from the index row key and PARTITION_ID() changes during region splits and merges
-            if (IndexUtil.getMaxTimestamp(put) == indexTimestamp) {
+            // from the index row key and PARTITION_ID() changes during region splits and merges.
+            // If the scan is a raw scan, even the time check is not necessary for the CDC indexes
+            if (scan.isRaw() || IndexUtil.getMaxTimestamp(put) == indexTimestamp) {
                 return true;
             }
         } else if (indexMaintainer.checkIndexRow(indexRowKey, put)) {
@@ -324,7 +325,8 @@ public abstract class UncoveredIndexRegionScanner extends BaseRegionScanner {
             return true;
         }
         // This is not a valid index row
-        if (indexMaintainer.isAgedEnough(IndexUtil.getMaxTimestamp(put), ageThreshold)) {
+        if (indexMaintainer.isAgedEnough(IndexUtil.getMaxTimestamp(put), ageThreshold)
+                && !indexMaintainer.isCDCIndex()) {
             region.delete(indexMaintainer.createDelete(indexRowKey, IndexUtil.getMaxTimestamp(put),
                     false));
         }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/UncoveredIndexRegionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/UncoveredIndexRegionScanner.java
@@ -301,10 +301,12 @@ public abstract class UncoveredIndexRegionScanner extends BaseRegionScanner {
             put.add(cell);
         }
         if (indexMaintainer.isCDCIndex()) {
-            // A CDC index row key is PARTITION_ID() + PHOENIX_ROW_TIMESTAMP() + data row key. The
-            // only necessary check is the row timestamp check since the data row key is extracted
-            // from the index row key and PARTITION_ID() changes during region splits and merges.
-            // If the scan is a raw scan, even the time check is not necessary for the CDC indexes
+            // A CDC index row key is [view index id] + [tenant id] + PARTITION_ID()
+            // + PHOENIX_ROW_TIMESTAMP() + data row key. The only necessary check is the row
+            // timestamp check since the data row key is extracted from the index row key and
+            // PARTITION_ID() changes during region splits and merges so we cannot check it.
+            // If the scan is a raw scan which is expected to be the case for CDC scans,
+            // even the time check is not necessary
             if (scan.isRaw() || IndexUtil.getMaxTimestamp(put) == indexTimestamp) {
                 return true;
             }


### PR DESCRIPTION
For regular indexes we do index maintenance such that if a data table row is deleted, we also delete the corresponding index row. This is especially needed for covered indexes for correctness as we use the index alone to serve the queries.

For uncovered indexes, this delete is not necessary for correctness but needed for performance reason not to scan deleted rows again and again, and not to attempt to scan the corresponding deleted data table rows. However, none of these reasons are really applicable to CDC indexes. Since CDC index table rows expires quickly we do not really need to delete them. It is also expected that a CDC index row is scanned once.

For CDC indexes we add an extra delete markers for each deleted row to have two delete markers, one with the embedded row timestamp value that is equal to the delete operation timestamp and the other with the embedded row timestamp value that is equal to the latest put operation timestamp of this row. However, we need only the former one for including the delete operation in the correct order.

For the same reasons, we do not need to read repair index rows for CDC indexes either. The read repair is done currently to delete the orphan index rows. These rows happens if index put succeed but the corresponding data put does not. 

