### PR TITLE
PHOENIX-7484 Optimize mutation plan creation for upserts over tenant connection

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
@@ -761,9 +761,9 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
     }
 
     public PTable getTable(PTableKey key) throws SQLException {
-        PTableRef tableRef = getTableRefOptimized(key);
+        PTableRef tableRef = getTableRefNoTNFE(key);
         if (tableRef == null && key.getTenantId() != null) {
-            tableRef = getTableRefOptimized(new PTableKey(null, key.getName()));
+            tableRef = getTableRefNoTNFE(new PTableKey(null, key.getName()));
         }
         if (tableRef == null) {
             return getTableNoCache(key.getName());
@@ -771,8 +771,8 @@ public class PhoenixConnection implements MetaDataMutated, SQLCloseable, Phoenix
         return tableRef.getTable();
     }
 
-    public PTableRef getTableRefOptimized(PTableKey key) {
-        PTableRef tableRef = getQueryServices().getMetaDataCache().getTableRefOptimized(key);
+    public PTableRef getTableRefNoTNFE(PTableKey key) {
+        PTableRef tableRef = getQueryServices().getMetaDataCache().getTableRefNoTNFE(key);
         if (tableRef != null && prune(tableRef.getTable())) {
             return null;
         }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaData.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaData.java
@@ -29,6 +29,7 @@ public interface PMetaData extends MetaDataMutated, Iterable<PTable> {
     }
     public int size();
     public PTableRef getTableRef(PTableKey key) throws TableNotFoundException;
+    public PTableRef getTableRefOptimized(PTableKey key);
     public void pruneTables(Pruner pruner);
     public PFunction getFunction(PTableKey key) throws FunctionNotFoundException;
     public void pruneFunctions(Pruner pruner);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaData.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaData.java
@@ -29,7 +29,7 @@ public interface PMetaData extends MetaDataMutated, Iterable<PTable> {
     }
     public int size();
     public PTableRef getTableRef(PTableKey key) throws TableNotFoundException;
-    public PTableRef getTableRefOptimized(PTableKey key);
+    public PTableRef getTableRefNoTNFE(PTableKey key);
     public void pruneTables(Pruner pruner);
     public PFunction getFunction(PTableKey key) throws FunctionNotFoundException;
     public void pruneFunctions(Pruner pruner);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaDataImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaDataImpl.java
@@ -87,7 +87,7 @@ public class PMetaDataImpl implements PMetaData {
     }
 
     @Override
-    public PTableRef getTableRefOptimized(PTableKey key) {
+    public PTableRef getTableRefNoTNFE(PTableKey key) {
         try {
             return getTableRef(key, true);
         } catch (TableNotFoundException e) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaDataImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaDataImpl.java
@@ -83,6 +83,19 @@ public class PMetaDataImpl implements PMetaData {
 
     @Override
     public PTableRef getTableRef(PTableKey key) throws TableNotFoundException {
+        return getTableRef(key, false);
+    }
+
+    @Override
+    public PTableRef getTableRefOptimized(PTableKey key) {
+        try {
+            return getTableRef(key, true);
+        } catch (TableNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private PTableRef getTableRef(PTableKey key, boolean doNotThrowTableNotFoundException) throws TableNotFoundException {
         if (physicalNameToLogicalTableMap.containsKey(key.getName())) {
             key = physicalNameToLogicalTableMap.get(key.getName());
         }
@@ -90,7 +103,7 @@ public class PMetaDataImpl implements PMetaData {
         if (!key.getName().contains(QueryConstants.SYSTEM_SCHEMA_NAME)) {
             updateGlobalMetric(ref);
         }
-        if (ref == null) {
+        if (ref == null && ! doNotThrowTableNotFoundException) {
             throw new TableNotFoundException(key.getName());
         }
         return ref;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaDataImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PMetaDataImpl.java
@@ -95,7 +95,7 @@ public class PMetaDataImpl implements PMetaData {
         }
     }
 
-    private PTableRef getTableRef(PTableKey key, boolean doNotThrowTableNotFoundException) throws TableNotFoundException {
+    private PTableRef getTableRef(PTableKey key, boolean skipTNFE) throws TableNotFoundException {
         if (physicalNameToLogicalTableMap.containsKey(key.getName())) {
             key = physicalNameToLogicalTableMap.get(key.getName());
         }
@@ -103,7 +103,7 @@ public class PMetaDataImpl implements PMetaData {
         if (!key.getName().contains(QueryConstants.SYSTEM_SCHEMA_NAME)) {
             updateGlobalMetric(ref);
         }
-        if (ref == null && ! doNotThrowTableNotFoundException) {
+        if (ref == null && ! skipTNFE) {
             throw new TableNotFoundException(key.getName());
         }
         return ref;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PSynchronizedMetaData.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PSynchronizedMetaData.java
@@ -83,10 +83,10 @@ public class PSynchronizedMetaData implements PMetaData {
     }
 
     @Override
-    public PTableRef getTableRefOptimized(PTableKey key) {
+    public PTableRef getTableRefNoTNFE(PTableKey key) {
         readWriteLock.readLock().lock();
         try {
-            return delegate.getTableRefOptimized(key);
+            return delegate.getTableRefNoTNFE(key);
         }
         finally {
             readWriteLock.readLock().unlock();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PSynchronizedMetaData.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/PSynchronizedMetaData.java
@@ -83,6 +83,17 @@ public class PSynchronizedMetaData implements PMetaData {
     }
 
     @Override
+    public PTableRef getTableRefOptimized(PTableKey key) {
+        readWriteLock.readLock().lock();
+        try {
+            return delegate.getTableRefOptimized(key);
+        }
+        finally {
+            readWriteLock.readLock().unlock();
+        }
+    }
+
+    @Override
     public void updateResolvedTimestamp(PTable table, long resolvedTimestamp) throws SQLException {
         readWriteLock.writeLock().lock();
         try {

--- a/phoenix-core/src/test/java/org/apache/phoenix/schema/PMetaDataImplTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/schema/PMetaDataImplTest.java
@@ -66,9 +66,9 @@ public class PMetaDataImplTest {
         return table;
     }
 
-    private static PTableRef getTableRefOptimized(PMetaData metaData, String tenantId, String name, TestTimeKeeper timeKeeper) {
+    private static PTableRef getTableRefNoTNFE(PMetaData metaData, String tenantId, String name, TestTimeKeeper timeKeeper) {
         PName keyTenantId = tenantId == null ? null : new PNameImpl(tenantId);
-        PTableRef tableRef = metaData.getTableRefOptimized(new PTableKey(keyTenantId, name));
+        PTableRef tableRef = metaData.getTableRefNoTNFE(new PTableKey(keyTenantId, name));
         timeKeeper.incrementTime();
         return tableRef;
     }
@@ -229,21 +229,21 @@ public class PMetaDataImplTest {
         // Test for PTableRef with null tenant Id
         addToTable(metaData, null, tableName, 5, timeKeeper);
         Assert.assertEquals(1, metaData.size());
-        PTableRef tableRef = getTableRefOptimized(metaData, null, tableName, timeKeeper);
+        PTableRef tableRef = getTableRefNoTNFE(metaData, null, tableName, timeKeeper);
         Assert.assertNotNull(tableRef);
         removeFromTable(metaData, null, tableName, timeKeeper);
         Assert.assertEquals(0, metaData.size());
-        tableRef = getTableRefOptimized(metaData, null, tableName, timeKeeper);
+        tableRef = getTableRefNoTNFE(metaData, null, tableName, timeKeeper);
         Assert.assertNull(tableRef);
 
         // Test for PTableRef with non-null tenant Id
         addToTable(metaData, tenantId, tableName, 5, timeKeeper);
         Assert.assertEquals(1, metaData.size());
-        tableRef = getTableRefOptimized(metaData, tenantId, tableName, timeKeeper);
+        tableRef = getTableRefNoTNFE(metaData, tenantId, tableName, timeKeeper);
         Assert.assertNotNull(tableRef);
         removeFromTable(metaData, tenantId, tableName, timeKeeper);
         Assert.assertEquals(0, metaData.size());
-        tableRef = getTableRefOptimized(metaData, tenantId, tableName, timeKeeper);
+        tableRef = getTableRefNoTNFE(metaData, tenantId, tableName, timeKeeper);
         Assert.assertNull(tableRef);
     }
 

--- a/phoenix-core/src/test/java/org/apache/phoenix/schema/PMetaDataImplTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/schema/PMetaDataImplTest.java
@@ -217,7 +217,7 @@ public class PMetaDataImplTest {
     }
 
     @Test
-    public void testGetTableRefOptimized() throws Exception {
+    public void testGetTableRefOptimizationForMultiTenancy() throws Exception {
         TestTimeKeeper timeKeeper = new TestTimeKeeper();
         Map<String, String> props = Maps.newHashMapWithExpectedSize(2);
         props.put(QueryServices.MAX_CLIENT_METADATA_CACHE_SIZE_ATTRIB, "10");


### PR DESCRIPTION
Upserts to multi-tenant tables over tenant connections were regressed by 5K - 6K % compared to non-tenant connections. But with this patch upserts over tenant connection are as good as non-tenant connection.