### PR TITLE
PHOENIX-7462 Single row Atomic Upsert/Delete returning result should return ResultSet

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPrefetchedResultSet.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPrefetchedResultSet.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.jdbc;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.phoenix.compile.RowProjector;
+import org.apache.phoenix.compile.StatementContext;
+import org.apache.phoenix.schema.tuple.Tuple;
+
+/**
+ * Phoenix ResultSet implementation with prefetched rows. It is expected that the implementation
+ * does not need to use any iterators to make server side RPC call.
+ */
+public class PhoenixPrefetchedResultSet extends PhoenixResultSet {
+
+  private final List<Tuple> prefetchedRows;
+  private int prefetchedRowsIndex;
+
+  public PhoenixPrefetchedResultSet(RowProjector rowProjector,
+      StatementContext ctx, List<Tuple> prefetchedRows) throws SQLException {
+    super(null, rowProjector, ctx);
+    this.prefetchedRows = prefetchedRows;
+    this.prefetchedRowsIndex = 0;
+  }
+
+  @Override
+  protected Tuple getCurrentRowImpl() {
+    return prefetchedRows.get(prefetchedRowsIndex++);
+  }
+
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -222,11 +222,11 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
      * If the row is successfully updated, return the updated row, otherwise if the row
      * cannot be updated, return non-updated row.
      *
-     * @return The pair of int and Tuple, where int represents value 1 for successful row update
-     * and 0 for non-successful row update, and Tuple represents the state of the row.
+     * @return The pair of int and ResultSet, where int represents value 1 for successful row update
+     * and 0 for non-successful row update, and ResultSet represents the state of the row.
      * @throws SQLException If the statement cannot be executed.
      */
-    public Pair<Integer, Tuple> executeUpdateReturnRow() throws SQLException {
+    public Pair<Integer, ResultSet> executeUpdateReturnRow() throws SQLException {
         if (!connection.getAutoCommit()) {
             throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()
                     .buildException();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -57,7 +57,6 @@ import org.apache.phoenix.execute.MutationState;
 import org.apache.phoenix.schema.ExecuteQueryNotApplicableException;
 import org.apache.phoenix.schema.ExecuteUpdateNotApplicableException;
 import org.apache.phoenix.schema.Sequence;
-import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.util.DateUtil;
 import org.apache.phoenix.util.SQLCloseable;
@@ -226,7 +225,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
      * and 0 for non-successful row update, and ResultSet represents the state of the row.
      * @throws SQLException If the statement cannot be executed.
      */
-    public Pair<Integer, ResultSet> executeUpdateReturnRow() throws SQLException {
+    public Pair<Integer, ResultSet> executeAtomicUpdateReturnRow() throws SQLException {
         if (!connection.getAutoCommit()) {
             throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()
                     .buildException();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixResultSet.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixResultSet.java
@@ -224,7 +224,9 @@ public class PhoenixResultSet implements PhoenixMonitoredResultSet, SQLCloseable
             return;
         }
         try {
-            scanner.close();
+            if (scanner != null) {
+                scanner.close();
+            }
         } finally {
             isClosed = true;
             statement.removeResultSet(this);
@@ -880,6 +882,10 @@ public class PhoenixResultSet implements PhoenixMonitoredResultSet, SQLCloseable
         return currentRow;
     }
 
+    protected Tuple getCurrentRowImpl() throws SQLException {
+        return scanner.next();
+    }
+
     @Override
     public boolean next() throws SQLException {
         checkOpen();
@@ -888,7 +894,7 @@ public class PhoenixResultSet implements PhoenixMonitoredResultSet, SQLCloseable
                 firstRecordRead = true;
                 overAllQueryMetrics.startResultSetWatch();
             }
-            currentRow = scanner.next();
+            currentRow = getCurrentRowImpl();
             if (currentRow != null) {
                 count++;
                 // Reset this projector with each row
@@ -1520,7 +1526,7 @@ public class PhoenixResultSet implements PhoenixMonitoredResultSet, SQLCloseable
      * @return the row projector including dynamic column projectors in case we are including
      * dynamic columns, otherwise the regular row projector containing static column projectors
      */
-    private RowProjector getRowProjector() {
+    public RowProjector getRowProjector() {
         if (this.rowProjectorWithDynamicCols != null) {
             return this.rowProjectorWithDynamicCols;
         }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -230,6 +230,7 @@ import org.apache.phoenix.util.PhoenixRuntime;
 import org.apache.phoenix.util.QueryUtil;
 import org.apache.phoenix.util.SQLCloseable;
 import org.apache.phoenix.util.ParseNodeUtil.RewriteResult;
+import org.apache.phoenix.util.TupleUtil;
 import org.apache.phoenix.util.ValidateLastDDLTimestampUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -584,17 +585,15 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         return executeMutation(stmt, true, queryLogger, null).getFirst();
     }
 
-    Pair<Integer, Tuple> executeMutation(final CompilableStatement stmt,
+    Pair<Integer, ResultSet> executeMutation(final CompilableStatement stmt,
                                    final AuditQueryLogger queryLogger,
                                    final ReturnResult returnResult) throws SQLException {
         return executeMutation(stmt, true, queryLogger, returnResult);
     }
 
-    private Pair<Integer, Tuple> executeMutation(final CompilableStatement stmt,
-                                                  final boolean doRetryOnMetaNotFoundError,
-                                                  final AuditQueryLogger queryLogger,
-                                                  final ReturnResult returnResult)
-            throws SQLException {
+    private Pair<Integer, ResultSet> executeMutation(final CompilableStatement stmt,
+        final boolean doRetryOnMetaNotFoundError, final AuditQueryLogger queryLogger,
+        final ReturnResult returnResult) throws SQLException {
         if (connection.isReadOnly()) {
             throw new SQLExceptionInfo.Builder(
                 SQLExceptionCode.READ_ONLY_CONNECTION).
@@ -604,9 +603,9 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         try {
             return CallRunner
                    .run(
-                           new CallRunner.CallableThrowable<Pair<Integer, Tuple>, SQLException>() {
+                           new CallRunner.CallableThrowable<Pair<Integer, ResultSet>, SQLException>() {
                         @Override
-                            public Pair<Integer, Tuple> call() throws SQLException {
+                            public Pair<Integer, ResultSet> call() throws SQLException {
                             boolean success = false;
                             String tableName = null;
                             boolean isUpsert = false;
@@ -683,9 +682,11 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                     queryLogger.log(QueryLogInfo.NO_OF_RESULTS_ITERATED_I, lastUpdateCount);
                                     queryLogger.syncAudit();
                                 }
-
                                 success = true;
-                                return new Pair<>(lastUpdateCount, new ResultTuple(result));
+                                return new Pair<>(lastUpdateCount,
+                                    result == null || result.isEmpty() ?
+                                        null : TupleUtil.getResultSet(new ResultTuple(result),
+                                        tableName, connection));
                             }
                             //Force update cache and retry if meta not found error occurs
                             catch (MetaDataEntityNotFoundException e) {
@@ -2478,17 +2479,17 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
      * cannot be updated, return non-updated row.
      *
      * @param sql The SQL DML statement, UPSERT or DELETE for Phoenix.
-     * @return The pair of int and Tuple, where int represents value 1 for successful row
-     * update and 0 for non-successful row update, and Tuple represents the state of the row.
+     * @return The pair of int and ResultSet, where int represents value 1 for successful row
+     * update and 0 for non-successful row update, and ResultSet represents the state of the row.
      * @throws SQLException If the statement cannot be executed.
      */
-    public Pair<Integer, Tuple> executeUpdateReturnRow(String sql) throws SQLException {
+    public Pair<Integer, ResultSet> executeUpdateReturnRow(String sql) throws SQLException {
         if (!connection.getAutoCommit()) {
             throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()
                     .buildException();
         }
         CompilableStatement stmt = preExecuteUpdate(sql);
-        Pair<Integer, Tuple> result =
+        Pair<Integer, ResultSet> result =
                 executeMutation(stmt, createAuditQueryLogger(stmt, sql), ReturnResult.ROW);
         flushIfNecessary();
         return result;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -2483,7 +2483,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
      * update and 0 for non-successful row update, and ResultSet represents the state of the row.
      * @throws SQLException If the statement cannot be executed.
      */
-    public Pair<Integer, ResultSet> executeUpdateReturnRow(String sql) throws SQLException {
+    public Pair<Integer, ResultSet> executeAtomicUpdateReturnRow(String sql) throws SQLException {
         if (!connection.getAutoCommit()) {
             throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()
                     .buildException();

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
@@ -31,13 +31,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
 
-import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.util.Pair;
-import org.apache.phoenix.jdbc.PhoenixConnection;
-import org.apache.phoenix.query.QueryConstants;
-import org.apache.phoenix.schema.PTable;
-import org.apache.phoenix.schema.tuple.Tuple;
-import org.apache.phoenix.schema.types.PBson;
 import org.apache.phoenix.schema.types.PDouble;
 import org.bson.BsonArray;
 import org.bson.BsonBinary;
@@ -495,7 +489,7 @@ public class Bson4IT extends ParallelStatsDisabledIT {
                                               boolean success)
           throws SQLException, IOException {
     Pair<Integer, ResultSet> resultPair =
-        stmt.unwrap(PhoenixPreparedStatement.class).executeUpdateReturnRow();
+        stmt.unwrap(PhoenixPreparedStatement.class).executeAtomicUpdateReturnRow();
     assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
     ResultSet resultSet = resultPair.getSecond();
     assertEquals(RawBsonDocument.parse(getJsonString(jsonPath)), resultSet.getObject(3));

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
@@ -494,17 +494,11 @@ public class Bson4IT extends ParallelStatsDisabledIT {
                                               String jsonPath,
                                               boolean success)
           throws SQLException, IOException {
-    Pair<Integer, Tuple> resultPair =
-            stmt.unwrap(PhoenixPreparedStatement.class).executeUpdateReturnRow();
+    Pair<Integer, ResultSet> resultPair =
+        stmt.unwrap(PhoenixPreparedStatement.class).executeUpdateReturnRow();
     assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
-    Tuple result = resultPair.getSecond();
-    PTable table = conn.unwrap(PhoenixConnection.class).getTable(tableName);
-
-    Cell cell = result.getValue(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
-            table.getColumns().get(2).getColumnQualifierBytes());
-    assertEquals(RawBsonDocument.parse(getJsonString(jsonPath)),
-            PBson.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
-                    cell.getValueLength()));
+    ResultSet resultSet = resultPair.getSecond();
+    assertEquals(RawBsonDocument.parse(getJsonString(jsonPath)), resultSet.getObject(3));
   }
 
   private static void validateIndexUsed(PreparedStatement ps, String indexName)

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Result;
@@ -52,7 +51,6 @@ import org.apache.hadoop.hbase.util.VersionInfo;
 import org.apache.phoenix.compile.ExplainPlan;
 import org.apache.phoenix.compile.ExplainPlanAttributes;
 import org.apache.phoenix.exception.SQLExceptionCode;
-import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
 import org.apache.phoenix.jdbc.PhoenixStatement;
@@ -60,12 +58,6 @@ import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTableKey;
-import org.apache.phoenix.schema.tuple.ResultTuple;
-import org.apache.phoenix.schema.tuple.Tuple;
-import org.apache.phoenix.schema.types.PBson;
-import org.apache.phoenix.schema.types.PDouble;
-import org.apache.phoenix.schema.types.PInteger;
-import org.apache.phoenix.schema.types.PVarchar;
 import org.apache.phoenix.util.EncodedColumnsUtil;
 import org.apache.phoenix.util.PhoenixRuntime;
 import org.apache.phoenix.util.PropertiesUtil;
@@ -362,7 +354,7 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
                                                        BsonDocument expectedDoc,
                                                        Integer col4)
             throws SQLException {
-        final Pair<Integer, ResultSet> resultPair = ps.executeUpdateReturnRow();
+        final Pair<Integer, ResultSet> resultPair = ps.executeAtomicUpdateReturnRow();
         ResultSet resultSet = resultPair.getSecond();
         if (!isSinglePointLookup) {
             assertNull(resultSet);
@@ -409,10 +401,10 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
             PhoenixPreparedStatement ps =
                     conn.prepareStatement(upsertSql).unwrap(PhoenixPreparedStatement.class);
             ps.setObject(1, inputDoc);
-            resultPair = ps.executeUpdateReturnRow();
+            resultPair = ps.executeAtomicUpdateReturnRow();
         } else {
             resultPair = conn.createStatement().unwrap(PhoenixStatement.class)
-                    .executeUpdateReturnRow(upsertSql);
+                    .executeAtomicUpdateReturnRow(upsertSql);
         }
         assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
         ResultSet resultSet = resultPair.getSecond();

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
@@ -146,6 +146,11 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
     public void testReturnRowResult1() throws Exception {
         Assume.assumeTrue("Set correct result to RegionActionResult on hbase versions " +
                 "2.4.18+, 2.5.9+, and 2.6.0+", isSetCorrectResultEnabledOnHBase());
+        // NOTE - Tuple result projection does not work well with local index because
+        // this assertion can be false: CellUtil.matchingRows(kvs[0], kvs[kvs.length-1])
+        // as the Tuple contains different rowkeys.
+        Assume.assumeTrue("ResultSet return does not work with local index",
+            !indexDDL.startsWith("create local index"));
 
         Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
         String sample1 = getJsonString("json/sample_01.json");
@@ -171,10 +176,8 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
             ps.setString(1, "pk000");
             ps.setDouble(2, -123.98);
             ps.setString(3, "pk003");
-            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", true, true,
-                    bsonDocument2, 234);
-            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", true, false,
-                    bsonDocument2, 234);
+            validateReturnedRowAfterDelete(ps, "col2_001", true, true, bsonDocument2, 234);
+            validateReturnedRowAfterDelete(ps, "col2_001", true, false, bsonDocument2, 234);
 
             validateMultiRowDelete(tableName, conn, bsonDocument2);
         }
@@ -184,6 +187,11 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
     public void testReturnRowResult2() throws Exception {
         Assume.assumeTrue("Set correct result to RegionActionResult on hbase versions " +
                 "2.4.18+, 2.5.9+, and 2.6.0+", isSetCorrectResultEnabledOnHBase());
+        // NOTE - Tuple result projection does not work well with local index because
+        // this assertion can be false: CellUtil.matchingRows(kvs[0], kvs[kvs.length-1])
+        // as the Tuple contains different rowkeys.
+        Assume.assumeTrue("ResultSet return does not work with local index",
+            !indexDDL.startsWith("create local index"));
 
         Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
         String sample1 = getJsonString("json/sample_01.json");
@@ -213,8 +221,7 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
             ps.setDouble(2, -123.98);
             ps.setString(3, "pk003");
             ps.setInt(4, 235);
-            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", true, false,
-                    bsonDocument2, 234);
+            validateReturnedRowAfterDelete(ps, "col2_001", true, false, bsonDocument2, 234);
 
             ps = conn.prepareStatement("DELETE FROM " + tableName
                             + " WHERE PK1 = ? AND PK2 = ? AND PK3 = ? AND COL4 = ?")
@@ -223,12 +230,10 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
             ps.setDouble(2, -123.98);
             ps.setString(3, "pk003");
             ps.setInt(4, 234);
-            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", true, true,
-                    bsonDocument2, 234);
+            validateReturnedRowAfterDelete(ps, "col2_001", true, true, bsonDocument2, 234);
 
             verifyIndexRow(conn, tableName, true);
-            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", true, false,
-                    bsonDocument2, 234);
+            validateReturnedRowAfterDelete(ps, "col2_001", true, false, bsonDocument2, 234);
 
             validateMultiRowDelete(tableName, conn, bsonDocument2);
         }
@@ -266,13 +271,11 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
                 .unwrap(PhoenixPreparedStatement.class);
         ps.setString(1, "pk001");
         ps.setDouble(2, 122.34);
-        validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", false, false,
-                bsonDocument2, 234);
+        validateReturnedRowAfterDelete(ps, "col2_001", false, false, bsonDocument2, 234);
 
         ps = conn.prepareStatement(
                 "DELETE FROM " + tableName).unwrap(PhoenixPreparedStatement.class);
-        validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", false, false,
-                bsonDocument2, 234);
+        validateReturnedRowAfterDelete(ps, "col2_001", false, false, bsonDocument2, 234);
 
         ResultSet rs = conn.createStatement().executeQuery("SELECT * FROM " + tableName);
         assertFalse(rs.next());
@@ -287,8 +290,7 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
         ps.setDouble(2, 122.34);
         ps.setString(3, "pk004");
         ps.setString(4, "pk005");
-        validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", false, false,
-                bsonDocument2, 234);
+        validateReturnedRowAfterDelete(ps, "col2_001", false, false, bsonDocument2, 234);
     }
 
     private static void validateAtomicUpsertReturnRow(String tableName, Connection conn, BsonDocument bsonDocument1,
@@ -353,71 +355,42 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
         conn.createStatement().execute(upsertSql);
     }
 
-    private static void validateReturnedRowAfterDelete(Connection conn,
-                                                       PhoenixPreparedStatement ps,
-                                                       String tableName,
-                                                       Double col1,
+    private static void validateReturnedRowAfterDelete(PhoenixPreparedStatement ps,
                                                        String col2,
                                                        boolean isSinglePointLookup,
                                                        boolean atomicDeleteSuccessful,
                                                        BsonDocument expectedDoc,
                                                        Integer col4)
             throws SQLException {
-        final Pair<Integer, Tuple> resultPair = ps.executeUpdateReturnRow();
-        ResultTuple result = (ResultTuple) resultPair.getSecond();
-
-        PTable table = conn.unwrap(PhoenixConnection.class).getTable(tableName);
-
+        final Pair<Integer, ResultSet> resultPair = ps.executeUpdateReturnRow();
+        ResultSet resultSet = resultPair.getSecond();
         if (!isSinglePointLookup) {
-            assertNull(result.getResult());
+            assertNull(resultSet);
             return;
         }
-        Cell cell =
-                result.getResult()
-                        .getColumnLatestCell(table.getColumns().get(3).getFamilyName().getBytes(),
-                                table.getColumns().get(3).getColumnQualifierBytes());
         if (!atomicDeleteSuccessful) {
-            assertNull(cell);
+            assertTrue(resultSet == null || resultSet.getObject(4) == null);
             return;
         }
-
-        validateReturnedRowResult(col2, expectedDoc, col4, table, result);
+        validateReturnedRowResult(col2, expectedDoc, col4, resultSet);
     }
 
-    private static void validateReturnedRowResult(String col2,
-                                                  BsonDocument expectedDoc, Integer col4,
-                                                  PTable table, ResultTuple result) {
-        Cell cell = result.getResult()
-                .getColumnLatestCell(table.getColumns().get(4).getFamilyName().getBytes(),
-                        table.getColumns().get(4).getColumnQualifierBytes());
+    private static void validateReturnedRowResult(String col2, BsonDocument expectedDoc,
+        Integer col4, ResultSet resultSet) throws SQLException {
         if (col2 != null) {
-            assertEquals(col2,
-                    PVarchar.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
-                            cell.getValueLength()));
+            assertEquals(col2, resultSet.getString(5));
         } else {
-            assertNull(cell);
+            assertNull(resultSet.getString(5));
         }
-
-        cell = result.getResult()
-                .getColumnLatestCell(table.getColumns().get(5).getFamilyName().getBytes(),
-                        table.getColumns().get(5).getColumnQualifierBytes());
         if (expectedDoc != null) {
-            assertEquals(expectedDoc,
-                    PBson.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
-                            cell.getValueLength()));
+            assertEquals(expectedDoc, resultSet.getObject(6));
         } else {
-            assertNull(cell);
+            assertNull(resultSet.getObject(6));
         }
-
-        cell = result.getResult()
-                .getColumnLatestCell(table.getColumns().get(6).getFamilyName().getBytes(),
-                        table.getColumns().get(6).getColumnQualifierBytes());
         if (col4 != null) {
-            assertEquals(col4,
-                    PInteger.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
-                            cell.getValueLength()));
+            assertEquals(col4, resultSet.getObject(7));
         } else {
-            assertNull(cell);
+            assertNull(resultSet.getObject(7));
         }
     }
 
@@ -431,7 +404,7 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
                                                        BsonDocument expectedDoc,
                                                        Integer col4)
             throws SQLException {
-        final Pair<Integer, Tuple> resultPair;
+        final Pair<Integer, ResultSet> resultPair;
         if (inputDoc != null) {
             PhoenixPreparedStatement ps =
                     conn.prepareStatement(upsertSql).unwrap(PhoenixPreparedStatement.class);
@@ -442,31 +415,14 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
                     .executeUpdateReturnRow(upsertSql);
         }
         assertEquals(success ? 1 : 0, resultPair.getFirst().intValue());
-        ResultTuple result = (ResultTuple) resultPair.getSecond();
+        ResultSet resultSet = resultPair.getSecond();
         PTable table = conn.unwrap(PhoenixConnection.class).getTable(tableName);
 
-        Cell cell =
-                result.getResult()
-                        .getColumnLatestCell(table.getColumns().get(3).getFamilyName().getBytes(),
-                                table.getColumns().get(3).getColumnQualifierBytes());
-        ImmutableBytesPtr ptr = new ImmutableBytesPtr();
-        table.getRowKeySchema().iterator(cell.getRowArray(), ptr, 1);
-        assertEquals("pk000",
-                PVarchar.INSTANCE.toObject(ptr.get(), ptr.getOffset(), ptr.getLength()));
-
-        ptr = new ImmutableBytesPtr();
-        table.getRowKeySchema().iterator(cell.getRowArray(), ptr, 2);
-        assertEquals(-123.98,
-                PDouble.INSTANCE.toObject(ptr.get(), ptr.getOffset(), ptr.getLength()));
-
-        ptr = new ImmutableBytesPtr();
-        table.getRowKeySchema().iterator(cell.getRowArray(), ptr, 3);
-        assertEquals("pk003",
-                PVarchar.INSTANCE.toObject(ptr.get(), ptr.getOffset(), ptr.getLength()));
-        assertEquals(col1,
-                PDouble.INSTANCE.toObject(cell.getValueArray(), cell.getValueOffset(),
-                        cell.getValueLength()));
-        validateReturnedRowResult(col2, expectedDoc, col4, table, result);
+        assertEquals("pk000", resultSet.getString(1));
+        assertEquals(-123.98, resultSet.getDouble(2), 0.0);
+        assertEquals("pk003", resultSet.getString(3));
+        assertEquals(col1, resultSet.getDouble(4), 0.0);
+        validateReturnedRowResult(col2, expectedDoc, col4, resultSet);
     }
 
     @Test
@@ -492,8 +448,7 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
             ps.setString(1, "pk001");
             ps.setString(2, "pk002");
             ps.setString(3, "pk003");
-            validateReturnedRowAfterDelete(conn, ps, tableName, 2233.99, "col2_001", false, false,
-                    null, 234);
+            validateReturnedRowAfterDelete(ps, "col2_001", false, false, null, 234);
 
             ResultSet rs = conn.createStatement().executeQuery("SELECT * FROM " + tableName);
             assertFalse(rs.next());


### PR DESCRIPTION
[PHOENIX-7398](https://issues.apache.org/jira/browse/PHOENIX-7398) introduces new PhoenixStatement API to return row for Atomic/Conditional Upserts. Phoenix already supports Upserts as Atomic operation by using ON DUPLICATE KEY clause.

Similarly, [PHOENIX-7411](https://issues.apache.org/jira/browse/PHOENIX-7411) and [PHOENIX-7434](https://issues.apache.org/jira/browse/PHOENIX-7434) introduce Atomic Delete support for the single row deletion. It returns result (row) back to the client (using new API) only if the given client initiated Delete operation deleted the row when the row was alive. In the context of atomicity, this means that the delete operation is already idempotent and will continue to be idempotent, however the client that was able to successfully delete the row by taking lock on the live row (row without delete marker) is expected to be the only client that can retrieve the old row result back.

The purpose of this Jira is to update the API signature for the PhoenixStatement API such that the abstract level ResultSet object can be returned for the returned row instead of Tuple object.

Old API signature:

```
/**
 * Executes the given SQL statement similar to JDBC API executeUpdate() but also returns the
 * updated or non-updated row as Result object back to the client. This must be used with
 * auto-commit Connection. This makes the operation atomic.
 * If the row is successfully updated, return the updated row, otherwise if the row
 * cannot be updated, return non-updated row.
 *
 * @param sql The SQL DML statement, UPSERT or DELETE for Phoenix.
 * @return The pair of int and Tuple, where int represents value 1 for successful row
 * update and 0 for non-successful row update, and Tuple represents the state of the row.
 * @throws SQLException If the statement cannot be executed.
 */
public Pair<Integer, Tuple> executeUpdateReturnRow(String sql) throws SQLException {
```

New API signature:

```
/**
 * Executes the given SQL statement similar to JDBC API executeUpdate() but also returns the
 * updated or non-updated row as ResultSet object back to the client. This must be used with
 * auto-commit Connection. This makes the operation atomic.
 * If the row is successfully updated, return the updated row, otherwise if the row
 * cannot be updated, return non-updated row.
 *
 * @param sql The SQL DML statement, UPSERT or DELETE for Phoenix.
 * @return The pair of int and ResultSet, where int represents value 1 for successful row
 * update and 0 for non-successful row update, and ResultSet represents the state of the row.
 * @throws SQLException If the statement cannot be executed.
 */
public Pair<Integer, ResultSet> executeAtomicUpdateReturnRow(String sql) throws SQLException {
```