### PR TITLE
PHOENIX-7528 Add metrics for overall wall clock query wait time in Phoenix client thread pool and total time spent in executing HBase scan tasks

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/iterate/RoundRobinResultIterator.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/iterate/RoundRobinResultIterator.java
@@ -19,12 +19,12 @@ package org.apache.phoenix.iterate;
 
 import static org.apache.phoenix.thirdparty.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.phoenix.monitoring.GlobalClientMetrics.GLOBAL_FAILED_QUERY_COUNTER;
+import static org.apache.phoenix.job.JobManager.JobCallable;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -32,7 +32,10 @@ import org.apache.phoenix.compile.ExplainPlanAttributes
     .ExplainPlanAttributesBuilder;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.compile.StatementContext;
+import org.apache.phoenix.job.JobManager;
 import org.apache.phoenix.monitoring.OverAllQueryMetrics;
+import org.apache.phoenix.monitoring.ReadMetricQueue;
+import org.apache.phoenix.monitoring.TaskExecutionMetricsHolder;
 import org.apache.phoenix.query.ConnectionQueryServices;
 import org.apache.phoenix.schema.tuple.Tuple;
 import org.apache.phoenix.util.ClientUtil;
@@ -167,7 +170,7 @@ public class RoundRobinResultIterator implements ResultIterator {
     }
 
     @VisibleForTesting
