### PR TITLE
PHOENIX-7489 Add all partition ids internally to optimize full CDC Index scan queries

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -48,7 +48,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.sql.BatchUpdateException;
-import java.sql.Connection;
 import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -395,10 +394,10 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                                         && selectNodes.get(0)
                                                         .getNode() instanceof PartitionIdParseNode;
                                         if (!queryPartitionIds &&
-                                                !isPartitionIdIncludedInTree(parseNode)) {
-                                            stmt = parseStatement(addPartitionInList(conn,
+                                                !CDCUtil.isPartitionIdIncludedInTree(parseNode)) {
+                                            stmt = parseStatement(CDCUtil.addPartitionInList(conn,
                                                     plan.getTableRef().getTable().toString(),
-                                                    stmt));
+                                                    stmt.toString()));
                                             plan = stmt.compilePlan(PhoenixStatement.this,
                                                     Sequence.ValueOp.VALIDATE_SEQUENCE);
                                         }
@@ -579,75 +578,6 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
             Throwables.propagate(e);
             throw new IllegalStateException(); // Can't happen as Throwables.propagate() always throws
         }
-    }
-
-    /**
-     * Add IN Operator for PARTITION_ID() so that the full table scan CDC query can be
-     * optimized to be range scan.
-     *
-     * @param conn The Connection.
-     * @param cdcName CDC Object name.
-     * @param stmt Compilable Statement object.
-     * @return Updated query including PartitionId with IN operator.
-     * @throws SQLException If the distinct partition ids retrival fails.
-     */
-    private static String addPartitionInList(Connection conn, String cdcName,
-                                             CompilableStatement stmt)
-            throws SQLException {
-        ResultSet rs = conn.createStatement().executeQuery("SELECT DISTINCT PARTITION_ID() FROM "
-                + cdcName);
-        List<String> partitionIds = new ArrayList<>();
-        while (rs.next()) {
-            partitionIds.add(rs.getString(1));
-        }
-        String query = stmt.toString();
-        if (partitionIds.isEmpty()) {
-            return query;
-        }
-        StringBuilder builder;
-        boolean queryHasWhere = query.contains(" WHERE ");
-        if (queryHasWhere) {
-            builder = new StringBuilder(query);
-            builder.append(" AND PARTITION_ID() IN (");
-        } else {
-            builder = new StringBuilder(query.split(cdcName)[0]);
-            builder.append(cdcName);
-            builder.append(" WHERE PARTITION_ID() IN (");
-        }
-        boolean initialized = false;
-        for (String partitionId : partitionIds) {
-            if (!initialized) {
-                builder.append("'");
-                initialized = true;
-            } else {
-                builder.append(",'");
-            }
-            builder.append(partitionId);
-            builder.append("'");
-        }
-        builder.append(")");
-        if (!queryHasWhere) {
-            builder.append(query.split(cdcName)[1]);
-        }
-        return builder.toString();
-    }
-
-    /**
-     * Return true if the parseNode or any of its children contains PARTITION_ID() function.
-     *
-     * @param parseNode The parseNode from Where clause.
-     * @return True if the parseNode or any of its children contains PARTITION_ID()
-     * function. False otherwise.
-     */
-    private static boolean isPartitionIdIncludedInTree(ParseNode parseNode) {
-        if (parseNode instanceof PartitionIdParseNode) {
-            return true;
-        }
-        if (parseNode == null || CollectionUtils.isEmpty(parseNode.getChildren())) {
-            return false;
-        }
-        return parseNode.getChildren().stream()
-                .anyMatch(PhoenixStatement::isPartitionIdIncludedInTree);
     }
 
     public String getTargetForAudit(CompilableStatement stmt) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/CDCUtil.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/CDCUtil.java
@@ -188,7 +188,7 @@ public class CDCUtil {
      * @param cdcName CDC Object name.
      * @param query SQL Query Statement.
      * @return Updated query including PartitionId with IN operator.
-     * @throws SQLException If the distinct partition ids retrival fails.
+     * @throws SQLException If the distinct partition ids retrieval fails.
      */
     public static String addPartitionInList(final Connection conn, final String cdcName,
                                             final String query) throws SQLException {

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
@@ -249,7 +249,7 @@ public class CDCQueryIT extends CDCBaseIT {
         return query.toString();
     }
 
-    private static PreparedStatement getCDCQueryPreparedStatement(Connection conn, String cdcName,
+    private static PreparedStatement getCDCQueryPreparedStatement(Connection conn,
             String query, long minTimestamp, long maxTimestamp)
             throws SQLException {
         StringBuilder builder = new StringBuilder(query);
@@ -338,21 +338,21 @@ public class CDCQueryIT extends CDCBaseIT {
                 put("V2", "INTEGER");
                 put("B.VB", "INTEGER");
             }};
-            verifyChangesViaSCN(tenantId, getCDCQueryPreparedStatement(conn, cdcFullName,
+            verifyChangesViaSCN(tenantId, getCDCQueryPreparedStatement(conn,
                             "SELECT /*+ CDC_INCLUDE(CHANGE) */ * FROM " + cdcFullName, startTS,
                             endTS).executeQuery(),
                     datatableName, dataColumns, changes, CHANGE_IMG);
-            verifyChangesViaSCN(tenantId, getCDCQueryPreparedStatement(conn, cdcFullName,
+            verifyChangesViaSCN(tenantId, getCDCQueryPreparedStatement(conn,
                             "SELECT /*+ CDC_INCLUDE(CHANGE) */ PHOENIX_ROW_TIMESTAMP(), K,"
                                     + "\"CDC JSON\" FROM " + cdcFullName, startTS, endTS)
                             .executeQuery(),
                     datatableName, dataColumns, changes, CHANGE_IMG);
-            verifyChangesViaSCN(tenantId, getCDCQueryPreparedStatement(conn, cdcFullName,
+            verifyChangesViaSCN(tenantId, getCDCQueryPreparedStatement(conn,
                             "SELECT /*+ CDC_INCLUDE(PRE, POST) */ * FROM " + cdcFullName,
                             startTS, endTS).executeQuery(),
                     datatableName, dataColumns, changes,
                     PRE_POST_IMG);
-            verifyChangesViaSCN(tenantId, getCDCQueryPreparedStatement(conn, cdcFullName,
+            verifyChangesViaSCN(tenantId, getCDCQueryPreparedStatement(conn,
                     "SELECT * FROM " + cdcFullName,startTS, endTS).executeQuery(),
                     datatableName, dataColumns, changes, new HashSet<>());
 


### PR DESCRIPTION
Jira: PHOENIX-7489

Since [PHOENIX-7425](https://issues.apache.org/jira/browse/PHOENIX-7425) introduced partitioned CDC Index to eliminate salting, it is important to include PARTITION_ID() in addition to PHOENIX_ROW_TIMESTAMP() with the WHERE clause of the CDC query. Before [PHOENIX-7425](https://issues.apache.org/jira/browse/PHOENIX-7425), providing only PHOENIX_ROW_TIMESTAMP() was sufficient as it was the rowkey prefix of the CDC Index table. However, that is not the case anymore.

If the user only provides PHOENIX_ROW_TIMESTAMP() with the WHERE clause, it would result into the full table scan over the CDC Index. By providing both PARTITION_ID() and PHOENIX_ROW_TIMESTAMP(), it results into the range scan.

Not all the clients might be aware of all unique partition ids present in the CDC Index. Hence, even if a client only provides the timestamp range with the CDC query, the list of partition ids should be internally retrieved and used alongside the timestamp range for the efficient range scan performance.