### PR TITLE
PHOENIX-7502 :- Decouple principal from HAGroupInfo

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/FailoverPhoenixConnection.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/FailoverPhoenixConnection.java
@@ -105,7 +105,8 @@ public class FailoverPhoenixConnection implements PhoenixMonitoredConnection {
         this.context = context;
         this.policy = FailoverPolicy.get(context.getProperties());
         this.isClosed = false;
-        this.connection = context.getHAGroup().connectActive(context.getProperties(), context.getHAURLInfo());
+        this.connection = context.getHAGroup().connectActive(context.getProperties(),
+                context.getHAURLInfo());
     }
 
     /**
@@ -179,7 +180,8 @@ public class FailoverPhoenixConnection implements PhoenixMonitoredConnection {
         while (newConn == null &&
                 EnvironmentEdgeManager.currentTimeMillis() < startTime + timeoutMs) {
             try {
-                newConn = context.getHAGroup().connectActive(context.getProperties(), context.getHAURLInfo());
+                newConn = context.getHAGroup().connectActive(context.getProperties(),
+                        context.getHAURLInfo());
             } catch (SQLException e) {
                 cause = e;
                 LOG.info("Got exception when trying to connect to active cluster.", e);
@@ -222,7 +224,8 @@ public class FailoverPhoenixConnection implements PhoenixMonitoredConnection {
                 }
             }
         }
-        LOG.info("Connection {} failed over to {}", context.getHAGroup().getGroupInfo(), connection.getURL());
+        LOG.info("Connection {} failed over to {}", context.getHAGroup().getGroupInfo(),
+                connection.getURL());
     }
 
     /**
@@ -323,8 +326,9 @@ public class FailoverPhoenixConnection implements PhoenixMonitoredConnection {
     @VisibleForTesting
     <T> T wrapActionDuringFailover(SupplierWithSQLException<T> s) throws SQLException {
         checkConnection();
-        final long timeoutMs = Long.parseLong(context.getProperties().getProperty(FAILOVER_TIMEOUT_MS_ATTR,
-                String.valueOf(FAILOVER_TIMEOUT_MS_DEFAULT)));
+        final long timeoutMs = Long.parseLong(context.getProperties().
+                getProperty(FAILOVER_TIMEOUT_MS_ATTR,
+                        String.valueOf(FAILOVER_TIMEOUT_MS_DEFAULT)));
         int failoverCount = 0;
         while (true) {
             try {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/FailoverPhoenixContext.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/FailoverPhoenixContext.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import java.util.Properties;
+
+/**
+ * FailoverPhoenixContext holds the properties and HAGroup Info for a failover phoenix connection.
+ */
+public class FailoverPhoenixContext {
+
+    private final Properties properties;
+    private final HighAvailabilityGroup haGroup;
+    private final HAURLInfo haurlInfo;
+
+    FailoverPhoenixContext(Properties properties, HighAvailabilityGroup haGroup, HAURLInfo haurlInfo) {
+        this.properties = properties;
+        this.haGroup = haGroup;
+        this.haurlInfo = haurlInfo;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public HighAvailabilityGroup getHAGroup() {
+        return haGroup;
+    }
+
+    public HAURLInfo getHAURLInfo() {
+        return haurlInfo;
+    }
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/FailoverPhoenixContext.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/FailoverPhoenixContext.java
@@ -28,7 +28,8 @@ public class FailoverPhoenixContext {
     private final HighAvailabilityGroup haGroup;
     private final HAURLInfo haurlInfo;
 
-    FailoverPhoenixContext(Properties properties, HighAvailabilityGroup haGroup, HAURLInfo haurlInfo) {
+    FailoverPhoenixContext(Properties properties, HighAvailabilityGroup haGroup,
+                           HAURLInfo haurlInfo) {
         this.properties = properties;
         this.haGroup = haGroup;
         this.haurlInfo = haurlInfo;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAURLInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAURLInfo.java
@@ -1,0 +1,87 @@
+package org.apache.phoenix.jdbc;
+
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.phoenix.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.phoenix.thirdparty.com.google.common.base.Preconditions;
+
+/**
+ * An HAURLInfo contains information of an HA Url with respect of HA Group Name.
+ * <p>
+ * It is constructed based on client input, including the JDBC connection string and properties.
+ * Objects of this class are used to get appropriate principal and additional JDBC parameters.
+ * <p>
+ * This class is immutable.
+ */
+
+@VisibleForTesting
+public class HAURLInfo {
+    private final String name;
+    private final String principal;
+    private final String additionalJDBCParams;
+
+    HAURLInfo(String name, String principal, String additionalJDBCParams) {
+        Preconditions.checkNotNull(name);
+        this.name = name;
+        this.principal = principal;
+        this.additionalJDBCParams = additionalJDBCParams;
+    }
+
+    HAURLInfo(String name, String principal) {
+        this(name, principal, null);
+    }
+
+    HAURLInfo(String name) {
+        this(name, null, null);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPrincipal() {
+        return principal;
+    }
+
+    public String getAdditionalJDBCParams() {
+        return additionalJDBCParams;
+    }
+
+    @Override
+    public String toString() {
+        if (principal != null) {
+            return String.format("%s[%s]", name, principal);
+        }
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (other.getClass() != getClass()) {
+            return false;
+        }
+        HAURLInfo otherInfo = (HAURLInfo) other;
+        return new EqualsBuilder()
+                .append(name, otherInfo.name)
+                .append(principal, otherInfo.principal)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        if (principal != null) {
+            return new HashCodeBuilder(7, 47)
+                    .append(name)
+                    .append(principal).hashCode();
+        }
+        return new HashCodeBuilder(7, 47).append(name).hashCode();
+    }
+
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAURLInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAURLInfo.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.phoenix.jdbc;
 
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
@@ -852,8 +852,6 @@ public class HighAvailabilityGroup {
         }
 
 
-        //It applies only the current thread context's URL Info as we have 1:n mapping between
-        //HAURLInfo -> HAGroupInfo.
         public String getJDBCUrl(String zkUrl, HAURLInfo haURLInfo) {
             Preconditions.checkArgument(zkUrl.equals(getUrl1()) || zkUrl.equals(getUrl2())
                             || zkUrl.equals("[" + getUrl1() + "|" + getUrl2() + "]")

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
@@ -217,15 +217,18 @@ public class HighAvailabilityGroup {
                 if (extraIdx != 0) {
                     principal = additionalJDBCParams.substring(0, extraIdx);
                 }
+                //Storing terminator as part of additional Params
                 additionalJDBCParams = additionalJDBCParams.substring(extraIdx + 1);
             } else {
                 extraIdx = additionalJDBCParams.indexOf(PhoenixRuntime.JDBC_PROTOCOL_TERMINATOR);
                 if (extraIdx != -1) {
+                    //Not storing terminator to make it consistent.
                     principal = additionalJDBCParams.substring(0, extraIdx);
+                    additionalJDBCParams = String.valueOf(PhoenixRuntime.JDBC_PROTOCOL_TERMINATOR);
                 } else {
                     principal = additionalJDBCParams;
+                    additionalJDBCParams = null;
                 }
-                additionalJDBCParams = null;
             }
         }
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
@@ -213,7 +213,8 @@ public class HighAvailabilityGroup {
             //after zk quorums there should be a separator
             if (extraIdx != idx + 1) {
                 throw new SQLExceptionInfo.Builder(SQLExceptionCode.MALFORMED_CONNECTION_URL)
-                        .setMessage(String.format("URL %s is not a valid HA connection string", url))
+                        .setMessage(String.format("URL %s is not a valid HA connection string",
+                                url))
                         .build()
                         .buildException();
             }
@@ -240,10 +241,12 @@ public class HighAvailabilityGroup {
         } else {
             extraIdx = url.indexOf(PhoenixRuntime.JDBC_PROTOCOL_TERMINATOR, idx + 1);
             if (extraIdx != -1) {
-                //There is something in between zkquorum and terminator but no separator(s), So not sure what it is
+                //There is something in between zkquorum and terminator but no separator(s),
+                //So not sure what it is
                 if (extraIdx != idx + 1) {
                     throw new SQLExceptionInfo.Builder(SQLExceptionCode.MALFORMED_CONNECTION_URL)
-                            .setMessage(String.format("URL %s is not a valid HA connection string", url))
+                            .setMessage(String.format("URL %s is not a valid HA connection string",
+                                    url))
                             .build()
                             .buildException();
                 } else {
@@ -265,7 +268,8 @@ public class HighAvailabilityGroup {
         return haurlInfo;
     }
 
-    private static HAGroupInfo getHAGroupInfo(String url, Properties properties) throws SQLException {
+    private static HAGroupInfo getHAGroupInfo(String url, Properties properties)
+            throws SQLException {
         url = checkUrl(url);
         url = url.substring(url.indexOf("[") + 1, url.indexOf("]"));
         String [] urls = url.split("\\|");
@@ -580,7 +584,8 @@ public class HighAvailabilityGroup {
      * @return a Phoenix connection to current active HBase cluster
      * @throws SQLException if fails to get a connection
      */
-    PhoenixConnection connectActive(final Properties properties, final HAURLInfo haurlInfo) throws SQLException {
+    PhoenixConnection connectActive(final Properties properties, final HAURLInfo haurlInfo)
+            throws SQLException {
         try {
             Optional<String> url = roleRecord.getActiveUrl();
             if (state == State.READY && url.isPresent()) {
@@ -648,7 +653,8 @@ public class HighAvailabilityGroup {
      * connection to the given cluster without checking the context of the cluster's role. Please
      * use {@link #connectActive(Properties, HAURLInfo)} to connect to the ACTIVE cluster.
      */
-    PhoenixConnection connectToOneCluster(String url, Properties properties, HAURLInfo haurlInfo) throws SQLException {
+    PhoenixConnection connectToOneCluster(String url, Properties properties, HAURLInfo haurlInfo)
+            throws SQLException {
         Preconditions.checkNotNull(url);
         if (url.startsWith(PhoenixRuntime.JDBC_PROTOCOL)) {
             Preconditions.checkArgument(url.length() > PhoenixRuntime.JDBC_PROTOCOL.length(),
@@ -862,8 +868,8 @@ public class HighAvailabilityGroup {
             sb.append(PhoenixRuntime.JDBC_PROTOCOL_SEPARATOR);
             sb.append(zkUrl);
             if (haURLInfo != null) {
-                if (!Strings.isNullOrEmpty(haURLInfo.getPrincipal()) &&
-                        !Strings.isNullOrEmpty(haURLInfo.getAdditionalJDBCParams())) {
+                if (!Strings.isNullOrEmpty(haURLInfo.getPrincipal())
+                        && !Strings.isNullOrEmpty(haURLInfo.getAdditionalJDBCParams())) {
                     sb.append(PhoenixRuntime.JDBC_PROTOCOL_SEPARATOR);
                     sb.append(haURLInfo.getPrincipal());
                     if (!haURLInfo.getAdditionalJDBCParams().

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityPolicy.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityPolicy.java
@@ -66,9 +66,10 @@ enum HighAvailabilityPolicy {
             LOG.info("Cluster {} becomes STANDBY in HA group {}, now close all its connections",
                     zkUrl, haGroup.getGroupInfo());
             ConnectionQueryServices cqs = null;
-            try {
-                //Close connections for every HAURLInfo's (different principal) connections for a give HAGroup
-                for (HAURLInfo haurlInfo : HighAvailabilityGroup.URLS.get(haGroup.getGroupInfo())) {
+
+            //Close connections for every HAURLInfo's (different principal) connections for a give HAGroup
+            for (HAURLInfo haurlInfo : HighAvailabilityGroup.URLS.get(haGroup.getGroupInfo())) {
+                try {
                     String jdbcZKUrl = haGroup.getGroupInfo().getJDBCUrl(zkUrl, haurlInfo);
                     cqs = PhoenixDriver.INSTANCE.getConnectionQueryServices(
                             jdbcZKUrl, haGroup.getProperties());
@@ -78,16 +79,15 @@ enum HighAvailabilityPolicy {
                             .setHaGroupInfo(haGroup.getGroupInfo().toString()));
                     LOG.info("Closed all connections to cluster {} for HA group {}",
                             jdbcZKUrl, haGroup.getGroupInfo());
-                }
-
-            } finally {
-                if (cqs != null) {
-                    // CQS is closed but it is not invalidated from global cache in PhoenixDriver
-                    // so that any new connection will get error instead of creating a new CQS
-                    LOG.info("Closing CQS after cluster '{}' becomes STANDBY", zkUrl);
-                    cqs.close();
-                    LOG.info("Successfully closed CQS after cluster '{}' becomes STANDBY", zkUrl);
-                }
+                } finally {
+                        if (cqs != null) {
+                            // CQS is closed but it is not invalidated from global cache in PhoenixDriver
+                            // so that any new connection will get error instead of creating a new CQS
+                            LOG.info("Closing CQS after cluster '{}' becomes STANDBY", zkUrl);
+                            cqs.close();
+                            LOG.info("Successfully closed CQS after cluster '{}' becomes STANDBY", zkUrl);
+                        }
+                    }
             }
         }
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ParallelPhoenixConnection.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ParallelPhoenixConnection.java
@@ -69,14 +69,14 @@ public class ParallelPhoenixConnection implements PhoenixMonitoredConnection {
     CompletableFuture<PhoenixConnection> futureConnection2;
     public ParallelPhoenixConnection(ParallelPhoenixContext context) throws SQLException {
         this.context = context;
-        LOG.trace("First Url: {} Second Url: {}", context.getHaGroup().getGroupInfo().getJDBCUrl1(),
-                context.getHaGroup().getGroupInfo().getJDBCUrl2());
+        LOG.trace("First Url: {} Second Url: {}", context.getHaGroup().getGroupInfo().getJDBCUrl1(context.getHaurlInfo()),
+                context.getHaGroup().getGroupInfo().getJDBCUrl2(context.getHaurlInfo()));
         futureConnection1 = context.chainOnConn1(() -> getConnection(context.getHaGroup(),
-                context.getHaGroup().getGroupInfo().getJDBCUrl1(),
-                context.getProperties()));
+                context.getHaGroup().getGroupInfo().getJDBCUrl1(context.getHaurlInfo()),
+                context.getProperties(), context.getHaurlInfo()));
         futureConnection2 = context.chainOnConn2(() -> getConnection(context.getHaGroup(),
-                context.getHaGroup().getGroupInfo().getJDBCUrl2(),
-                context.getProperties()));
+                context.getHaGroup().getGroupInfo().getJDBCUrl2(context.getHaurlInfo()),
+                context.getProperties(), context.getHaurlInfo()));
 
         // Ensure one connection is successful before returning
         ParallelPhoenixUtil.INSTANCE.runFutures(Arrays.asList(futureConnection1, futureConnection2), context, false);
@@ -91,9 +91,10 @@ public class ParallelPhoenixConnection implements PhoenixMonitoredConnection {
         ParallelPhoenixUtil.INSTANCE.runFutures(Arrays.asList(futureConnection1, futureConnection2), context, false);
     }
 
-    private static PhoenixConnection getConnection(HighAvailabilityGroup haGroup, String url, Properties properties) {
+    private static PhoenixConnection getConnection(HighAvailabilityGroup haGroup, String url, Properties properties,
+                                                   HAURLInfo haurlInfo) {
         try {
-            return haGroup.connectToOneCluster(url, properties);
+            return haGroup.connectToOneCluster(url, properties, haurlInfo);
         } catch (SQLException exception) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace(String.format("Failed to get a connection for haGroup %s to %s", haGroup.toString(), url), exception);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ParallelPhoenixConnection.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ParallelPhoenixConnection.java
@@ -69,8 +69,9 @@ public class ParallelPhoenixConnection implements PhoenixMonitoredConnection {
     CompletableFuture<PhoenixConnection> futureConnection2;
     public ParallelPhoenixConnection(ParallelPhoenixContext context) throws SQLException {
         this.context = context;
-        LOG.trace("First Url: {} Second Url: {}", context.getHaGroup().getGroupInfo().getJDBCUrl1(context.getHaurlInfo()),
-                context.getHaGroup().getGroupInfo().getJDBCUrl2(context.getHaurlInfo()));
+        LOG.trace("First Url: {} Second Url: {}", context.getHaGroup().getGroupInfo().
+                        getJDBCUrl1(context.getHaurlInfo()), context.getHaGroup().getGroupInfo().
+                        getJDBCUrl2(context.getHaurlInfo()));
         futureConnection1 = context.chainOnConn1(() -> getConnection(context.getHaGroup(),
                 context.getHaGroup().getGroupInfo().getJDBCUrl1(context.getHaurlInfo()),
                 context.getProperties(), context.getHaurlInfo()));
@@ -91,8 +92,8 @@ public class ParallelPhoenixConnection implements PhoenixMonitoredConnection {
         ParallelPhoenixUtil.INSTANCE.runFutures(Arrays.asList(futureConnection1, futureConnection2), context, false);
     }
 
-    private static PhoenixConnection getConnection(HighAvailabilityGroup haGroup, String url, Properties properties,
-                                                   HAURLInfo haurlInfo) {
+    private static PhoenixConnection getConnection(HighAvailabilityGroup haGroup, String url,
+                                                   Properties properties, HAURLInfo haurlInfo) {
         try {
             return haGroup.connectToOneCluster(url, properties, haurlInfo);
         } catch (SQLException exception) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ParallelPhoenixContext.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ParallelPhoenixContext.java
@@ -57,6 +57,7 @@ public class ParallelPhoenixContext {
     private final Properties properties;
 
     private final HighAvailabilityGroup haGroup;
+    private final HAURLInfo haurlInfo;
     private final long operationTimeoutMs;
 
     private volatile boolean isClosed = false;
@@ -72,12 +73,15 @@ public class ParallelPhoenixContext {
      * @param executorCapacities Ordered list of executorCapacities corresponding to executors. Null is interpreted as
      *                           executors having capacity
      */
-    ParallelPhoenixContext(Properties properties, HighAvailabilityGroup haGroup, List<PhoenixHAExecutorServiceProvider.PhoenixHAClusterExecutorServices> executors, List<Boolean> executorCapacities) {
+    ParallelPhoenixContext(Properties properties, HighAvailabilityGroup haGroup,
+                           List<PhoenixHAExecutorServiceProvider.PhoenixHAClusterExecutorServices> executors,
+                           List<Boolean> executorCapacities, HAURLInfo haurlInfo) {
         Preconditions.checkNotNull(executors);
         Preconditions.checkArgument(executors.size() >= 2, "Expected 2 executor pairs, one for each connection with a normal/close executor");
         GLOBAL_HA_PARALLEL_CONNECTION_CREATED_COUNTER.increment();
         this.properties = properties;
         this.haGroup = haGroup;
+        this.haurlInfo = haurlInfo;
 
         this.parallelPhoenixMetrics = new ParallelPhoenixMetrics();
         this.operationTimeoutMs = getOperationTimeoutMs(properties);
@@ -122,6 +126,10 @@ public class ParallelPhoenixContext {
 
     public HighAvailabilityGroup getHaGroup() {
         return haGroup;
+    }
+
+    public HAURLInfo getHaurlInfo() {
+        return haurlInfo;
     }
 
     public boolean isAutoCommit() {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixEmbeddedDriver.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixEmbeddedDriver.java
@@ -17,7 +17,6 @@
  */
 package org.apache.phoenix.jdbc;
 
-import static org.apache.phoenix.jdbc.HighAvailabilityGroup.PHOENIX_HA_GROUP_ATTR;
 import static org.apache.phoenix.util.PhoenixRuntime.PHOENIX_TEST_DRIVER_URL_PARAM;
 
 import java.sql.Connection;
@@ -31,10 +30,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.concurrent.Immutable;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.phoenix.coprocessorclient.MetaDataProtocol;
-import org.apache.phoenix.exception.SQLExceptionCode;
-import org.apache.phoenix.exception.SQLExceptionInfo;
 import org.apache.phoenix.query.ConnectionQueryServices;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableMap;

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/FailoverPhoenixConnectionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/FailoverPhoenixConnectionIT.java
@@ -651,16 +651,22 @@ public class FailoverPhoenixConnectionIT {
         FailoverPhoenixConnection fconn2 = (FailoverPhoenixConnection) conn2;
         ConnectionQueryServices cqsi2 = PhoenixDriver.INSTANCE.getConnectionQueryServices(CLUSTERS.getJdbcUrl1(), clientProperties);
 
-        clientProperties.setProperty(PHOENIX_HA_GROUP_ATTR, haGroupName);
-        String principal3 = RandomStringUtils.randomAlphabetic(5);
-        Connection conn3 = DriverManager.getConnection(CLUSTERS.getJdbcHAUrl(principal3), clientProperties);//principal3, haGroupName
+        Connection conn3 = DriverManager.getConnection(CLUSTERS.getJdbcHAUrlWithoutPrincipal(), clientProperties); //null,haGroupName2
         FailoverPhoenixConnection fconn3 = (FailoverPhoenixConnection) conn3;
-        ConnectionQueryServices cqsi3 = PhoenixDriver.INSTANCE.getConnectionQueryServices(CLUSTERS.getJdbcUrl1(principal3), clientProperties);
+        ConnectionQueryServices cqsi3 = PhoenixDriver.INSTANCE.getConnectionQueryServices(CLUSTERS.
+                getJdbcUrlWithoutPrincipal(CLUSTERS.getUrl1()), clientProperties);
+
+        clientProperties.setProperty(PHOENIX_HA_GROUP_ATTR, haGroupName);
+        String principal4 = RandomStringUtils.randomAlphabetic(5);
+        Connection conn4 = DriverManager.getConnection(CLUSTERS.getJdbcHAUrl(principal4), clientProperties);//principal4, haGroupName
+        FailoverPhoenixConnection fconn4 = (FailoverPhoenixConnection) conn4;
+        ConnectionQueryServices cqsi4 = PhoenixDriver.INSTANCE.getConnectionQueryServices(CLUSTERS.getJdbcUrl1(principal4), clientProperties);
 
         //Check wrapped connection urls
         Assert.assertEquals(CLUSTERS.getJdbcUrl1(), fconn.getWrappedConnection().getURL());
         Assert.assertEquals(CLUSTERS.getJdbcUrl1(), fconn2.getWrappedConnection().getURL());
-        Assert.assertEquals(CLUSTERS.getJdbcUrl1(principal3), fconn3.getWrappedConnection().getURL());
+        Assert.assertEquals(CLUSTERS.getJdbcUrlWithoutPrincipal(CLUSTERS.getUrl1()), fconn3.getWrappedConnection().getURL());
+        Assert.assertEquals(CLUSTERS.getJdbcUrl1(principal4), fconn4.getWrappedConnection().getURL());
 
         //Check cqsi objects should be same with what we get from connections
         Assert.assertEquals(HBaseTestingUtilityPair.PRINCIPAL,cqsi.getUserName());
@@ -669,8 +675,11 @@ public class FailoverPhoenixConnectionIT {
         Assert.assertEquals(HBaseTestingUtilityPair.PRINCIPAL,cqsi2.getUserName());
         Assert.assertSame(cqsi2, fconn2.getWrappedConnection().getQueryServices());
 
-        Assert.assertEquals(principal3,cqsi3.getUserName());
+        Assert.assertNull(cqsi3.getUserName());
         Assert.assertSame(cqsi3, fconn3.getWrappedConnection().getQueryServices());
+
+        Assert.assertEquals(principal4,cqsi4.getUserName());
+        Assert.assertSame(cqsi4, fconn4.getWrappedConnection().getQueryServices());
 
     }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/FailoverPhoenixConnectionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/FailoverPhoenixConnectionIT.java
@@ -662,11 +662,6 @@ public class FailoverPhoenixConnectionIT {
         Assert.assertEquals(CLUSTERS.getJdbcUrl1(), fconn2.getWrappedConnection().getURL());
         Assert.assertEquals(CLUSTERS.getJdbcUrl1(principal3), fconn3.getWrappedConnection().getURL());
 
-        //Check HAGroup mappings
-        Assert.assertEquals(2, GROUPS.size());
-        Assert.assertEquals(GROUPS.size(), URLS.size());
-        Assert.assertEquals(2, URLS.get(haGroup.getGroupInfo()).size());
-
         //Check cqsi objects should be same with what we get from connections
         Assert.assertEquals(HBaseTestingUtilityPair.PRINCIPAL,cqsi.getUserName());
         Assert.assertSame(cqsi, fconn.getWrappedConnection().getQueryServices());

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/FailoverPhoenixConnectionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/FailoverPhoenixConnectionIT.java
@@ -19,7 +19,6 @@ package org.apache.phoenix.jdbc;
 
 import static org.apache.hadoop.test.GenericTestUtils.waitFor;
 import static org.apache.phoenix.exception.SQLExceptionCode.CANNOT_ESTABLISH_CONNECTION;
-import static org.apache.phoenix.jdbc.HighAvailabilityGroup.GROUPS;
 import static org.apache.phoenix.jdbc.HighAvailabilityGroup.URLS;
 import static org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.doTestBasicOperationsWithConnection;
 import static org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.HBaseTestingUtilityPair;
@@ -48,9 +47,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.exception.FailoverSQLException;
 import org.apache.phoenix.jdbc.ClusterRoleRecord.ClusterRole;
@@ -683,6 +683,52 @@ public class FailoverPhoenixConnectionIT {
 
     }
 
+    @Test(timeout = 300000)
+    public void testHAGroupMappingsWithDifferentPrincipalsOnDifferentThreads() throws Exception {
+        int numThreads = RandomUtils.nextInt(3, 5);
+        List<Thread> connectionThreads = new ArrayList<>(numThreads);
+        AtomicBoolean isPrincipalNull = new AtomicBoolean(false);
+        //Creating random number of connections one connection per thread with different principal
+        //Including one connection will null principal all of them will be using given haGroupName
+        //which is specific to test
+        for (int i = 0; i < numThreads; i++) {
+            isPrincipalNull.set((i + 1) % 3 == 0);
+            connectionThreads.add(new Thread(() -> {
+                try {
+                    createConnectionWithRandomPrincipal(isPrincipalNull.get());
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }));
+        }
+
+        //Create multiple connections with given principal
+        String principal = RandomStringUtils.randomAlphabetic(3);
+        int numConnectionsWithSamePrincipal = 3;
+        for (int i = 0; i < numConnectionsWithSamePrincipal; i++) {
+            connectionThreads.add(new Thread(() -> {
+                try {
+                    DriverManager.getConnection(CLUSTERS.getJdbcHAUrl(principal), clientProperties);
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }));
+        }
+
+        for (Thread connectionThread : connectionThreads) {
+            connectionThread.start();
+        }
+
+        for (Thread connectionThread : connectionThreads) {
+            connectionThread.join();
+        }
+
+        //For the given ha group of current test the value in URLS set for current haGroupInfo
+        //should be numThreads + 1 as all the connections created with same principal should have
+        //one entry in map.
+        Assert.assertEquals(numThreads + 1, URLS.get(haGroup.getGroupInfo()).size());
+    }
+
     /**
      * Helper method to verify that the failover connection has expected mutation metrics.
      *
@@ -726,5 +772,13 @@ public class FailoverPhoenixConnectionIT {
             assertTrue(e.getCause() instanceof FailoverSQLException);
             LOG.info("Got expected failover exception after connection is closed.", e);
         } // all other type of exception will fail this test.
+    }
+
+    private Connection createConnectionWithRandomPrincipal(boolean isPrincipalNull) throws SQLException {
+        String principal = RandomStringUtils.randomAlphabetic(5);
+        if (isPrincipalNull) {
+            return DriverManager.getConnection(CLUSTERS.getJdbcHAUrlWithoutPrincipal(), clientProperties);
+        }
+        return DriverManager.getConnection(CLUSTERS.getJdbcHAUrl(principal), clientProperties);
     }
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityGroupIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityGroupIT.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -199,14 +200,6 @@ public class HighAvailabilityGroupIT {
                     haGroup2.get().getGroupInfo().getJDBCUrl(CLUSTERS.getUrl2(), haURLInfo2));
             assertEquals(CLUSTERS.getJdbcHAUrl(principal), haGroup2.get().getGroupInfo().
                     getJDBCUrl(String.format("[%s|%s]", CLUSTERS.getUrl1(), CLUSTERS.getUrl2()), haURLInfo2));
-
-            //GROUPS cache and URL cache should be of size 1 as both should have same HAGroupInfo
-            assertEquals(1, GROUPS.size());
-            assertEquals(GROUPS.size(), URLS.size());
-            assertSame(haGroup.getGroupInfo(), haGroup2.get().getGroupInfo());
-            //URLS cache should have a list of size 2 for the current HAGroupInfo one for each principal maintaining
-            //1:n mapping in map.
-            assertEquals(2, URLS.get(haGroup.getGroupInfo()).size());
         } finally {
             haGroup2.ifPresent(HighAvailabilityGroup::close);
         }
@@ -223,9 +216,6 @@ public class HighAvailabilityGroupIT {
             assertTrue(haGroup3.isPresent());
             assertNotSame(haGroup, haGroup3.get());
 
-            //GROUPS cache and URL cache should be of size 2 as we have a new mapping of different HAGroupName
-            assertEquals(2, GROUPS.size());
-            assertEquals(GROUPS.size(), URLS.size());
             assertNotSame(haGroup.getGroupInfo(), haGroup3.get().getGroupInfo());
 
             //URLs we are getting for haGroup3 should have same principal as default PRINCIPAL.
@@ -235,11 +225,6 @@ public class HighAvailabilityGroupIT {
                     haGroup3.get().getGroupInfo().getJDBCUrl(CLUSTERS.getUrl2(), haurlInfo3));
             assertEquals(CLUSTERS.getJdbcHAUrl(), haGroup3.get().getGroupInfo().
                     getJDBCUrl(String.format("[%s|%s]", CLUSTERS.getUrl1(), CLUSTERS.getUrl2()), haurlInfo3));
-
-            //URLS cache should have a list of size 2 for the current HAGroupInfo one for each principal maintaining
-            //1:n mapping in map.
-            assertEquals(2, URLS.get(haGroup.getGroupInfo()).size());
-            assertEquals(1, URLS.get(haGroup3.get().getGroupInfo()).size());
 
         } finally {
             haGroup3.ifPresent(HighAvailabilityGroup::close);
@@ -266,13 +251,6 @@ public class HighAvailabilityGroupIT {
             assertEquals(CLUSTERS.getJdbcHAUrl(principal), haGroup4.get().getGroupInfo().
                     getJDBCUrl(String.format("[%s|%s]", CLUSTERS.getUrl1(), CLUSTERS.getUrl2()), haURLInfo4));
 
-            //GROUPS cache and URL cache should be of size 2 as we are using the default HAGroup mapping
-            assertEquals(2, GROUPS.size());
-            assertEquals(GROUPS.size(), URLS.size());
-            assertSame(haGroup.getGroupInfo(), haGroup4.get().getGroupInfo());
-            //URLS cache should have a list of size 3 for the current HAGroupInfo one for each principal maintaining
-            //1:n mapping in map.
-            assertEquals(3, URLS.get(haGroup.getGroupInfo()).size());
         } finally {
             haGroup4.ifPresent(HighAvailabilityGroup::close);
         }

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
@@ -358,6 +358,11 @@ public class HighAvailabilityTestingUtility {
         public String getJdbcUrl1() {
             return getJdbcUrl(url1);
         }
+
+        public String getJdbcUrl1(String principal) {
+            return getJdbcUrl(url1, principal);
+        }
+
         public String getJdbcUrl2() {
             return getJdbcUrl(url2);
         }

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
@@ -350,6 +350,11 @@ public class HighAvailabilityTestingUtility {
             return getJdbcUrl(String.format("[%s|%s]", url1, url2));
         }
 
+        public String getJdbcHAUrl(String principal) {
+            return getJdbcUrl(String.format("[%s|%s]", url1, url2), principal);
+        }
+
+
         public String getJdbcUrl1() {
             return getJdbcUrl(url1);
         }
@@ -359,6 +364,10 @@ public class HighAvailabilityTestingUtility {
 
         public String getJdbcUrl(String zkUrl) {
             return String.format("jdbc:phoenix+zk:%s:%s", zkUrl, PRINCIPAL);
+        }
+
+        public String getJdbcUrl(String zkUrl, String principal) {
+            return String.format("jdbc:phoenix+zk:%s:%s", zkUrl, principal);
         }
 
         public String getUrl1() {

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
@@ -354,6 +354,10 @@ public class HighAvailabilityTestingUtility {
             return getJdbcUrl(String.format("[%s|%s]", url1, url2), principal);
         }
 
+        public String getJdbcHAUrlWithoutPrincipal() {
+            return getJdbcUrlWithoutPrincipal(String.format("[%s|%s]", url1, url2));
+        }
+
 
         public String getJdbcUrl1() {
             return getJdbcUrl(url1);
@@ -373,6 +377,10 @@ public class HighAvailabilityTestingUtility {
 
         public String getJdbcUrl(String zkUrl, String principal) {
             return String.format("jdbc:phoenix+zk:%s:%s", zkUrl, principal);
+        }
+
+        public String getJdbcUrlWithoutPrincipal(String zkUrl) {
+            return String.format("jdbc:phoenix+zk:%s", zkUrl);
         }
 
         public String getUrl1() {

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/ParallelPhoenixConnectionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/ParallelPhoenixConnectionIT.java
@@ -138,24 +138,25 @@ public class ParallelPhoenixConnectionIT {
         try (Connection conn = getParallelConnection()) {
             ParallelPhoenixConnection pr = conn.unwrap(ParallelPhoenixConnection.class);
             ParallelPhoenixContext context = pr.getContext();
+            HAURLInfo haurlInfo = context.getHaurlInfo();
             HighAvailabilityGroup.HAGroupInfo group = context.getHaGroup().getGroupInfo();
             if (CLUSTERS.getUrl1().compareTo(CLUSTERS.getUrl2()) <= 0) {
-                Assert.assertEquals(CLUSTERS.getJdbcUrl1(), group.getJDBCUrl1());
-                Assert.assertEquals(CLUSTERS.getJdbcUrl2(), group.getJDBCUrl2());
+                Assert.assertEquals(CLUSTERS.getJdbcUrl1(), group.getJDBCUrl1(haurlInfo));
+                Assert.assertEquals(CLUSTERS.getJdbcUrl2(), group.getJDBCUrl2(haurlInfo));
             } else {
-                Assert.assertEquals(CLUSTERS.getJdbcUrl2(), group.getJDBCUrl1());
-                Assert.assertEquals(CLUSTERS.getJdbcUrl1(), group.getJDBCUrl2());
+                Assert.assertEquals(CLUSTERS.getJdbcUrl2(), group.getJDBCUrl1(haurlInfo));
+                Assert.assertEquals(CLUSTERS.getJdbcUrl1(), group.getJDBCUrl2(haurlInfo));
             }
             ConnectionQueryServices cqsi;
             // verify connection#1
-            cqsi = PhoenixDriver.INSTANCE.getConnectionQueryServices(group.getJDBCUrl1(), clientProperties);
+            cqsi = PhoenixDriver.INSTANCE.getConnectionQueryServices(group.getJDBCUrl1(haurlInfo), clientProperties);
             Assert.assertEquals(HBaseTestingUtilityPair.PRINCIPAL, cqsi.getUserName());
             PhoenixConnection pConn = pr.getFutureConnection1().get();
             ConnectionQueryServices cqsiFromConn = pConn.getQueryServices();
             Assert.assertEquals(HBaseTestingUtilityPair.PRINCIPAL, cqsiFromConn.getUserName());
             Assert.assertTrue(cqsi == cqsiFromConn);
             // verify connection#2
-            cqsi = PhoenixDriver.INSTANCE.getConnectionQueryServices(group.getJDBCUrl2(), clientProperties);
+            cqsi = PhoenixDriver.INSTANCE.getConnectionQueryServices(group.getJDBCUrl2(haurlInfo), clientProperties);
             Assert.assertEquals(HBaseTestingUtilityPair.PRINCIPAL, cqsi.getUserName());
             pConn = pr.getFutureConnection2().get();
             cqsiFromConn = pConn.getQueryServices();

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixConnectionFailureTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixConnectionFailureTest.java
@@ -73,7 +73,7 @@ public class ParallelPhoenixConnectionFailureTest extends BaseTest {
                 new ParallelPhoenixContext(new Properties(),
                         Mockito.mock(HighAvailabilityGroup.class),
                         HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(),
-                        null);
+                        null, Mockito.mock(HAURLInfo.class));
         ParallelPhoenixConnection parallelConn =
                 new ParallelPhoenixConnection(context, CompletableFuture.completedFuture(connSpy1),
                         CompletableFuture.completedFuture(connSpy2));

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixConnectionTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixConnectionTest.java
@@ -53,7 +53,7 @@ public class ParallelPhoenixConnectionTest {
     @Before
     public void init() throws SQLException {
         context = new ParallelPhoenixContext(new Properties(), Mockito.mock(HighAvailabilityGroup.class),
-            HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null);
+            HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null, Mockito.mock(HAURLInfo.class));
         parallelPhoenixConnection = new ParallelPhoenixConnection(context,CompletableFuture.completedFuture(connection1),CompletableFuture.completedFuture(connection2));
     }
 
@@ -185,7 +185,8 @@ public class ParallelPhoenixConnectionTest {
                 "1000");
         ParallelPhoenixContext context =
                 new ParallelPhoenixContext(properties, Mockito.mock(HighAvailabilityGroup.class),
-                        HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null);
+                        HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null,
+                        Mockito.mock(HAURLInfo.class));
 
         CountDownLatch cdl = new CountDownLatch(1);
         CompletableFuture<PhoenixConnection> futureConnection1 = CompletableFuture.supplyAsync(getDelayConnectionSupplier(cdl, connection1));
@@ -212,7 +213,8 @@ public class ParallelPhoenixConnectionTest {
                 "1000");
         ParallelPhoenixContext context =
                 new ParallelPhoenixContext(properties, Mockito.mock(HighAvailabilityGroup.class),
-                        HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null);
+                        HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null,
+                        Mockito.mock(HAURLInfo.class));
 
         CountDownLatch cdl = new CountDownLatch(1);
         CompletableFuture<PhoenixConnection> futureConnection1 = CompletableFuture.completedFuture(connection1);
@@ -239,7 +241,8 @@ public class ParallelPhoenixConnectionTest {
                 "1000");
         ParallelPhoenixContext context =
                 new ParallelPhoenixContext(properties, Mockito.mock(HighAvailabilityGroup.class),
-                        HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null);
+                        HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null,
+                        Mockito.mock(HAURLInfo.class));
 
         CountDownLatch cdl1 = new CountDownLatch(1);
         CompletableFuture<PhoenixConnection> futureConnection1 = CompletableFuture.supplyAsync(getDelayConnectionSupplier(cdl1, connection1));
@@ -346,7 +349,8 @@ public class ParallelPhoenixConnectionTest {
             "1000");
         ParallelPhoenixContext context =
                 new ParallelPhoenixContext(properties, Mockito.mock(HighAvailabilityGroup.class),
-                    HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null);
+                    HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null,
+                        Mockito.mock(HAURLInfo.class));
         parallelPhoenixConnection =
                 new ParallelPhoenixConnection(context,
                         CompletableFuture.completedFuture(connection1),

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixContextTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixContextTest.java
@@ -70,7 +70,9 @@ public class ParallelPhoenixContextTest {
             ParallelPhoenixContext context =
                     new ParallelPhoenixContext(new Properties(),
                             Mockito.mock(HighAvailabilityGroup.class),
-                            Lists.newArrayList(Mockito.mock(PhoenixHAExecutorServiceProvider.PhoenixHAClusterExecutorServices.class)), null);
+                            Lists.newArrayList(Mockito.mock(PhoenixHAExecutorServiceProvider.
+                                    PhoenixHAClusterExecutorServices.class)), null,
+                            Mockito.mock(HAURLInfo.class));
             fail("Should not construct with less than 2 ThreadPools");
         } catch (IllegalArgumentException e) {
         }
@@ -85,7 +87,8 @@ public class ParallelPhoenixContextTest {
                                 Mockito.mock(Properties.class),
                                 Mockito.mock(ClusterRoleRecord.class),
                                 HighAvailabilityGroup.State.READY),
-                        executorList, Lists.newArrayList(Boolean.FALSE, Boolean.TRUE));
+                        executorList, Lists.newArrayList(Boolean.FALSE, Boolean.TRUE),
+                        Mockito.mock(HAURLInfo.class));
         CompletableFuture<Boolean> future1 = context.chainOnConn1(() -> true);
         assertTrue(future1.isCompletedExceptionally());
         assertEquals(0, ((TrackingThreadPoolExecutor) executorList.get(0).getExecutorService()).tasksExecuted.get());
@@ -105,7 +108,8 @@ public class ParallelPhoenixContextTest {
                                 Mockito.mock(Properties.class),
                                 Mockito.mock(ClusterRoleRecord.class),
                                 HighAvailabilityGroup.State.READY),
-                        executorList, Lists.newArrayList(Boolean.TRUE, Boolean.FALSE));
+                        executorList, Lists.newArrayList(Boolean.TRUE, Boolean.FALSE),
+                        Mockito.mock(HAURLInfo.class));
         CompletableFuture<Boolean> future1 = context.chainOnConn1(() -> true);
         assertTrue(future1.get());
         assertEquals(1, ((TrackingThreadPoolExecutor) executorList.get(0).getExecutorService()).tasksExecuted.get());
@@ -121,7 +125,8 @@ public class ParallelPhoenixContextTest {
         ParallelPhoenixContext context =
                 new ParallelPhoenixContext(new Properties(),
                         Mockito.mock(HighAvailabilityGroup.class), executorList,
-                        Lists.newArrayList(Boolean.TRUE, Boolean.TRUE));
+                        Lists.newArrayList(Boolean.TRUE, Boolean.TRUE),
+                        Mockito.mock(HAURLInfo.class));
         CompletableFuture<Boolean> future1 = context.chainOnConn1(() -> true);
         assertTrue(future1.get());
         assertEquals(1, ((TrackingThreadPoolExecutor) executorList.get(0).getExecutorService()).tasksExecuted.get());

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixNullComparingResultSetTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixNullComparingResultSetTest.java
@@ -55,7 +55,8 @@ public class ParallelPhoenixNullComparingResultSetTest {
                         Mockito.mock(Properties.class),
                         Mockito.mock(ClusterRoleRecord.class),
                         HighAvailabilityGroup.State.READY),
-                HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null);
+                HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null,
+                Mockito.mock(HAURLInfo.class));
         rs1 = Mockito.mock(ResultSet.class);
         rs2 = Mockito.mock(ResultSet.class);
         completableRs1 = CompletableFuture.completedFuture(rs1);

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixPreparedStatementTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixPreparedStatementTest.java
@@ -47,7 +47,8 @@ public class ParallelPhoenixPreparedStatementTest {
     @Before
     public void init() throws Exception {
         context = new ParallelPhoenixContext(new Properties(), Mockito.mock(HighAvailabilityGroup.class),
-            HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null);
+            HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null,
+                Mockito.mock(HAURLInfo.class));
 
         statement1 = Mockito.mock(PhoenixMonitoredPreparedStatement.class);
         statement2 = Mockito.mock(PhoenixMonitoredPreparedStatement.class);

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixResultSetTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixResultSetTest.java
@@ -53,7 +53,8 @@ public class ParallelPhoenixResultSetTest {
                         new ParallelPhoenixContext(new Properties(), null,
                                 HighAvailabilityTestingUtility
                                         .getListOfSingleThreadExecutorServices(),
-                                null),
+                                null,
+                                Mockito.mock(HAURLInfo.class)),
                         completableRs1, completableRs2);
     }
 
@@ -109,7 +110,8 @@ public class ParallelPhoenixResultSetTest {
                         new ParallelPhoenixContext(new Properties(), null,
                                 HighAvailabilityTestingUtility
                                         .getListOfSingleThreadExecutorServices(),
-                                null),
+                                null,
+                                Mockito.mock(HAURLInfo.class)),
                         completableRs1, completableRs2);
 
         resultSet.next();
@@ -149,7 +151,8 @@ public class ParallelPhoenixResultSetTest {
                         new ParallelPhoenixContext(new Properties(), null,
                                 HighAvailabilityTestingUtility
                                         .getListOfSingleThreadExecutorServices(),
-                                null),
+                                null,
+                                Mockito.mock(HAURLInfo.class)),
                         completableRs1, completableRs2);
 
         resultSet.next();
@@ -189,7 +192,8 @@ public class ParallelPhoenixResultSetTest {
                         new ParallelPhoenixContext(new Properties(), null,
                                 HighAvailabilityTestingUtility
                                         .getListOfSingleThreadExecutorServices(),
-                                null),
+                                null,
+                                Mockito.mock(HAURLInfo.class)),
                         completableRs1, completableRs2);
 
         resultSet.next();
@@ -250,7 +254,8 @@ public class ParallelPhoenixResultSetTest {
                         new ParallelPhoenixContext(new Properties(), null,
                                 HighAvailabilityTestingUtility
                                         .getListOfSingleThreadExecutorServices(),
-                                null),
+                                null,
+                                Mockito.mock(HAURLInfo.class)),
                         completableRs1, completableRs2);
 
         //run next in the background

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixUtilTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ParallelPhoenixUtilTest.java
@@ -46,7 +46,8 @@ public class ParallelPhoenixUtilTest {
 
     private static final ParallelPhoenixContext context =
             new ParallelPhoenixContext(new Properties(), null,
-                    HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null);
+                    HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(), null,
+                    Mockito.mock(HAURLInfo.class));
 
     @Test
     public void getAnyOfNonExceptionallySingleFutureTest() throws Exception {
@@ -114,7 +115,7 @@ public class ParallelPhoenixUtilTest {
         ParallelPhoenixContext ctx =
                 new ParallelPhoenixContext(props, null,
                         HighAvailabilityTestingUtility.getListOfSingleThreadExecutorServices(),
-                        null);
+                        null, Mockito.mock(HAURLInfo.class));
         long startTime = EnvironmentEdgeManager.currentTime();
         try {
             util.getAnyOfNonExceptionally(futures, ctx);


### PR DESCRIPTION
- Decoupling principal from HAGroupInfo so that we can have 1:1 mapping between HAGroupInfo -> HighAvailabilityGroup and 1:n mapping between HAGroupInfo -> HAURLInfo (principal)
- Storing HAURLInfo in connection's own context so it has correct info.
- Policy can access all users associated with given HAGroup in case of clusterRoleRecord change
- This means we can have a single HighAvailability group/ clusterRoleRecord for different principals connecting to it and we don't have to create separate watchers for every principal.