-    int getNumberOfParallelFetches() {
+    public int getNumberOfParallelFetches() {
         return numParallelFetches;
     }
 
@@ -230,6 +233,8 @@ public class RoundRobinResultIterator implements ResultIterator {
         Collections.shuffle(openIterators);
         boolean success = false;
         SQLException toThrow = null;
+        long maxTaskQueueWaitTime = 0;
+        long maxTaskEndToEndTime = 0;
         try {
             StatementContext context = plan.getContext();
             final ConnectionQueryServices services = context.getConnection().getQueryServices();
@@ -238,12 +243,29 @@ public class RoundRobinResultIterator implements ResultIterator {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Performing parallel fetch for " + openIterators.size() + " iterators. ");
             }
+            String physicalTableName = plan.getTableRef().getTable().getPhysicalName().getString();
             for (final RoundRobinIterator itr : openIterators) {
-                Future<Tuple> future = executor.submit(new Callable<Tuple>() {
+                ReadMetricQueue readMetricQueue = context.getReadMetricsQueue();
+                TaskExecutionMetricsHolder taskMetrics =
+                        new TaskExecutionMetricsHolder(readMetricQueue, physicalTableName);
+                Future<Tuple> future = executor.submit(new JobCallable<Tuple>() {
                     @Override
                     public Tuple call() throws Exception {
                         // Read the next record to refill the scanner's cache.
                         return itr.next();
+                    }
+
+                    @Override
+                    public Object getJobId() {
+                        // Prior to using JobCallable, every callable refilling the scanner cache
+                        // was treated as a separate producer in JobManager queue so, keeping
+                        // that same. Should this be changed to ResultIterators.this ?
+                        return this;
+                    }
+
+                    @Override
+                    public TaskExecutionMetricsHolder getTaskExecutionMetric() {
+                        return taskMetrics;
                     }
                 });
                 futures.add(future);
@@ -251,6 +273,10 @@ public class RoundRobinResultIterator implements ResultIterator {
             int i = 0;
             for (Future<Tuple> future : futures) {
                 Tuple tuple = future.get();
+                long taskQueueWaitTime = JobManager.getTaskQueueWaitTime(future);
+                long taskEndToEndTime = JobManager.getTaskEndToEndTime(future);
+                maxTaskQueueWaitTime = Math.max(maxTaskQueueWaitTime, taskQueueWaitTime);
+                maxTaskEndToEndTime = Math.max(maxTaskEndToEndTime, taskEndToEndTime);
                 if (tuple != null) {
                     results.add(new RoundRobinIterator(openIterators.get(i).delegate, tuple));
                 } else {
@@ -279,9 +305,12 @@ public class RoundRobinResultIterator implements ResultIterator {
                     }
                 }
             } finally {
+                OverAllQueryMetrics overAllQueryMetrics =
+                        plan.getContext().getOverallQueryMetrics();
+                overAllQueryMetrics.updateQueryWaitTime(maxTaskQueueWaitTime);
+                overAllQueryMetrics.updateQueryTaskEndToEndTime(maxTaskEndToEndTime);
                 if (toThrow != null) {
                     GLOBAL_FAILED_QUERY_COUNTER.increment();
-                    OverAllQueryMetrics overAllQueryMetrics = plan.getContext().getOverallQueryMetrics();
                     overAllQueryMetrics.queryFailed();
                     if (plan.getContext().getScanRanges().isPointLookup()) {
                         overAllQueryMetrics.queryPointLookupFailed();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/job/JobManager.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/job/JobManager.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.Nullable;
 
-import org.apache.phoenix.iterate.PeekingResultIterator;
 import org.apache.phoenix.monitoring.TaskExecutionMetricsHolder;
 
 import org.apache.phoenix.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/monitoring/MetricType.java
@@ -141,6 +141,11 @@ public enum MetricType {
     CACHE_REFRESH_SPLITS_COUNTER("cr", "Number of times cache was refreshed because of splits",LogLevel.DEBUG, PLong.INSTANCE),
     WALL_CLOCK_TIME_MS("tq", "Wall clock time elapsed for the overall query execution",LogLevel.INFO, PLong.INSTANCE),
     RESULT_SET_TIME_MS("tn", "Wall clock time elapsed for reading all records using resultSet.next()",LogLevel.INFO, PLong.INSTANCE),
+    WALL_CLOCK_QUERY_WAIT_TIME("qwt", "Total wall clock time spent by a " +
+            "query waiting in the Phoenix client thread pool queue", LogLevel.OFF, PLong.INSTANCE),
+    WALL_CLOCK_QUERY_TASK_END_TO_END_TIME("qeet", "Total wall clock time " +
+            "spent by a query in task execution in the Phoenix client thread pool" +
+            "including the queue wait time", LogLevel.OFF, PLong.INSTANCE),
     OPEN_PHOENIX_CONNECTIONS_COUNTER("o", "Number of open phoenix connections",LogLevel.OFF, PLong.INSTANCE),
     OPEN_INTERNAL_PHOENIX_CONNECTIONS_COUNTER("io", "Number of open internal phoenix connections",LogLevel.OFF, PLong.INSTANCE),
     QUERY_SERVICES_COUNTER("cqs", "Number of ConnectionQueryServicesImpl instantiated",LogLevel.OFF, PLong.INSTANCE),

--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/PhoenixMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/PhoenixMetricsIT.java
@@ -75,6 +75,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.metrics2.AbstractMetric;
@@ -84,6 +85,7 @@ import org.apache.hbase.thirdparty.com.google.common.collect.Sets;
 import org.apache.phoenix.compile.StatementContext;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.exception.SQLExceptionCode;
+import org.apache.phoenix.iterate.RoundRobinResultIterator;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixDriver;
 import org.apache.phoenix.jdbc.PhoenixResultSet;
@@ -486,7 +488,9 @@ public class PhoenixMetricsIT extends BasePhoenixMetricsIT {
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery(query);
         PhoenixResultSet resultSetBeingTested = rs.unwrap(PhoenixResultSet.class);
-        changeInternalStateForTesting(resultSetBeingTested);
+        // TODO use a spy ?
+        ReadMetricQueue testMetricsQueue = new TestReadMetricsQueue(LogLevel.OFF,true);
+        changeInternalStateForTesting(resultSetBeingTested, testMetricsQueue);
         while (resultSetBeingTested.next()) {}
         resultSetBeingTested.close();
         Set<String> expectedTableNames = Sets.newHashSet(tableName);
@@ -955,12 +959,11 @@ public class PhoenixMetricsIT extends BasePhoenixMetricsIT {
         }
     }
 
-    private void changeInternalStateForTesting(PhoenixResultSet rs) throws NoSuchFieldException,
-            SecurityException, IllegalArgumentException, IllegalAccessException {
+    private void changeInternalStateForTesting(PhoenixResultSet rs,
+                                               ReadMetricQueue testMetricsQueue) throws
+            NoSuchFieldException, SecurityException, IllegalArgumentException,
+            IllegalAccessException {
         // get and set the internal state for testing purposes.
-        // TODO use a spy ?
-        ReadMetricQueue testMetricsQueue = new TestReadMetricsQueue(LogLevel.OFF,true);
-
         Field rsQueueField = PhoenixResultSet.class.getDeclaredField("readMetricsQueue");
         rsQueueField.setAccessible(true);
         rsQueueField.set(rs, testMetricsQueue);
@@ -1298,5 +1301,227 @@ public class PhoenixMetricsIT extends BasePhoenixMetricsIT {
         }
     }
 
+    @Test
+    public void testPhoenixClientQueueWaitTimeAndEndToEndTime() throws SQLException,
+            NoSuchFieldException,
+            IllegalAccessException {
+        int saltBucketNum = 8;
+        String tableName = generateUniqueName();
+        String getRows = "SELECT COL1, COL2, PK4, PK2, PK3 FROM " + tableName
+                + " WHERE PK1=? AND PK2=? AND PK3=? AND PK4 IN (?";
+        // Send at least 4 tasks in Phoenix client thread pool and we will assert also on this
+        // later while actually querying data.
+        int taskCount = 4;
+        for (int i = 1; i < taskCount; i++) {
+            getRows += ", ?";
+        }
+        getRows += ")";
+        final String upsertRows = "UPSERT INTO " + tableName + " VALUES(?, ?, ?, ?, ?, ?)";
+        String creatTableDdl = "CREATE TABLE IF NOT EXISTS " + tableName + " (\n" +
+                "    PK1 CHAR(15) NOT NULL,\n" +
+                "    PK2 CHAR(15) NOT NULL,\n" +
+                "    PK3 DECIMAL NOT NULL,\n" +
+                "    PK4 CHAR(32) NOT NULL,\n" +
+                "    COL1 VARCHAR NOT NULL,\n" +
+                "    COL2 VARCHAR NOT NULL,\n" +
+                "    CONSTRAINT PK PRIMARY KEY (\n" +
+                "        PK1,\n" +
+                "        PK2,\n" +
+                "        PK3,\n" +
+                "        PK4\n" +
+                "    )\n" +
+                ") MULTI_TENANT=true, IMMUTABLE_ROWS=TRUE, SALT_BUCKETS=" + saltBucketNum;
+        long vpk3 = 1000;
+        try(Connection conn = DriverManager.getConnection(getUrl())) {
+            PreparedStatement stmt = conn.prepareStatement(upsertRows);
+            stmt.execute(creatTableDdl);
+            // Best effort to have 1 row per salt bucket
+            for (int i = 1; i <= saltBucketNum; i++) {
+                stmt.setString(1, "VPK1");
+                stmt.setString(2, "VPK2");
+                stmt.setLong(3, vpk3);
+                stmt.setString(4, "VPK4_" + i);
+                stmt.setString(5, "{i:" + i + "}");
+                stmt.setString(6, "{o:" + i + "}");
+                stmt.executeUpdate();
+            }
+            conn.commit();
+        }
+        try(Connection conn = DriverManager.getConnection(getUrl())) {
+            PreparedStatement stmt = conn.prepareStatement(getRows);
+            stmt.setString(1, "VPK1");
+            stmt.setString(2, "VPK2");
+            stmt.setLong(3, vpk3);
+            for (int i = 4; i < taskCount + 4; i++) {
+                stmt.setString(i, "VPK4_" + i);
+            }
+            ResultSet rs = stmt.executeQuery();
+            PhoenixResultSet phoenixResultSet = rs.unwrap(PhoenixResultSet.class);
+            ReadMetricQueue readMetricQueue = new TestTaskReadMetricsQueue(LogLevel.OFF,
+                    true);
+            changeInternalStateForTesting(phoenixResultSet, readMetricQueue);
+            while(rs.next()) {}
+            Map<MetricType, Long> overallQueryMetrics =
+                    PhoenixRuntime.getOverAllReadRequestMetricInfo(rs);
+            Map<MetricType, Long> readMetrics =
+                    PhoenixRuntime.getRequestReadMetricInfo(rs).get(tableName);
+            // Sent 4 tasks in Phoenix client thread pool. So, that we do see the max task
+            // queue time and max task end to end time.
+            assertEquals(4, (long) readMetrics.get(TASK_EXECUTED_COUNTER));
+            assertEquals(20, (long) overallQueryMetrics.get(
+                    MetricType.WALL_CLOCK_QUERY_WAIT_TIME));
+            assertEquals(41, (long) overallQueryMetrics.get(
+                    MetricType.WALL_CLOCK_QUERY_TASK_END_TO_END_TIME));
+        }
+    }
+
+    /**
+     * This test aims to test that when scanner cache of first batch of scans is exhausted
+     * in RoundRobinResultItr and next batch of scans is submitted then overall query wait
+     * time and query end to end task time is updated correctly.
+     *
+     * @throws SQLException
+     * @throws NoSuchFieldException
+     * @throws IllegalAccessException
+     */
+    @Test
+    public void testPhoenixClientQueueWaitTimeAndEndToEndTimeWithScannerCacheRefill()
+            throws Exception {
+        int fetchSize = 2;
+        int saltBucketNum = 8;
+        String tableName = generateUniqueName();
+        String getRows = "SELECT COL1, COL2, PK4, PK2, PK3 FROM " + tableName
+                + " WHERE PK1=? AND PK2=? AND PK3=? AND PK4 IN (?";
+        // Send at least 2 batches of scans. The salt buckets are 8 so, even if first batch of
+        // scans cover all the salt buckets still only 16 rows will be cached with fetch size of 2.
+        // So, setting rows to read per query greater than 16.
+        int taskCount = saltBucketNum * fetchSize + saltBucketNum;
+        for (int i = 1; i < taskCount; i++) {
+            getRows += ", ?";
+        }
+        getRows += ")";
+        final String upsertRows = "UPSERT INTO " + tableName + " VALUES(?, ?, ?, ?, ?, ?)";
+        String creatTableDdl = "CREATE TABLE IF NOT EXISTS " + tableName + " (\n" +
+                "    PK1 CHAR(15) NOT NULL,\n" +
+                "    PK2 CHAR(15) NOT NULL,\n" +
+                "    PK3 DECIMAL NOT NULL,\n" +
+                "    PK4 CHAR(32) NOT NULL,\n" +
+                "    COL1 VARCHAR NOT NULL,\n" +
+                "    COL2 VARCHAR NOT NULL,\n" +
+                "    CONSTRAINT PK PRIMARY KEY (\n" +
+                "        PK1,\n" +
+                "        PK2,\n" +
+                "        PK3,\n" +
+                "        PK4\n" +
+                "    )\n" +
+                ") MULTI_TENANT=true, IMMUTABLE_ROWS=TRUE, SALT_BUCKETS=" + saltBucketNum;
+        long vpk3 = 1000;
+        try(Connection conn = DriverManager.getConnection(getUrl())) {
+            PreparedStatement stmt = conn.prepareStatement(upsertRows);
+            stmt.execute(creatTableDdl);
+            // Best effort to have 1 row per salt bucket
+            for (int i = 1; i <= saltBucketNum; i++) {
+                stmt.setString(1, "VPK1");
+                stmt.setString(2, "VPK2");
+                stmt.setLong(3, vpk3);
+                stmt.setString(4, "VPK4_" + i);
+                stmt.setString(5, "{i:" + i + "}");
+                stmt.setString(6, "{o:" + i + "}");
+                stmt.executeUpdate();
+            }
+            conn.commit();
+        }
+        String url = getUrl("TEST");
+        Properties props = new Properties();
+        props.setProperty(QueryServices.FORCE_ROW_KEY_ORDER_ATTRIB, String.valueOf(false));
+        try(Connection conn = DriverManager.getConnection(url, props)) {
+            PreparedStatement stmt = conn.prepareStatement(getRows);
+            stmt.setFetchSize(fetchSize);
+            stmt.setString(1, "VPK1");
+            stmt.setString(2, "VPK2");
+            stmt.setLong(3, vpk3);
+            for (int i = 4; i < taskCount + 4; i++) {
+                stmt.setString(i, "VPK4_" + i);
+            }
+            ResultSet rs = stmt.executeQuery();
+            PhoenixResultSet phoenixResultSet = rs.unwrap(PhoenixResultSet.class);
+            // Make sure we are using RoundRobinResultItr. as it refills scanner cache
+            assertTrue(phoenixResultSet.getUnderlyingIterator()
+                    instanceof RoundRobinResultIterator);
+            RoundRobinResultIterator itr =
+                    (RoundRobinResultIterator) phoenixResultSet.getUnderlyingIterator();
+            ReadMetricQueue readMetricQueue = new TestTaskReadMetricsQueue(LogLevel.OFF,
+                    true);
+            changeInternalStateForTesting(phoenixResultSet, readMetricQueue);
+            while(rs.next()) {}
+            Map<MetricType, Long> overallQueryMetrics =
+                    PhoenixRuntime.getOverAllReadRequestMetricInfo(rs);
+            Map<MetricType, Long> readMetrics =
+                    PhoenixRuntime.getRequestReadMetricInfo(rs).get(tableName);
+            // Make sure scanner cache was refilled once
+            assertEquals(1, itr.getNumberOfParallelFetches());
+            assertEquals(40,
+                    (long) overallQueryMetrics.get(MetricType.WALL_CLOCK_QUERY_WAIT_TIME));
+            assertEquals(82, (long) overallQueryMetrics.get(
+                    MetricType.WALL_CLOCK_QUERY_TASK_END_TO_END_TIME));
+            long totalTasksExecuted = readMetrics.get(TASK_EXECUTED_COUNTER);
+            assertEquals(totalTasksExecuted * TASK_EXECUTION_TIME_DELTA,
+                    (long) readMetrics.get(TASK_EXECUTION_TIME));
+        }
+    }
+
+    private class TestTaskReadMetricsQueue extends ReadMetricQueue {
+
+        int taskQueueWaitTimeIndex = 0;
+        int taskEndToEndTimeIndex = 0;
+        int[] taskQueueWaitTime = {10, 5, 20, 7};
+        int[] taskEndToEndTime = {20, 15, 41, 16};
+        // To make test predictable
+        final Object lock = new Object();
+
+        public TestTaskReadMetricsQueue(LogLevel connectionLogLevel,
+                                      boolean isRequestMetricsEnabled) {
+            super(isRequestMetricsEnabled, connectionLogLevel);
+        }
+
+        @Override
+        public CombinableMetric getMetric(MetricType type) {
+            switch (type) {
+                case TASK_QUEUE_WAIT_TIME:
+                    return new CombinableMetricImpl(type) {
+
+                        @Override
+                        public void change(long delta) {
+                            synchronized (lock) {
+                                super.change(taskQueueWaitTime[taskQueueWaitTimeIndex]);
+                                taskQueueWaitTimeIndex++;
+                                taskQueueWaitTimeIndex %= taskQueueWaitTime.length;
+                            }
+                        }
+                    };
+                case TASK_END_TO_END_TIME:
+                    return new CombinableMetricImpl(type) {
+
+                        @Override
+                        public void change(long delta) {
+                            synchronized (lock) {
+                                super.change(taskEndToEndTime[taskEndToEndTimeIndex]);
+                                taskEndToEndTimeIndex++;
+                                taskEndToEndTimeIndex %= taskEndToEndTime.length;
+                            }
+                        }
+                    };
+                case TASK_EXECUTION_TIME:
+                    return new CombinableMetricImpl(type) {
+
+                        @Override
+                        public void change(long delta) {
+                            super.change(TASK_EXECUTION_TIME_DELTA);
+                        }
+                    };
+            }
+            return super.getMetric(type);
+        }
+    }
 
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
@@ -441,6 +441,13 @@ public abstract class BaseTest {
         }
         return url;
     }
+
+    protected static String getUrl(String principal) throws Exception {
+        if (!clusterInitialized) {
+            throw new IllegalStateException("Cluster must be initialized before attempting to get the URL");
+        }
+        return getLocalClusterUrl(utility, principal);
+    }
     
     protected static String checkClusterInitialized(ReadOnlyProps serverProps) throws Exception {
         if (!clusterInitialized) {
@@ -567,6 +574,13 @@ public abstract class BaseTest {
 
     protected static String getLocalClusterUrl(HBaseTestingUtility util) throws Exception {
         String url = QueryUtil.getConnectionUrl(new Properties(), util.getConfiguration());
+        return url + PHOENIX_TEST_DRIVER_URL_PARAM;
+    }
+
+    protected static String getLocalClusterUrl(HBaseTestingUtility util, String principal)
+            throws Exception {
+        String url = QueryUtil.getConnectionUrl(new Properties(), util.getConfiguration(),
+                principal);
         return url + PHOENIX_TEST_DRIVER_URL_PARAM;
     }
     


### PR DESCRIPTION
Summary of the change:
- Introducing two new metrics for tracking wall clock wait time of a query in Phoenix client thread pool and wall clock time spent in executing HBase scan tasks in Phoenix client thread pool.
- Also, made the change to use `JobCallable` in `RoundRobinResultItr.` when submitting next batches of scans as scanner cache of previous batches of scan has been exhausted. By using JobCallable we can track total wall clock time spent by a query waiting in Phoenix client thread pool queue along with total wall clock time spent in executing tasks (end to end).
