### PR TITLE
PHOENIX-7543 Wrong result returned when query is served by index and some columns are null

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/IndexUtil.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/IndexUtil.java
@@ -17,6 +17,8 @@
  */
 package org.apache.phoenix.util;
 
+import static org.apache.hadoop.hbase.Cell.Type.DeleteColumn;
+import static org.apache.hadoop.hbase.Cell.Type.DeleteFamily;
 import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.LOCAL_INDEX_BUILD;
 import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.LOCAL_INDEX_BUILD_PROTO;
 import static org.apache.phoenix.coprocessorclient.MetaDataProtocol.PHOENIX_MAJOR_VERSION;
@@ -49,6 +51,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.CoprocessorDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants;
 import org.apache.phoenix.index.PhoenixIndexCodec;
@@ -903,6 +906,38 @@ public class IndexUtil {
             }
         }
         return columns;
+    }
+
+    public static boolean isDeleteFamily(Mutation mutation) {
+        if (!(mutation instanceof Delete)) {
+            return false;
+        }
+        for (List<Cell> cells : mutation.getFamilyCellMap().values()) {
+            for (Cell cell : cells) {
+                if (cell.getType() == DeleteFamily) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean isDeleteColumn(Mutation mutation) {
+        if (!(mutation instanceof Delete)) {
+            return false;
+        }
+        for (List<Cell> cells : mutation.getFamilyCellMap().values()) {
+            for (Cell cell : cells) {
+                if (cell.getType() == DeleteColumn) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean isDeleteFamilyOrDeleteColumn(Mutation mutation) {
+        return isDeleteFamily(mutation) || isDeleteColumn(mutation);
     }
 
     public static class SimpleValueGetter implements ValueGetter {

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
@@ -729,8 +729,8 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
         while (iterator.hasNext()) {
             Mutation mutation = iterator.next();
             if ((mutation instanceof Put && !isVerified((Put) mutation)) ||
-                    (mutation instanceof Delete &&
-                            !IndexUtil.isDeleteFamilyOrDeleteColumn(mutation))) {
+                    (mutation instanceof Delete
+                            && !IndexUtil.isDeleteFamilyOrDeleteColumn(mutation))) {
                 iterator.remove();
             } else {
                 if (((previous instanceof Put && mutation instanceof Put) ||
@@ -872,8 +872,8 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
                     // Between an expected delete and put, there can be one or more deletes due to
                     // concurrent mutations or data table write failures. Skip all of them if any
                     // There cannot be any actual delete mutation between two expected put mutations.
-                    while (getTimestamp(actual) >= getTimestamp(expected) &&
-                            IndexUtil.isDeleteFamily(actual)) {
+                    while (getTimestamp(actual) >= getTimestamp(expected)
+                            && IndexUtil.isDeleteFamily(actual)) {
                         actualIndex++;
                         if (actualIndex == actualSize) {
                             break;
@@ -898,8 +898,8 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
                 // unverified index rows on a deleted row and read-repair will put a DeleteFamily
                 // marker. Those delete family markers will be visible until compaction runs on the
                 // index table.
-                while (getTimestamp(actual) > getTimestamp(expected) &&
-                        IndexUtil.isDeleteFamily(actual)) {
+                while (getTimestamp(actual) > getTimestamp(expected)
+                        && IndexUtil.isDeleteFamily(actual)) {
                     actualIndex++;
                     if (actualIndex == actualSize) {
                         break;

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
@@ -868,22 +868,22 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
             }
             actual = actualMutationList.get(actualIndex);
             if (expected instanceof Put) {
-                    if (previousExpected instanceof Delete) {
-                        // Between an expected delete and put, there can be one or more deletes due to
-                        // concurrent mutations or data table write failures. Skip all of them if any
-                        // There cannot be any actual delete mutation between two expected put mutations.
-                        while (getTimestamp(actual) >= getTimestamp(expected) &&
-                                IndexUtil.isDeleteFamily(actual)) {
-                            actualIndex++;
-                            if (actualIndex == actualSize) {
-                                break;
-                            }
-                            actual = actualMutationList.get(actualIndex);
-                        }
+                if (previousExpected instanceof Delete) {
+                    // Between an expected delete and put, there can be one or more deletes due to
+                    // concurrent mutations or data table write failures. Skip all of them if any
+                    // There cannot be any actual delete mutation between two expected put mutations.
+                    while (getTimestamp(actual) >= getTimestamp(expected) &&
+                            IndexUtil.isDeleteFamily(actual)) {
+                        actualIndex++;
                         if (actualIndex == actualSize) {
                             break;
                         }
+                        actual = actualMutationList.get(actualIndex);
                     }
+                    if (actualIndex == actualSize) {
+                        break;
+                    }
+                }
                 if (actual instanceof Delete) {
                     break;
                 }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/GlobalIndexRegionScanner.java
@@ -93,6 +93,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static org.apache.hadoop.hbase.Cell.Type.DeleteColumn;
+import static org.apache.hadoop.hbase.Cell.Type.DeleteFamily;
 import static org.apache.phoenix.hbase.index.write.AbstractParallelWriterIndexCommitter.INDEX_WRITER_KEEP_ALIVE_TIME_CONF_KEY;
 import static org.apache.phoenix.mapreduce.index.IndexVerificationOutputRepository.IndexVerificationErrorType.BEYOND_MAX_LOOKBACK_INVALID;
 import static org.apache.phoenix.mapreduce.index.IndexVerificationOutputRepository.IndexVerificationErrorType.BEYOND_MAX_LOOKBACK_MISSING;
@@ -614,9 +616,40 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
     };
 
     private boolean isDeleteFamily(Mutation mutation) {
+        if (!(mutation instanceof Delete)) {
+            return false;
+        }
         for (List<Cell> cells : mutation.getFamilyCellMap().values()) {
             for (Cell cell : cells) {
-                if (cell.getType() == Cell.Type.DeleteFamily) {
+                if (cell.getType() == DeleteFamily) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isDeleteColumn(Mutation mutation) {
+        if (!(mutation instanceof Delete)) {
+            return false;
+        }
+        for (List<Cell> cells : mutation.getFamilyCellMap().values()) {
+            for (Cell cell : cells) {
+                if (cell.getType() == DeleteColumn) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isDeleteFamilyOrDeleteColumn(Mutation mutation) {
+        if (!(mutation instanceof Delete)) {
+            return false;
+        }
+        for (List<Cell> cells : mutation.getFamilyCellMap().values()) {
+            for (Cell cell : cells) {
+                if (cell.getType() == DeleteFamily || cell.getType() == DeleteColumn) {
                     return true;
                 }
             }
@@ -738,7 +771,7 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
         while (iterator.hasNext()) {
             Mutation mutation = iterator.next();
             if ((mutation instanceof Put && !isVerified((Put) mutation)) ||
-                    (mutation instanceof Delete && !isDeleteFamily(mutation))) {
+                    (mutation instanceof Delete && !isDeleteFamilyOrDeleteColumn(mutation))) {
                 iterator.remove();
             } else {
                 if (((previous instanceof Put && mutation instanceof Put) ||
@@ -787,6 +820,11 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
      * index rebuilds, the delete family markers are used to delete index rows due to data table row deletes or
      * data table row overwrites.
      *
+     * Delete Column Markers
+     * Delete column markers are generated during read repair, regular table updates and
+     * index rebuilds. The delete column markers are used for any included column in the index
+     * which is set to null.
+     *
      * Verification Algorithm
      *
      * IndexTool verification generates an expected list of index mutations from the data table rows and uses this list
@@ -797,7 +835,9 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
      *
      * Every mutation will include a set of cells with the same timestamp
      * Every mutation has a different timestamp
-     * A delete mutation will include only delete family cells and it is for deleting the entire row and its versions
+     * A delete mutation can either include delete family cells and it is for deleting the entire
+     * row and its versions or delete column cells. The delete column cells are added for those
+     * included columns in the index which are set to null.
      * Every put mutation is verified
      *
      * For both verification types, after the expected list of index mutations is constructed for a given data table,
@@ -807,7 +847,8 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
      * As in the construction for the expected list, the cells are grouped into a put and a delete set. The put and
      * delete sets for a given row are further grouped based on their timestamps into put and delete mutations such that
      * all the cells in a mutation have the timestamps. The put and delete mutations are then sorted within a single
-     * list. Mutations in this list are sorted in ascending order of their timestamp. This list is the actual list.
+     * list. Mutations in this list are sorted in descending order of their timestamp.
+     * This list is the actual list.
      *
      * For the without-repair verification, unverified mutations and family version delete markers are removed from
      * the actual list and then the list is compared with the expected list.
@@ -868,21 +909,21 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
             }
             actual = actualMutationList.get(actualIndex);
             if (expected instanceof Put) {
-                if (previousExpected instanceof Delete) {
-                    // Between an expected delete and put, there can be one or more deletes due to
-                    // concurrent mutations or data table write failures. Skip all of them if any
-                    // There cannot be any actual delete mutation between two expected put mutations.
-                    while (getTimestamp(actual) >= getTimestamp(expected) && actual instanceof Delete) {
-                        actualIndex++;
+                    if (previousExpected instanceof Delete) {
+                        // Between an expected delete and put, there can be one or more deletes due to
+                        // concurrent mutations or data table write failures. Skip all of them if any
+                        // There cannot be any actual delete mutation between two expected put mutations.
+                        while (getTimestamp(actual) >= getTimestamp(expected) && isDeleteFamily(actual)) {
+                            actualIndex++;
+                            if (actualIndex == actualSize) {
+                                break;
+                            }
+                            actual = actualMutationList.get(actualIndex);
+                        }
                         if (actualIndex == actualSize) {
                             break;
                         }
-                        actual = actualMutationList.get(actualIndex);
                     }
-                    if (actualIndex == actualSize) {
-                        break;
-                    }
-                }
                 if (actual instanceof Delete) {
                     break;
                 }
@@ -894,7 +935,7 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
             } else { // expected instanceof Delete
                 // Between put and delete, delete and delete, or before the first delete, there can be other deletes.
                 // Skip all of them if any
-                while (getTimestamp(actual) > getTimestamp(expected) && actual instanceof Delete) {
+                while (getTimestamp(actual) > getTimestamp(expected) && isDeleteFamily(actual)) {
                     actualIndex++;
                     if (actualIndex == actualSize) {
                         break;
@@ -904,8 +945,7 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
                 if (actualIndex == actualSize) {
                     break;
                 }
-                if (getTimestamp(actual) == getTimestamp(expected) &&
-                        (actual instanceof Delete && isDeleteFamily(actual))) {
+                if (isMatchingMutation(expected, actual)) {
                     expectedIndex++;
                     actualIndex++;
                     continue;
@@ -1179,7 +1219,8 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
     };
 
     public static List<Mutation> getMutationsWithSameTS(Put put, Delete del) {
-        // Reorder the mutations on the same row so that delete comes before put when they have the same timestamp
+        // Reorder the mutations on the same row so that put comes before delete when they
+        // have the same timestamp
         return getMutationsWithSameTS(put, del, MUTATION_TS_COMPARATOR);
     }
 
@@ -1277,7 +1318,7 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
      * uncovered partial indexes.
      * pendingMutations is a sorted list of data table mutations that are used to replay index
      * table mutations. This list is sorted in ascending order by the tuple of row key, timestamp
-     * and mutation type where delete comes after put.
+     * and mutation type where put comes before delete.
      */
     public static List<Mutation> prepareIndexMutationsForRebuild(IndexMaintainer indexMaintainer,
             Put dataPut, Delete dataDel, byte[] encodedRegionName) throws IOException {
@@ -1343,6 +1384,10 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
                     Put indexPut = prepareIndexPutForRebuild(indexMaintainer, rowKeyPtr,
                             nextDataRowVG, ts, encodedRegionName);
                     indexMutations.add(indexPut);
+                    Delete deleteColumn = indexMaintainer.buildDeleteColumnMutation(indexPut, ts);
+                    if (deleteColumn != null) {
+                        indexMutations.add(deleteColumn);
+                    }
                     // Delete the current index row if the new index key is different than the current one
                     if (indexRowKeyForCurrentDataRow != null) {
                         if (Bytes.compareTo(indexPut.getRow(), indexRowKeyForCurrentDataRow) != 0) {
@@ -1401,6 +1446,10 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
                     Put indexPut = prepareIndexPutForRebuild(indexMaintainer, rowKeyPtr,
                             nextDataRowVG, ts, encodedRegionName);
                     indexMutations.add(indexPut);
+                    Delete deleteColumn = indexMaintainer.buildDeleteColumnMutation(indexPut, ts);
+                    if (deleteColumn != null) {
+                        indexMutations.add(deleteColumn);
+                    }
                     // Delete the current index row if the new index key is different than the current one
                     if (indexRowKeyForCurrentDataRow != null) {
                         if (Bytes.compareTo(indexPut.getRow(), indexRowKeyForCurrentDataRow) != 0) {
@@ -1439,7 +1488,7 @@ public abstract class GlobalIndexRegionScanner extends BaseRegionScanner {
             List<Mutation> mutationList = indexMutationMap.get(indexRowKey);
             if (mutationList == null) {
                 if (!mostRecentDone) {
-                    if (mutation instanceof Put) {
+                    if (mutation instanceof Put || isDeleteColumn(mutation)) {
                         mostRecentIndexRowKeys.add(indexRowKey);
                         mostRecentDone = true;
                     }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -1115,7 +1115,9 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
                     if (m instanceof Put) {
                         // This will be done before the data table row is updated (i.e., in the first write phase)
                         context.preIndexUpdates.put(hTableInterfaceReference, m);
-                    } else {
+                    } else if (IndexUtil.isDeleteFamily(m)) {
+                        // DeleteColumn is always accompanied by a Put so no need to make the index
+                        // row unverified again. Only do this for DeleteFamily
                         // Set the status of the index row to "unverified"
                         Put unverifiedPut = new Put(m.getRow());
                         unverifiedPut.addColumn(

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -205,26 +205,26 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
           return lastContext;
       }
     }
-
-  private static boolean ignoreIndexRebuildForTesting  = false;
-  private static boolean failPreIndexUpdatesForTesting = false;
-  private static boolean failPostIndexUpdatesForTesting = false;
-  private static boolean failDataTableUpdatesForTesting = false;
-  private static boolean ignoreWritingDeleteColumnsToIndex = false;
-
-  public static void setIgnoreIndexRebuildForTesting(boolean ignore) { ignoreIndexRebuildForTesting = ignore; }
-
-  public static void setFailPreIndexUpdatesForTesting(boolean fail) { failPreIndexUpdatesForTesting = fail; }
-
-  public static void setFailPostIndexUpdatesForTesting(boolean fail) { failPostIndexUpdatesForTesting = fail; }
-
-  public static void setFailDataTableUpdatesForTesting(boolean fail) {
-      failDataTableUpdatesForTesting = fail;
-  }
-
-  public static void setIgnoreWritingDeleteColumnsToIndex(boolean ignore) {
-      ignoreWritingDeleteColumnsToIndex = ignore;
-  }
+    private static boolean ignoreIndexRebuildForTesting  = false;
+    private static boolean failPreIndexUpdatesForTesting = false;
+    private static boolean failPostIndexUpdatesForTesting = false;
+    private static boolean failDataTableUpdatesForTesting = false;
+    private static boolean ignoreWritingDeleteColumnsToIndex = false;
+    public static void setIgnoreIndexRebuildForTesting(boolean ignore) {
+        ignoreIndexRebuildForTesting = ignore;
+    }
+    public static void setFailPreIndexUpdatesForTesting(boolean fail) {
+        failPreIndexUpdatesForTesting = fail;
+    }
+    public static void setFailPostIndexUpdatesForTesting(boolean fail) {
+        failPostIndexUpdatesForTesting = fail;
+    }
+    public static void setFailDataTableUpdatesForTesting(boolean fail) {
+        failDataTableUpdatesForTesting = fail;
+    }
+    public static void setIgnoreWritingDeleteColumnsToIndex(boolean ignore) {
+        ignoreWritingDeleteColumnsToIndex = ignore;
+    }
 
   public enum BatchMutatePhase {
       PRE, POST, FAILED

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexToolIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexToolIT.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.MiniBatchOperationInProgress;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.CounterGroup;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.phoenix.compile.ExplainPlan;
@@ -836,6 +837,17 @@ public class IndexToolIT extends BaseTest {
 
     public static CounterGroup getMRJobCounters(IndexTool indexTool) throws IOException {
         return indexTool.getJob().getCounters().getGroup(PhoenixIndexToolJobCounters.class.getName());
+    }
+
+    public static void dumpMRJobCounters(IndexTool indexTool) throws IOException {
+        CounterGroup mrJobCounters = IndexToolIT.getMRJobCounters(indexTool);
+        dumpMRJobCounters(mrJobCounters);
+    }
+
+    public static void dumpMRJobCounters(CounterGroup mrJobCounters) {
+        for (Counter cntr : mrJobCounters) {
+            LOGGER.info(String.format("%s=%d", cntr.getName(), cntr.getValue()));
+        }
     }
 
     private static List<String> getArgList (boolean useSnapshot, String schemaName,

--- a/phoenix-core/src/test/java/org/apache/phoenix/index/IndexMaintainerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/index/IndexMaintainerTest.java
@@ -20,6 +20,8 @@ package org.apache.phoenix.index;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Connection;
@@ -37,6 +39,7 @@ import java.util.Set;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
@@ -50,8 +53,11 @@ import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
 import org.apache.phoenix.hbase.index.util.KeyValueBuilder;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.query.BaseConnectionlessQueryTest;
+import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTableKey;
+import org.apache.phoenix.util.EnvironmentEdgeManager;
+import org.apache.phoenix.util.IndexUtil;
 import org.apache.phoenix.util.PhoenixRuntime;
 import org.apache.phoenix.util.PropertiesUtil;
 import org.apache.phoenix.util.SchemaUtil;
@@ -63,7 +69,7 @@ import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
     private static final String DEFAULT_SCHEMA_NAME = "";
     private static final String DEFAULT_TABLE_NAME = "rkTest";
-    
+
     private void testIndexRowKeyBuilding(String dataColumns, String pk, String indexColumns, Object[] values) throws Exception {
         testIndexRowKeyBuilding(DEFAULT_SCHEMA_NAME, DEFAULT_TABLE_NAME, dataColumns, pk, indexColumns, values, "", "", "");
     }
@@ -88,10 +94,10 @@ public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
 			public byte[] getRowKey() {
 				return row;
 			}
-            
+
         };
     }
-    
+
     private void testIndexRowKeyBuilding(String schemaName, String tableName, String dataColumns, String pk, String indexColumns, Object[] values, String includeColumns, String dataProps, String indexProps) throws Exception {
         KeyValueBuilder builder = GenericKeyValueBuilder.INSTANCE;
         testIndexRowKeyBuilding(schemaName, tableName, dataColumns, pk, indexColumns, values, includeColumns, dataProps, indexProps, builder);
@@ -114,7 +120,7 @@ public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
             List<IndexMaintainer> c1 = IndexMaintainer.deserialize(ptr, builder, true);
             assertEquals(1,c1.size());
             IndexMaintainer im1 = c1.get(0);
-            
+
             StringBuilder buf = new StringBuilder("UPSERT INTO " + fullTableName  + " VALUES(");
             for (int i = 0; i < values.length; i++) {
                 buf.append("?,");
@@ -136,7 +142,7 @@ public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
                 dataMutation.add(kv);
             }
             ValueGetter valueGetter = newValueGetter(row, valueMap);
-            
+
             List<Mutation> indexMutations = IndexTestUtil.generateIndexData(index, table, dataMutation, ptr, builder);
             assertEquals(1,indexMutations.size());
             assertTrue(indexMutations.get(0) instanceof Put);
@@ -165,19 +171,19 @@ public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
     public void testRowKeyVarOnlyIndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 DECIMAL", "k1,k2", "k2, k1", new Object [] {"a",1.1});
     }
- 
+
     @Test
     public void testVarFixedndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER NOT NULL, v VARCHAR", "k1,k2", "k2, k1", new Object [] {"a",1.1});
     }
- 
-    
+
+
     @Test
     public void testCompositeRowKeyVarFixedIndex() throws Exception {
         // TODO: using 1.1 for INTEGER didn't give error
         testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER NOT NULL, v VARCHAR", "k1,k2", "k2, k1", new Object [] {"a",1});
     }
- 
+
     @Test
     public void testCompositeRowKeyVarFixedAtEndIndex() throws Exception {
         // Forces trailing zero in index key for fixed length
@@ -185,32 +191,32 @@ public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
             testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER NOT NULL, k3 VARCHAR, v VARCHAR", "k1,k2,k3", "k1, k3, k2", new Object [] {"a",i, "b"});
         }
     }
- 
+
    @Test
     public void testSingleKeyValueIndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER, v VARCHAR", "k1", "v", new Object [] {"a",1,"b"});
     }
- 
+
     @Test
     public void testMultiKeyValueIndex() throws Exception {
         testIndexRowKeyBuilding("k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 DECIMAL, v2 CHAR(2), v3 BIGINT", "k1, k2", "v2, k2, v1", new Object [] {"a",1,2.2,"bb"});
     }
- 
+
     @Test
     public void testMultiKeyValueCoveredIndex() throws Exception {
         testIndexRowKeyBuilding("k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 DECIMAL, v2 CHAR(2), v3 BIGINT, v4 CHAR(10)", "k1, k2", "v2, k2, v1", new Object [] {"a",1,2.2,"bb"}, "v3, v4");
     }
- 
+
     @Test
     public void testSingleKeyValueDescIndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER, v VARCHAR", "k1", "v DESC", new Object [] {"a",1,"b"});
     }
- 
+
     @Test
     public void testCompositeRowKeyVarFixedDescIndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER NOT NULL, v VARCHAR", "k1,k2", "k2 DESC, k1", new Object [] {"a",1});
     }
- 
+
     @Test
     public void testCompositeRowKeyTimeIndex() throws Exception {
         long timeInMillis = System.currentTimeMillis();
@@ -219,7 +225,7 @@ public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
         ts.setNanos((int) (timeInNanos % 1000000000));
         testIndexRowKeyBuilding("ts1 DATE NOT NULL, ts2 TIME NOT NULL, ts3 TIMESTAMP NOT NULL", "ts1,ts2,ts3", "ts2, ts1", new Object [] {new Date(timeInMillis), new Time(timeInMillis), ts});
     }
- 
+
     @Test
     public void testCompositeRowKeyBytesIndex() throws Exception {
         long timeInMillis = System.currentTimeMillis();
@@ -228,79 +234,79 @@ public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
         ts.setNanos((int) (timeInNanos % 1000000000));
         testIndexRowKeyBuilding("b1 BINARY(3) NOT NULL, v VARCHAR", "b1,v", "v, b1", new Object [] {new byte[] {41,42,43}, "foo"});
     }
- 
+
     @Test
     public void testCompositeDescRowKeyVarFixedDescIndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER NOT NULL, v VARCHAR", "k1, k2 DESC", "k2 DESC, k1", new Object [] {"a",1});
     }
- 
+
     @Test
     public void testCompositeDescRowKeyVarDescIndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 DECIMAL NOT NULL, v VARCHAR", "k1, k2 DESC", "k2 DESC, k1", new Object [] {"a",1.1,"b"});
     }
- 
+
     @Test
     public void testCompositeDescRowKeyVarAscIndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 DECIMAL NOT NULL, v VARCHAR", "k1, k2 DESC", "k2, k1", new Object [] {"a",1.1,"b"});
     }
- 
+
     @Test
     public void testCompositeDescRowKeyVarFixedDescSaltedIndex() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER NOT NULL, v VARCHAR", "k1, k2 DESC", "k2 DESC, k1", new Object [] {"a",1}, "", "", "SALT_BUCKETS=4");
     }
- 
+
     @Test
     public void testCompositeDescRowKeyVarFixedDescSaltedIndexSaltedTable() throws Exception {
         testIndexRowKeyBuilding("k1 VARCHAR, k2 INTEGER NOT NULL, v VARCHAR", "k1, k2 DESC", "k2 DESC, k1", new Object [] {"a",1}, "", "SALT_BUCKETS=3", "SALT_BUCKETS=3");
     }
- 
+
     @Test
     public void testMultiKeyValueCoveredSaltedIndex() throws Exception {
         testIndexRowKeyBuilding("k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 DECIMAL, v2 CHAR(2), v3 BIGINT, v4 CHAR(10)", "k1, k2", "v2 DESC, k2 DESC, v1", new Object [] {"a",1,2.2,"bb"}, "v3, v4", "", "SALT_BUCKETS=4");
     }
- 
+
     @Test
     public void tesIndexWithBigInt() throws Exception {
         testIndexRowKeyBuilding(
                 "k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 BIGINT, v2 CHAR(2), v3 BIGINT, v4 CHAR(10)", "k1, k2",
                 "v1 DESC, k2 DESC", new Object[] { "a", 1, 2.2, "bb" });
     }
-    
+
     @Test
     public void tesIndexWithAscBoolean() throws Exception {
         testIndexRowKeyBuilding(
                 "k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 BOOLEAN, v2 CHAR(2), v3 BIGINT, v4 CHAR(10)", "k1, k2",
                 "v1, k2 DESC", new Object[] { "a", 1, true, "bb" });
     }
-    
+
     @Test
     public void tesIndexWithAscNullBoolean() throws Exception {
         testIndexRowKeyBuilding(
                 "k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 BOOLEAN, v2 CHAR(2), v3 BIGINT, v4 CHAR(10)", "k1, k2",
                 "v1, k2 DESC", new Object[] { "a", 1, null, "bb" });
     }
-    
+
     @Test
     public void tesIndexWithAscFalseBoolean() throws Exception {
         testIndexRowKeyBuilding(
                 "k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 BOOLEAN, v2 CHAR(2), v3 BIGINT, v4 CHAR(10)", "k1, k2",
                 "v1, k2 DESC", new Object[] { "a", 1, false, "bb" });
     }
-    
+
     @Test
     public void tesIndexWithDescBoolean() throws Exception {
         testIndexRowKeyBuilding(
                 "k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 BOOLEAN, v2 CHAR(2), v3 BIGINT, v4 CHAR(10)", "k1, k2",
                 "v1 DESC, k2 DESC", new Object[] { "a", 1, true, "bb" });
     }
-    
+
     @Test
     public void tesIndexWithDescFalseBoolean() throws Exception {
         testIndexRowKeyBuilding(
                 "k1 CHAR(1) NOT NULL, k2 INTEGER NOT NULL, v1 BOOLEAN, v2 CHAR(2), v3 BIGINT, v4 CHAR(10)", "k1, k2",
                 "v1 DESC, k2 DESC", new Object[] { "a", 1, false, "bb" });
     }
-    
+
     @Test
     public void tesIndexedExpressionSerialization() throws Exception {
     	Properties props = PropertiesUtil.deepCopy(TestUtil.TEST_PROPERTIES);
@@ -320,6 +326,83 @@ public class IndexMaintainerTest  extends BaseConnectionlessQueryTest {
             assertEquals("Unexpected Number of indexed columns ", indexedColumns.size(), 4);
         } finally {
             conn.close();
+        }
+    }
+
+    @Test
+    public void testDeleteColumnMutation() throws Exception {
+        String tableName = "T_" + generateUniqueName();
+        String indexName1 = "I_" + generateUniqueName();
+        String indexName2 = "I_" + generateUniqueName();
+        String ddl = String.format("create table %s (id varchar primary key, " +
+                "col1 varchar, col2 varchar, col3 bigint)", tableName);
+        String index1 = String.format("create index %s on %s (col2) include (col1) ",
+                indexName1, tableName);
+        String index2 = String.format("create index %s on %s (col2) include (col1) " +
+                "COLUMN_ENCODED_BYTES=2, IMMUTABLE_STORAGE_SCHEME=SINGLE_CELL_ARRAY_WITH_OFFSETS",
+                indexName2, tableName);
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            conn.createStatement().execute(ddl);
+            conn.createStatement().execute(index1);
+            conn.createStatement().execute(index2);
+            PhoenixConnection pconn = conn.unwrap(PhoenixConnection.class);
+            PTable table = pconn.getTable(tableName);
+            ImmutableBytesWritable ptr = new ImmutableBytesWritable();
+            table.getIndexMaintainers(ptr, pconn);
+            List<IndexMaintainer> ims = IndexMaintainer.deserialize(ptr,
+                    GenericKeyValueBuilder.INSTANCE, true);
+            assertEquals(2, ims.size());
+            String dml = String.format("upsert into %s values ('a', 'ab', 'abc', 2)", tableName);
+            assertDeleteColumnMutation(tableName, dml, false, pconn, ims);
+            pconn.getMutationState().rollback();
+            dml = String.format("upsert into %s (id, col2) values  ('a', 'ab')", tableName);
+            assertDeleteColumnMutation(tableName, dml, true, pconn, ims);
+            pconn.getMutationState().rollback();
+        }
+    }
+
+    private static void assertDeleteColumnMutation(String tableName,
+                                                   String dml,
+                                                   boolean isPartialUpdate,
+                                                   PhoenixConnection pconn,
+                                                   List<IndexMaintainer> ims) throws Exception {
+        pconn.createStatement().execute(dml);
+        Iterator<Pair<byte[], List<Mutation>>> iterator =
+                pconn.getMutationState().toMutations();
+        while (iterator.hasNext()) {
+            Pair<byte[], List<Mutation>> mutationPair = iterator.next();
+            List<Mutation> batchMutations = mutationPair.getSecond();
+            assertEquals(1, batchMutations.size());
+            assertTrue(batchMutations.get(0) instanceof Put);
+            Put dataRow = (Put) batchMutations.get(0);
+            ValueGetter nextDataRowVG = new IndexUtil.SimpleValueGetter(dataRow);
+            long ts = EnvironmentEdgeManager.currentTimeMillis();
+            ImmutableBytesPtr rowKey = new ImmutableBytesPtr(dataRow.getRow());
+            for (IndexMaintainer im : ims) {
+                Put indexPut = im.buildUpdateMutation(GenericKeyValueBuilder.INSTANCE,
+                        nextDataRowVG, rowKey, ts, null, null, false, null);
+                if (indexPut == null) {
+                    // No covered column. Just prepare an index row with the empty column
+                    byte[] indexRowKey = im.buildRowKey(nextDataRowVG, rowKey,
+                            null, null, ts, null);
+                    indexPut = new Put(indexRowKey);
+                }
+                indexPut.addColumn(
+                        im.getEmptyKeyValueFamily().copyBytesIfNecessary(),
+                        im.getEmptyKeyValueQualifier(), ts,
+                        QueryConstants.UNVERIFIED_BYTES);
+                Delete deleteCol = im.buildDeleteColumnMutation(indexPut, ts);
+                if (im.getIndexStorageScheme() ==
+                        PTable.ImmutableStorageScheme.SINGLE_CELL_ARRAY_WITH_OFFSETS) {
+                    assertNull(deleteCol);
+                } else {
+                    if (isPartialUpdate) {
+                        assertNotNull(deleteCol);
+                    } else {
+                        assertNull(deleteCol);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Add DeleteColumn cells to index rows when a column is set to null in an upsert statement.