### PR TITLE
PHOENIX-7515: Add metric for count of Phoenix client batches used by a commit call

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
@@ -88,7 +88,7 @@ public enum MetricType {
     DELETE_BATCH_FAILED_COUNTER("dbfc", "Number of delete mutation batches that failed to be committed",
             LogLevel.OFF, PLong.INSTANCE),
 
-    MUTATION_BATCH_SUCCESS_COUNTER("mbsc", "Number of mutations batches successfully committed " +
+    MUTATION_BATCH_SUCCESS_COUNTER("mbsc", "Number of mutation batches successfully committed " +
             "in a commit call", LogLevel.OFF, PLong.INSTANCE),
 
     // select-specific query (read) metrics updated during executeQuery

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
@@ -88,7 +88,7 @@ public enum MetricType {
     DELETE_BATCH_FAILED_COUNTER("dbfc", "Number of delete mutation batches that failed to be committed",
             LogLevel.OFF, PLong.INSTANCE),
 
-    MUTATION_BATCH_SUCCESS_COUNTER("mbsc", "Number of mutation batches successfully committed " +
+    MUTATION_BATCH_COUNTER("mbc", "Number of mutation batches committed " +
             "in a commit call", LogLevel.OFF, PLong.INSTANCE),
 
     // select-specific query (read) metrics updated during executeQuery

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
@@ -88,6 +88,9 @@ public enum MetricType {
     DELETE_BATCH_FAILED_COUNTER("dbfc", "Number of delete mutation batches that failed to be committed",
             LogLevel.OFF, PLong.INSTANCE),
 
+    MUTATION_BATCH_SUCCESS_COUNTER("mbsc", "Number of mutations batches successfully committed " +
+            "in a commit call", LogLevel.OFF, PLong.INSTANCE),
+
     // select-specific query (read) metrics updated during executeQuery
     SELECT_SUCCESS_SQL_COUNTER("sss", "Counter for number of select sql queries that successfully"
             + " passed the executeQuery phase", LogLevel.OFF, PLong.INSTANCE),

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
@@ -88,8 +88,8 @@ public enum MetricType {
     DELETE_BATCH_FAILED_COUNTER("dbfc", "Number of delete mutation batches that failed to be committed",
             LogLevel.OFF, PLong.INSTANCE),
 
-    MUTATION_BATCH_COUNTER("mbc", "Number of mutation batches committed " +
-            "in a commit call", LogLevel.OFF, PLong.INSTANCE),
+    MUTATION_BATCH_COUNTER("mbc", "Number of mutation batches committed "
+            + "in a commit call", LogLevel.OFF, PLong.INSTANCE),
 
     // select-specific query (read) metrics updated during executeQuery
     SELECT_SUCCESS_SQL_COUNTER("sss", "Counter for number of select sql queries that successfully"

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MutationMetricQueue.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MutationMetricQueue.java
@@ -23,7 +23,7 @@ import static org.apache.phoenix.monitoring.MetricType.DELETE_BATCH_FAILED_SIZE;
 import static org.apache.phoenix.monitoring.MetricType.DELETE_COMMIT_TIME;
 import static org.apache.phoenix.monitoring.MetricType.DELETE_MUTATION_BYTES;
 import static org.apache.phoenix.monitoring.MetricType.DELETE_MUTATION_SQL_COUNTER;
-import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_SUCCESS_COUNTER;
+import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_FAILED_SIZE;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_SIZE;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BYTES;
@@ -94,7 +94,7 @@ public class MutationMetricQueue {
             publishedMetricsForTable.put(metric.getUpsertBatchFailedCounter().getMetricType(), metric.getUpsertBatchFailedCounter().getValue());
             publishedMetricsForTable.put(metric.getDeleteBatchFailedSize().getMetricType(), metric.getDeleteBatchFailedSize().getValue());
             publishedMetricsForTable.put(metric.getDeleteBatchFailedCounter().getMetricType(), metric.getDeleteBatchFailedCounter().getValue());
-            publishedMetricsForTable.put(metric.getMutationBatchSuccessCounter().getMetricType(), metric.getMutationBatchSuccessCounter().getValue());
+            publishedMetricsForTable.put(metric.getMutationBatchCounter().getMetricType(), metric.getMutationBatchCounter().getValue());
         }
         return publishedMetrics;
     }
@@ -126,7 +126,7 @@ public class MutationMetricQueue {
         private final CombinableMetric numOfIndexCommitFailMutations = new CombinableMetricImpl(
                 INDEX_COMMIT_FAILURE_SIZE);
 
-        private final CombinableMetric mutationBatchSuccessCounter = new CombinableMetricImpl(MUTATION_BATCH_SUCCESS_COUNTER);
+        private final CombinableMetric mutationBatchCounter = new CombinableMetricImpl(MUTATION_BATCH_COUNTER);
 
         public static final MutationMetric EMPTY_METRIC =
                 new MutationMetric(0,0,0,0, 0, 0,0,0,0,0,0,0,0,0,0, 0);
@@ -137,7 +137,7 @@ public class MutationMetricQueue {
                 long deleteMutationSqlCounterSuccess, long totalMutationBytes,
                 long numOfPhase3Failed, long upsertBatchFailedSize,
                 long upsertBatchFailedCounter, long deleteBatchFailedSize,
-                long deleteBatchFailedCounter, long mutationBatchSuccessCounter) {
+                long deleteBatchFailedCounter, long mutationBatchCounter) {
             this.numMutations.change(numMutations);
             this.totalCommitTimeForUpserts.change(commitTimeForUpserts);
             this.totalCommitTimeForAtomicUpserts.change(commitTimeForAtomicUpserts);
@@ -154,7 +154,7 @@ public class MutationMetricQueue {
             this.upsertBatchFailedCounter.change(upsertBatchFailedCounter);
             this.deleteBatchFailedSize.change(deleteBatchFailedSize);
             this.deleteBatchFailedCounter.change(deleteBatchFailedCounter);
-            this.mutationBatchSuccessCounter.change(mutationBatchSuccessCounter);
+            this.mutationBatchCounter.change(mutationBatchCounter);
         }
 
         public CombinableMetric getTotalCommitTimeForUpserts() {
@@ -219,8 +219,8 @@ public class MutationMetricQueue {
             return deleteBatchFailedCounter;
         }
 
-        public CombinableMetric getMutationBatchSuccessCounter() {
-            return mutationBatchSuccessCounter;
+        public CombinableMetric getMutationBatchCounter() {
+            return mutationBatchCounter;
         }
 
         public void combineMetric(MutationMetric other) {
@@ -240,7 +240,7 @@ public class MutationMetricQueue {
             this.upsertBatchFailedCounter.combine(other.upsertBatchFailedCounter);
             this.deleteBatchFailedSize.combine(other.deleteBatchFailedSize);
             this.deleteBatchFailedCounter.combine(other.deleteBatchFailedCounter);
-            this.mutationBatchSuccessCounter.combine(other.mutationBatchSuccessCounter);
+            this.mutationBatchCounter.combine(other.mutationBatchCounter);
         }
 
     }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MutationMetricQueue.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MutationMetricQueue.java
@@ -94,7 +94,8 @@ public class MutationMetricQueue {
             publishedMetricsForTable.put(metric.getUpsertBatchFailedCounter().getMetricType(), metric.getUpsertBatchFailedCounter().getValue());
             publishedMetricsForTable.put(metric.getDeleteBatchFailedSize().getMetricType(), metric.getDeleteBatchFailedSize().getValue());
             publishedMetricsForTable.put(metric.getDeleteBatchFailedCounter().getMetricType(), metric.getDeleteBatchFailedCounter().getValue());
-            publishedMetricsForTable.put(metric.getMutationBatchCounter().getMetricType(), metric.getMutationBatchCounter().getValue());
+            publishedMetricsForTable.put(metric.getMutationBatchCounter().getMetricType(),
+                    metric.getMutationBatchCounter().getValue());
         }
         return publishedMetrics;
     }
@@ -126,10 +127,11 @@ public class MutationMetricQueue {
         private final CombinableMetric numOfIndexCommitFailMutations = new CombinableMetricImpl(
                 INDEX_COMMIT_FAILURE_SIZE);
 
-        private final CombinableMetric mutationBatchCounter = new CombinableMetricImpl(MUTATION_BATCH_COUNTER);
+        private final CombinableMetric mutationBatchCounter =
+                new CombinableMetricImpl(MUTATION_BATCH_COUNTER);
 
         public static final MutationMetric EMPTY_METRIC =
-                new MutationMetric(0,0,0,0, 0, 0,0,0,0,0,0,0,0,0,0, 0);
+                new MutationMetric(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
         public MutationMetric(long numMutations, long upsertMutationsSizeBytes,
                 long deleteMutationsSizeBytes, long commitTimeForUpserts, long commitTimeForAtomicUpserts,

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MutationMetricQueue.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MutationMetricQueue.java
@@ -23,6 +23,7 @@ import static org.apache.phoenix.monitoring.MetricType.DELETE_BATCH_FAILED_SIZE;
 import static org.apache.phoenix.monitoring.MetricType.DELETE_COMMIT_TIME;
 import static org.apache.phoenix.monitoring.MetricType.DELETE_MUTATION_BYTES;
 import static org.apache.phoenix.monitoring.MetricType.DELETE_MUTATION_SQL_COUNTER;
+import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_SUCCESS_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_FAILED_SIZE;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_SIZE;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BYTES;
@@ -93,7 +94,7 @@ public class MutationMetricQueue {
             publishedMetricsForTable.put(metric.getUpsertBatchFailedCounter().getMetricType(), metric.getUpsertBatchFailedCounter().getValue());
             publishedMetricsForTable.put(metric.getDeleteBatchFailedSize().getMetricType(), metric.getDeleteBatchFailedSize().getValue());
             publishedMetricsForTable.put(metric.getDeleteBatchFailedCounter().getMetricType(), metric.getDeleteBatchFailedCounter().getValue());
-
+            publishedMetricsForTable.put(metric.getMutationBatchSuccessCounter().getMetricType(), metric.getMutationBatchSuccessCounter().getValue());
         }
         return publishedMetrics;
     }
@@ -125,8 +126,10 @@ public class MutationMetricQueue {
         private final CombinableMetric numOfIndexCommitFailMutations = new CombinableMetricImpl(
                 INDEX_COMMIT_FAILURE_SIZE);
 
+        private final CombinableMetric mutationBatchSuccessCounter = new CombinableMetricImpl(MUTATION_BATCH_SUCCESS_COUNTER);
+
         public static final MutationMetric EMPTY_METRIC =
-                new MutationMetric(0,0,0,0, 0, 0,0,0,0,0,0,0,0,0,0);
+                new MutationMetric(0,0,0,0, 0, 0,0,0,0,0,0,0,0,0,0, 0);
 
         public MutationMetric(long numMutations, long upsertMutationsSizeBytes,
                 long deleteMutationsSizeBytes, long commitTimeForUpserts, long commitTimeForAtomicUpserts,
@@ -134,7 +137,7 @@ public class MutationMetricQueue {
                 long deleteMutationSqlCounterSuccess, long totalMutationBytes,
                 long numOfPhase3Failed, long upsertBatchFailedSize,
                 long upsertBatchFailedCounter, long deleteBatchFailedSize,
-                long deleteBatchFailedCounter) {
+                long deleteBatchFailedCounter, long mutationBatchSuccessCounter) {
             this.numMutations.change(numMutations);
             this.totalCommitTimeForUpserts.change(commitTimeForUpserts);
             this.totalCommitTimeForAtomicUpserts.change(commitTimeForAtomicUpserts);
@@ -151,6 +154,7 @@ public class MutationMetricQueue {
             this.upsertBatchFailedCounter.change(upsertBatchFailedCounter);
             this.deleteBatchFailedSize.change(deleteBatchFailedSize);
             this.deleteBatchFailedCounter.change(deleteBatchFailedCounter);
+            this.mutationBatchSuccessCounter.change(mutationBatchSuccessCounter);
         }
 
         public CombinableMetric getTotalCommitTimeForUpserts() {
@@ -215,6 +219,10 @@ public class MutationMetricQueue {
             return deleteBatchFailedCounter;
         }
 
+        public CombinableMetric getMutationBatchSuccessCounter() {
+            return mutationBatchSuccessCounter;
+        }
+
         public void combineMetric(MutationMetric other) {
             this.numMutations.combine(other.numMutations);
             this.totalCommitTimeForUpserts.combine(other.totalCommitTimeForUpserts);
@@ -232,6 +240,7 @@ public class MutationMetricQueue {
             this.upsertBatchFailedCounter.combine(other.upsertBatchFailedCounter);
             this.deleteBatchFailedSize.combine(other.deleteBatchFailedSize);
             this.deleteBatchFailedCounter.combine(other.deleteBatchFailedCounter);
+            this.mutationBatchSuccessCounter.combine(other.mutationBatchSuccessCounter);
         }
 
     }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/TableClientMetrics.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/TableClientMetrics.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_SIZE;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_FAILED_SIZE;
+import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_SUCCESS_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BYTES;
 import static org.apache.phoenix.monitoring.MetricType.NUM_METADATA_LOOKUP_FAILURES;
 import static org.apache.phoenix.monitoring.MetricType.NUM_SYSTEM_TABLE_RPC_FAILURES;
@@ -140,7 +141,8 @@ public class TableClientMetrics {
                 TABLE_NUM_SYSTEM_TABLE_RPC_SUCCESS(NUM_SYSTEM_TABLE_RPC_SUCCESS),
                 TABLE_NUM_SYSTEM_TABLE_RPC_FAILURES(NUM_SYSTEM_TABLE_RPC_FAILURES),
                 TABLE_NUM_METADATA_LOOKUP_FAILURES(NUM_METADATA_LOOKUP_FAILURES),
-                TABLE_TIME_SPENT_IN_SYSTEM_TABLE_RPC_CALLS(TIME_SPENT_IN_SYSTEM_TABLE_RPC_CALLS);
+                TABLE_TIME_SPENT_IN_SYSTEM_TABLE_RPC_CALLS(TIME_SPENT_IN_SYSTEM_TABLE_RPC_CALLS),
+                TABLE_MUTATION_BATCH_SUCCESS_COUNTER(MUTATION_BATCH_SUCCESS_COUNTER);
 
         private MetricType metricType;
         private PhoenixTableMetric metric;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/TableClientMetrics.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/TableClientMetrics.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_SIZE;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_FAILED_SIZE;
-import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_SUCCESS_COUNTER;
+import static org.apache.phoenix.monitoring.MetricType.MUTATION_BATCH_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.MUTATION_BYTES;
 import static org.apache.phoenix.monitoring.MetricType.NUM_METADATA_LOOKUP_FAILURES;
 import static org.apache.phoenix.monitoring.MetricType.NUM_SYSTEM_TABLE_RPC_FAILURES;
@@ -75,9 +75,6 @@ import static org.apache.phoenix.monitoring.MetricType.DELETE_AGGREGATE_SUCCESS_
 import static org.apache.phoenix.monitoring.MetricType.DELETE_AGGREGATE_FAILURE_SQL_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.SELECT_AGGREGATE_SUCCESS_SQL_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.SELECT_AGGREGATE_FAILURE_SQL_COUNTER;
-import static org.apache.phoenix.monitoring.MetricType.NUM_SYSTEM_TABLE_RPC_SUCCESS;
-import static org.apache.phoenix.monitoring.MetricType.NUM_SYSTEM_TABLE_RPC_FAILURES;
-import static org.apache.phoenix.monitoring.MetricType.TIME_SPENT_IN_SYSTEM_TABLE_RPC_CALLS;
 import static org.apache.phoenix.monitoring.MetricType.ATOMIC_UPSERT_COMMIT_TIME;
 import static org.apache.phoenix.monitoring.MetricType.ATOMIC_UPSERT_SQL_COUNTER;
 import static org.apache.phoenix.monitoring.MetricType.ATOMIC_UPSERT_SQL_QUERY_TIME;
@@ -142,7 +139,7 @@ public class TableClientMetrics {
                 TABLE_NUM_SYSTEM_TABLE_RPC_FAILURES(NUM_SYSTEM_TABLE_RPC_FAILURES),
                 TABLE_NUM_METADATA_LOOKUP_FAILURES(NUM_METADATA_LOOKUP_FAILURES),
                 TABLE_TIME_SPENT_IN_SYSTEM_TABLE_RPC_CALLS(TIME_SPENT_IN_SYSTEM_TABLE_RPC_CALLS),
-                TABLE_MUTATION_BATCH_SUCCESS_COUNTER(MUTATION_BATCH_SUCCESS_COUNTER);
+                TABLE_MUTATION_BATCH_SUCCESS_COUNTER(MUTATION_BATCH_COUNTER);
 
         private MetricType metricType;
         private PhoenixTableMetric metric;

--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/BasePhoenixMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/BasePhoenixMetricsIT.java
@@ -115,7 +115,7 @@ public abstract class BasePhoenixMetricsIT extends BaseTest {
             assertEquals("Table names didn't match!", tableName, t);
             Map<MetricType, Long> p = entry.getValue();
 
-            assertEquals("There should have been sixteen metrics", 17, p.size());
+            assertEquals("There should have been seventeen metrics", 17, p.size());
 
             boolean mutationBatchSizePresent = false;
             boolean mutationCommitTimePresent = false;

--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/BasePhoenixMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/BasePhoenixMetricsIT.java
@@ -132,7 +132,7 @@ public abstract class BasePhoenixMetricsIT extends BaseTest {
             boolean upsertMutationSqlCounterPresent = false;
             boolean upsertCommitTimeCounterPresent = false;
             boolean deleteCommitTimeCounterPresent = false;
-            boolean mutationBatchSuccessCounterPresent = false;
+            boolean mutationBatchCounterPresent = false;
             for (Map.Entry<MetricType, Long> metric : p.entrySet()) {
                 MetricType metricType = metric.getKey();
                 long metricValue = metric.getValue();
@@ -207,10 +207,10 @@ public abstract class BasePhoenixMetricsIT extends BaseTest {
                     }
                     deleteCommitTimeCounterPresent = true;
                 }
-                else if (metricType.equals(MetricType.MUTATION_BATCH_SUCCESS_COUNTER)) {
+                else if (metricType.equals(MetricType.MUTATION_BATCH_COUNTER)) {
                     assertTrue("mutation batch success counter should be greater than zero",
                             metricValue > 0);
-                    mutationBatchSuccessCounterPresent = true;
+                    mutationBatchCounterPresent = true;
                 }
             }
             assertTrue(mutationBatchSizePresent);
@@ -228,7 +228,7 @@ public abstract class BasePhoenixMetricsIT extends BaseTest {
             assertTrue(deleteBatchFailedCounterPresent);
             assertTrue(upsertCommitTimeCounterPresent);
             assertTrue(deleteCommitTimeCounterPresent);
-            assertTrue(mutationBatchSuccessCounterPresent);
+            assertTrue(mutationBatchCounterPresent);
         }
     }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/BasePhoenixMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/BasePhoenixMetricsIT.java
@@ -115,7 +115,7 @@ public abstract class BasePhoenixMetricsIT extends BaseTest {
             assertEquals("Table names didn't match!", tableName, t);
             Map<MetricType, Long> p = entry.getValue();
 
-            assertEquals("There should have been sixteen metrics", 16, p.size());
+            assertEquals("There should have been sixteen metrics", 17, p.size());
 
             boolean mutationBatchSizePresent = false;
             boolean mutationCommitTimePresent = false;
@@ -132,6 +132,7 @@ public abstract class BasePhoenixMetricsIT extends BaseTest {
             boolean upsertMutationSqlCounterPresent = false;
             boolean upsertCommitTimeCounterPresent = false;
             boolean deleteCommitTimeCounterPresent = false;
+            boolean mutationBatchSuccessCounterPresent = false;
             for (Map.Entry<MetricType, Long> metric : p.entrySet()) {
                 MetricType metricType = metric.getKey();
                 long metricValue = metric.getValue();
@@ -206,6 +207,11 @@ public abstract class BasePhoenixMetricsIT extends BaseTest {
                     }
                     deleteCommitTimeCounterPresent = true;
                 }
+                else if (metricType.equals(MetricType.MUTATION_BATCH_SUCCESS_COUNTER)) {
+                    assertTrue("mutation batch success counter should be greater than zero",
+                            metricValue > 0);
+                    mutationBatchSuccessCounterPresent = true;
+                }
             }
             assertTrue(mutationBatchSizePresent);
             assertTrue(mutationCommitTimePresent);
@@ -222,6 +228,7 @@ public abstract class BasePhoenixMetricsIT extends BaseTest {
             assertTrue(deleteBatchFailedCounterPresent);
             assertTrue(upsertCommitTimeCounterPresent);
             assertTrue(deleteCommitTimeCounterPresent);
+            assertTrue(mutationBatchSuccessCounterPresent);
         }
     }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/PhoenixMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/PhoenixMetricsIT.java
@@ -379,6 +379,29 @@ public class PhoenixMetricsIT extends BasePhoenixMetricsIT {
         }
     }
 
+    static void createTableAndRunUpsertSelect(String destTableName, String sourceTableName,
+                                              boolean resetGlobalMetricsAfterTableCreate,
+                                              boolean resetTableMetricsAfterTableCreate,
+                                              boolean commit, Connection conn) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute(String.format(DDL, destTableName));
+        }
+        conn.commit();
+        if (resetGlobalMetricsAfterTableCreate) {
+            resetGlobalMetrics();
+        }
+
+        if (resetTableMetricsAfterTableCreate) {
+            PhoenixRuntime.clearTableLevelMetrics();
+        }
+        try (Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate(String.format(UPSERT_SELECT_DML, destTableName, sourceTableName));
+        }
+        if (commit) {
+            conn.commit();
+        }
+    }
+
     static void doPointDeleteFromTable(String tableName, Connection conn) throws SQLException {
         try (PreparedStatement stmt = conn.prepareStatement(
                 String.format(POINT_DELETE_DML, tableName))) {

--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/PhoenixMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/PhoenixMetricsIT.java
@@ -512,7 +512,7 @@ public class PhoenixMetricsIT extends BasePhoenixMetricsIT {
             String t = entry.getKey();
             assertEquals("Table names didn't match!", tableName, t);
             Map<MetricType, Long> p = entry.getValue();
-            assertEquals("There should have been sixteen metrics", 17, p.size());
+            assertEquals("There should have been seventeen metrics", 17, p.size());
             boolean mutationBatchSizePresent = false;
             boolean mutationCommitTimePresent = false;
             boolean mutationBytesPresent = false;

--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/PhoenixTableLevelMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/PhoenixTableLevelMetricsIT.java
@@ -335,6 +335,8 @@ public class PhoenixTableLevelMetricsIT extends BaseTest {
      * @param writeMutMetrics                       write mutation metrics object
      * @param conn                                  connection object. Note: this method must be called after connection close
      *                                              since that's where we populate table-level write metrics
+     * @param expectedMutationBatchCount            expected number of mutation batches per commit call
+
      */
     private static void assertMutationTableMetrics(final boolean isUpsert, final String tableName,
             final long expectedUpsertOrDeleteSuccessSqlCt,

--- a/phoenix-core/src/test/java/org/apache/phoenix/monitoring/TableMetricsManagerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/monitoring/TableMetricsManagerTest.java
@@ -236,32 +236,32 @@ public class TableMetricsManagerTest {
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 1, true);
         MutationMetricQueue.MutationMetric metric = new MutationMetricQueue.MutationMetric(
                 0L, 5L, 0L, 0L, 0L,0L,
-                0L, 1L, 0L, 5L, 0L, 0L, 0L, 0L, 0L);
+                0L, 1L, 0L, 5L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), true);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 2, true);
         metric = new MutationMetricQueue.MutationMetric(0L, 10L, 0L, 0L, 0L,0L,
-                0L, 1L, 0L, 10L, 0L, 0L, 0L, 0L, 0L);
+                0L, 1L, 0L, 10L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), true);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 4, true);
         metric = new MutationMetricQueue.MutationMetric(0L, 50L, 0L, 0L, 0L,0L,
-                0L, 1L, 0L, 50L, 0L, 0L, 0L, 0L, 0L);
+                0L, 1L, 0L, 50L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), true);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 5, true);
         metric = new MutationMetricQueue.MutationMetric(0L, 100L, 0L, 0L, 0L,0L,
-                0L, 1L, 0L, 100L, 0L, 0L, 0L, 0L, 0L);
+                0L, 1L, 0L, 100L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), true);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 6, true);
         metric = new MutationMetricQueue.MutationMetric(0L, 500L, 0L, 0L, 0L,0L,
-                0L, 1L, 0L, 500L, 0L, 0L, 0L, 0L, 0L);
+                0L, 1L, 0L, 500L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), true);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 8, true);
         metric = new MutationMetricQueue.MutationMetric(0L, 1000L, 0L, 0L, 0L,0L,
-                0L, 1L, 0L, 1000L, 0L, 0L, 0L, 0L, 0L);
+                0L, 1L, 0L, 1000L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), true);
 
 
@@ -300,32 +300,32 @@ public class TableMetricsManagerTest {
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 1, false);
         MutationMetricQueue.MutationMetric metric = new MutationMetricQueue.MutationMetric(
                 0L, 0L, 5L, 0L, 0L, 0L,
-                0L, 0L, 1L, 5L, 0L, 0L, 0L, 0L, 0L);
+                0L, 0L, 1L, 5L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), false);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 2, false);
         metric = new MutationMetricQueue.MutationMetric(0L, 0L, 10L, 0L, 0L, 0L,
-                0L, 0L, 1L, 10L, 0L, 0L, 0L, 0L, 0L);
+                0L, 0L, 1L, 10L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), false);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 4, false);
         metric = new MutationMetricQueue.MutationMetric(0L, 0L, 50L, 0L, 0L, 0L,
-                0L, 0L, 1L, 50L, 0L, 0L, 0L, 0L, 0L);
+                0L, 0L, 1L, 50L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), false);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 5,false);
         metric = new MutationMetricQueue.MutationMetric(0L, 0L, 100L, 0L, 0L, 0L,
-                0L, 0L, 1L, 100L, 0L, 0L, 0L, 0L, 0L);
+                0L, 0L, 1L, 100L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), false);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 6,false);
         metric = new MutationMetricQueue.MutationMetric(0L, 0L, 500L, 0L, 0L, 0L,
-                0L, 0L, 1L, 500L, 0L, 0L, 0L, 0L, 0L);
+                0L, 0L, 1L, 500L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), false);
 
         TableMetricsManager.updateLatencyHistogramForMutations(tableName, 8, false);
         metric = new MutationMetricQueue.MutationMetric(0L, 0L, 1000L, 0L, 0L, 0L,
-                0L, 0L, 1L, 1000L, 0L, 0L, 0L, 0L, 0L);
+                0L, 0L, 1L, 1000L, 0L, 0L, 0L, 0L, 0L, 0L);
         TableMetricsManager.updateSizeHistogramMetricsForMutations(tableName, metric.getTotalMutationsSizeBytes().getValue(), false);
 
 


### PR DESCRIPTION
Summary of the changes:
- Added a metric to track no. of mutation batches successful per commit call. 