### PR TITLE
python3.13 supported: no module `pipes` when running `sqlline.py`

### DIFF
--- a/bin/phoenix_utils.py
+++ b/bin/phoenix_utils.py
@@ -216,9 +216,9 @@ def shell_quote(args):
         import subprocess
         return subprocess.list2cmdline(args)
     else:
-        # pipes module isn't available on Windows
-        import pipes
-        return " ".join([pipes.quote(tryDecode(v)) for v in args])
+        # *nix
+        import shlex
+        return " ".join([shlex.quote(tryDecode(v)) for v in args])
 
 
 def __set_java_home():


### PR DESCRIPTION
# Problem
can not start sqlline.py due to no module `pipes`
```bash
Traceback (most recent call last):
  File "/opt/phoenix/bin/sqlline.py", line 103, in <module>
    (not args.noconnect and " -u " + phoenix_utils.shell_quote([jdbc_url]) or "") + \
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/opt/phoenix-hbase-2.5-5.2.1-bin/bin/phoenix_utils.py", line 209, in shell_quote
    import pipes
ModuleNotFoundError: No module named 'pipes'
```

# Causes
- `pipes` module is deprecated in python 3.13

# Fix
changes `pipes` module to `shlex`