### PR TITLE
PHOENIX-7488. Use central repo, not repository.apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,6 @@
     <!-- shaded artifact and assembly modules are added in shade-and-assembly profile -->
   </modules>
 
-  <repositories>
-    <repository>
-      <id>apache release</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `repository.apache.org` definition, to let the build use `central` repo from super POM.

Please see last item about `repository.apache.org` at https://infra.apache.org/infra-ban.html.

https://issues.apache.org/jira/browse/PHOENIX-7488

## How was this patch tested?

Local build:

```
$ mvn -DskipTests clean package
...
[INFO] Reactor Summary for Apache Phoenix 5.3.0-SNAPSHOT:
[INFO] 
[INFO] Apache Phoenix ..................................... SUCCESS [  0.988 s]
[INFO] Phoenix Hbase 2.6.0 compatibility .................. SUCCESS [ 15.988 s]
[INFO] Phoenix Hbase 2.5.4 compatibility .................. SUCCESS [ 15.753 s]
[INFO] Phoenix Hbase 2.5.0 compatibility .................. SUCCESS [ 26.659 s]
[INFO] Phoenix Hbase 2.4.1 compatibility .................. SUCCESS [ 17.087 s]
[INFO] Phoenix Core Client ................................ SUCCESS [ 34.392 s]
[INFO] Phoenix Core Server ................................ SUCCESS [  3.473 s]
[INFO] Phoenix Core ....................................... SUCCESS [  9.634 s]
[INFO] Phoenix - Pherf .................................... SUCCESS [ 10.289 s]
[INFO] Phoenix - Tracing Web Application .................. SUCCESS [  1.625 s]
[INFO] Phoenix Client Parent .............................. SUCCESS [  0.011 s]
[INFO] Phoenix Client Embedded ............................ SUCCESS [09:16 min]
[INFO] Phoenix Client Lite ................................ SUCCESS [06:08 min]
[INFO] Phoenix Server JAR ................................. SUCCESS [03:06 min]
[INFO] Phoenix Mapreduce .................................. SUCCESS [02:31 min]
[INFO] Phoenix Assembly ................................... SUCCESS [ 11.413 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```