### PR TITLE
PHOENIX-7533 Fix broken compatibility for Zookeeper based ConnectionInfo

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
@@ -53,7 +53,7 @@ public abstract class ConnectionInfo {
             + " determined. Ignoring realm equivalency check.";
     protected static final String TERMINATOR = "" + PhoenixRuntime.JDBC_PROTOCOL_TERMINATOR;
     protected static final String DELIMITERS = TERMINATOR + PhoenixRuntime.JDBC_PROTOCOL_SEPARATOR;
-    protected static final String CLIENT_CONNECTION_REGISTRY_IMPL_CONF_KEY =
+    public static final String CLIENT_CONNECTION_REGISTRY_IMPL_CONF_KEY =
             "hbase.client.registry.impl";
 
     protected static final boolean HAS_MASTER_REGISTRY;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/RPCConnectionInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/RPCConnectionInfo.java
@@ -35,7 +35,7 @@ import org.apache.phoenix.util.ReadOnlyProps;
 public class RPCConnectionInfo extends AbstractRPCConnectionInfo {
 
     // We may be on an older HBase version, which does not even have RpcConnectionRegistry
-    private static final String BOOTSTRAP_NODES = "hbase.client.bootstrap.servers";
+    public static final String BOOTSTRAP_NODES = "hbase.client.bootstrap.servers";
     private static final String RPC_REGISTRY_CLASS_NAME =
             "org.apache.hadoop.hbase.client.RpcConnectionRegistry";
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ZKConnectionInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ZKConnectionInfo.java
@@ -17,7 +17,6 @@
 package org.apache.phoenix.jdbc;
 
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -60,17 +59,6 @@ public class ZKConnectionInfo extends ConnectionInfo {
         return zkPort;
     }
 
-    public String getZkHostsWithoutPorts() {
-        if (zkHosts == null) {
-            return null;
-        }
-        String[] hostsWithoutPorts = zkHosts.split(",");
-        String[] hosts = Arrays.stream(hostsWithoutPorts)
-                .map(hostsWithoutPort -> hostsWithoutPort.split(":")[0].trim())
-                .toArray(String[]::new);
-        return String.join(",", hosts);
-    }
-
     public String getZkRootNode() {
         return zkRootNode;
     }
@@ -94,10 +82,7 @@ public class ZKConnectionInfo extends ConnectionInfo {
         if (getZkHosts() != null) {
             //This has the highest priority
             connectionProps.put(HConstants.CLIENT_ZOOKEEPER_QUORUM, getZkHosts());
-        }
-        String zkHostsWithoutPorts = getZkHostsWithoutPorts();
-        if (zkHostsWithoutPorts != null) {
-            connectionProps.put(HConstants.ZOOKEEPER_QUORUM, zkHostsWithoutPorts);
+            connectionProps.put(HConstants.ZOOKEEPER_QUORUM, getZkHosts());
         }
         //Port is already normalized into zkHosts
         if (getZkRootNode() != null) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ZKConnectionInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ZKConnectionInfo.java
@@ -17,6 +17,7 @@
 package org.apache.phoenix.jdbc;
 
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -59,6 +60,17 @@ public class ZKConnectionInfo extends ConnectionInfo {
         return zkPort;
     }
 
+    public String getZkHostsWithoutPorts() {
+        if (zkHosts == null) {
+            return null;
+        }
+        String[] hostsWithoutPorts = zkHosts.split(",");
+        String[] hosts = Arrays.stream(hostsWithoutPorts)
+                .map(hostsWithoutPort -> hostsWithoutPort.split(":")[0].trim())
+                .toArray(String[]::new);
+        return String.join(",", hosts);
+    }
+
     public String getZkRootNode() {
         return zkRootNode;
     }
@@ -82,6 +94,10 @@ public class ZKConnectionInfo extends ConnectionInfo {
         if (getZkHosts() != null) {
             //This has the highest priority
             connectionProps.put(HConstants.CLIENT_ZOOKEEPER_QUORUM, getZkHosts());
+        }
+        String zkHostsWithoutPorts = getZkHostsWithoutPorts();
+        if (zkHostsWithoutPorts != null) {
+            connectionProps.put(HConstants.ZOOKEEPER_QUORUM, zkHostsWithoutPorts);
         }
         //Port is already normalized into zkHosts
         if (getZkRootNode() != null) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -165,6 +165,7 @@ import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.RpcConnectionRegistry;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
@@ -475,6 +476,22 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
         // Without making a copy of the configuration we cons up, we lose some of our properties
         // on the server side during testing.
         this.config = HBaseFactoryProvider.getConfigurationFactory().getConfiguration(config);
+
+        LOGGER.info(
+                "CQS Configs {} = {} , {} = {} , {} = {} , {} = {} , {} = {} , {} = {} , {} = {}",
+                HConstants.ZOOKEEPER_QUORUM,
+                this.config.get(HConstants.ZOOKEEPER_QUORUM), HConstants.CLIENT_ZOOKEEPER_QUORUM,
+                this.config.get(HConstants.CLIENT_ZOOKEEPER_QUORUM),
+                HConstants.CLIENT_ZOOKEEPER_CLIENT_PORT,
+                this.config.get(HConstants.CLIENT_ZOOKEEPER_CLIENT_PORT),
+                HConstants.ZOOKEEPER_CLIENT_PORT,
+                this.config.get(HConstants.ZOOKEEPER_CLIENT_PORT),
+                RpcConnectionRegistry.BOOTSTRAP_NODES,
+                this.config.get(RpcConnectionRegistry.BOOTSTRAP_NODES),
+                HConstants.MASTER_ADDRS_KEY, this.config.get(HConstants.MASTER_ADDRS_KEY),
+                ConnectionInfo.CLIENT_CONNECTION_REGISTRY_IMPL_CONF_KEY,
+                this.config.get(ConnectionInfo.CLIENT_CONNECTION_REGISTRY_IMPL_CONF_KEY));
+
         //Set the rpcControllerFactory if it is a server side connnection.
         boolean isServerSideConnection = config.getBoolean(QueryUtil.IS_SERVER_CONNECTION, false);
         if (isServerSideConnection) {

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixEmbeddedDriverTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixEmbeddedDriverTest.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.util.VersionInfo;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.query.HBaseFactoryProvider;
+import org.apache.phoenix.util.ReadOnlyProps;
 import org.junit.Test;
 
 public class PhoenixEmbeddedDriverTest {
@@ -563,5 +564,42 @@ public class PhoenixEmbeddedDriverTest {
         assertTrue(ConnectionInfo.isSameName("user/foobar@APACHE.ORG", "user/_HOST", "foobar", "APACHE.ORG"));
         assertFalse(ConnectionInfo.isSameName("user/localhost@APACHE.NET", "user/_HOST", "localhost", "APACHE.ORG"));
         assertFalse(ConnectionInfo.isSameName("user/foobar@APACHE.NET", "user/_HOST", "foobar", "APACHE.ORG"));
+    }
+
+    @Test
+    public void testZkQuorumConfigs() throws Exception {
+        ConnectionInfo connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "localhost\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        ReadOnlyProps props = connectionInfo.asProps();
+        assertEquals("127.23.45.678,host123.48576,localhost,v3",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+        assertEquals("127.23.45.678:7634,host123.48576:723,localhost:2181,v3:1",
+                props.get(HConstants.CLIENT_ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix:"
+                + "localhost\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("127.23.45.678,host123.48576,localhost,v3",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+        assertEquals("127.23.45.678:7634,host123.48576:723,localhost:2181,v3:1",
+                props.get(HConstants.CLIENT_ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix:"
+                + "localhost,v3,127.23.45.678,host987:12345:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("127.23.45.678,host987,localhost,v3",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+        assertEquals("127.23.45.678:12345,host987:12345,localhost:12345,v3:12345",
+                props.get(HConstants.CLIENT_ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix+rpc:"
+                + "localhost\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723::;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertNull(props.get(HConstants.ZOOKEEPER_QUORUM));
+        assertNull(props.get(HConstants.CLIENT_ZOOKEEPER_QUORUM));
     }
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixEmbeddedDriverTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixEmbeddedDriverTest.java
@@ -575,7 +575,7 @@ public class PhoenixEmbeddedDriverTest {
                 + "localhost\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
                 + "test=true", null, null);
         ReadOnlyProps props = connectionInfo.asProps();
-        assertEquals("127.23.45.678,host123.48576,localhost,v3",
+        assertEquals("127.23.45.678:7634,host123.48576:723,localhost:2181,v3:1",
                 props.get(HConstants.ZOOKEEPER_QUORUM));
         assertEquals("127.23.45.678:7634,host123.48576:723,localhost:2181,v3:1",
                 props.get(HConstants.CLIENT_ZOOKEEPER_QUORUM));
@@ -584,7 +584,7 @@ public class PhoenixEmbeddedDriverTest {
                 + "localhost\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
                 + "test=true", null, null);
         props = connectionInfo.asProps();
-        assertEquals("127.23.45.678,host123.48576,localhost,v3",
+        assertEquals("127.23.45.678:7634,host123.48576:723,localhost:2181,v3:1",
                 props.get(HConstants.ZOOKEEPER_QUORUM));
         assertEquals("127.23.45.678:7634,host123.48576:723,localhost:2181,v3:1",
                 props.get(HConstants.CLIENT_ZOOKEEPER_QUORUM));
@@ -593,7 +593,7 @@ public class PhoenixEmbeddedDriverTest {
                 + "localhost,v3,127.23.45.678,host987:12345:/hbase;"
                 + "test=true", null, null);
         props = connectionInfo.asProps();
-        assertEquals("127.23.45.678,host987,localhost,v3",
+        assertEquals("127.23.45.678:12345,host987:12345,localhost:12345,v3:12345",
                 props.get(HConstants.ZOOKEEPER_QUORUM));
         assertEquals("127.23.45.678:12345,host987:12345,localhost:12345,v3:12345",
                 props.get(HConstants.CLIENT_ZOOKEEPER_QUORUM));


### PR DESCRIPTION
Jira: PHOENIX-7533

Before PHOENIX-6523, ConnectionInfo used to provide hbase.zookeeper.quorum with Zookeeper host names separated by comma. With PHOENIX-6523, for zk registry, ConnectionInfo provides hbase.client.zookeeper.quorum with Zookeeper hosts and port values combined, separated by comma (e.g. "host1:1234,host2:2181,host3:9876" etc).

For the purpose of creating HBase Connection, providing "hbase.client.zookeeper.quorum" is sufficient. However, Phoenix downstream applications that are using "hbase.zookeeper.quorum" value to determine which HTable threadpool to use for the given Connection can no longer function for cases like dual client where different HTable threadpools need to be used for different HBase connections.

Given that Phoenix 5.1 client used to provide "hbase.zookeeper.quorum", 5.2 should not break this compatibility even though it provides "hbase.client.zookeeper.quorum" as additional Connection level configuration.