### PR TITLE
Resolve character encoding mismatch by enforcing UTF-8 in sqlline.py

### DIFF
--- a/bin/sqlline.py
+++ b/bin/sqlline.py
@@ -101,6 +101,7 @@ java_cmd = phoenix_utils.java + ' ' + phoenix_utils.jvm_module_flags + \
     '" -Djava.util.logging.config.class=org.apache.hadoop.hbase.logging.JulToSlf4jInitializer ' + \
     ' -Dlog4j2.configurationFile=file:' + os.path.join(phoenix_utils.current_dir, "log4j2.properties") + \
     disable_jna + \
+    " -Dfile.encoding=UTF-8 " + \
     " sqlline.SqlLine -d org.apache.phoenix.jdbc.PhoenixDriver" + \
     (not args.noconnect and " -u " + phoenix_utils.shell_quote([jdbc_url]) or "") + \
     " -n none -p none --color=" + \


### PR DESCRIPTION
The issue with certain characters, such as Japanese, Polish, and other non-ASCII characters, being exported incorrectly has been resolved. The root cause was an encoding mismatch, where character data was not properly handled in the `java_cmd` command in `sqlline.py`. This command constructs and executes a Java process to launch SQLLine, a command-line tool for executing SQL queries against Apache Phoenix.  

To address this, the `sqlline.py` file was modified to explicitly enforce UTF-8 encoding.  

This ensures that all character data is correctly encoded and exported, preventing data corruption or misinterpretation due to incorrect encoding settings.