### PR TITLE
PHOENIX-7186 Support Square Brackets Notation for IPv6 in JDBC URL

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
@@ -537,11 +537,11 @@ public abstract class ConnectionInfo {
             String[] quorumParts = quorum.split(",");
             String[] normalizedParts = new String[quorumParts.length];
             for (int i = 0; i < quorumParts.length; i++) {
-                boolean urlHasPort = quorumParts[i].trim().contains(":");
+                int urlHasPort = quorumParts[i].trim().split(":").length;
                 quorumParts[i] = quorumParts[i].replace('~', ':');
-                if (!urlHasPort) {
+                if (urlHasPort == 1) {
                     normalizedParts[i] = quorumParts[i].trim().toLowerCase() + ":" + defaultPort;
-                } else if (urlHasPort) {
+                } else if (urlHasPort == 2) {
                     normalizedParts[i] = quorumParts[i].trim().toLowerCase();
                 } else {
                     throw getMalFormedUrlException(url);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.security.User;
@@ -119,6 +121,20 @@ public abstract class ConnectionInfo {
         return escaped.replaceAll("\\\\:", "=");
     }
 
+    protected static String escapeIPv6Literals(String unescaped) {
+        String regex = "(\\[.*?\\])";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(unescaped);
+        StringBuffer result = new StringBuffer();
+        while (matcher.find()) {
+            String matchedText = matcher.group(1);
+            String modifiedText = matchedText.replace(":", "~");
+            matcher.appendReplacement(result, modifiedText);
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
     public static ConnectionInfo createNoLogin(String url, ReadOnlyProps props, Properties info)
             throws SQLException {
         return create(url, getCachedConfiguration(), props, info, true);
@@ -143,7 +159,8 @@ public abstract class ConnectionInfo {
             ReadOnlyProps props, Properties info, boolean doNotLogin) throws SQLException {
         // registry-independent URL preprocessing
         url = url == null ? "" : url;
-        url = unescape(url);
+        boolean isIPv6 = url.contains("[") && url.contains("]");
+        url = isIPv6 ? unescape(escapeIPv6Literals(url)) : unescape(url);
 
         // Assume missing prefix
         if (url.isEmpty()) {
@@ -521,6 +538,7 @@ public abstract class ConnectionInfo {
             String[] normalizedParts = new String[quorumParts.length];
             for (int i = 0; i < quorumParts.length; i++) {
                 String[] hostAndPort = quorumParts[i].trim().split(":");
+                hostAndPort[0] = hostAndPort[0].replace("~", ":");
                 if (hostAndPort.length == 1) {
                     normalizedParts[i] = hostAndPort[0].trim().toLowerCase() + ":" + defaultPort;
                 } else if (hostAndPort.length == 2) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
@@ -537,12 +537,12 @@ public abstract class ConnectionInfo {
             String[] quorumParts = quorum.split(",");
             String[] normalizedParts = new String[quorumParts.length];
             for (int i = 0; i < quorumParts.length; i++) {
-                int urlHasPort = quorumParts[i].trim().split(":").length;
-                quorumParts[i] = quorumParts[i].replace('~', ':');
-                if (urlHasPort == 1) {
-                    normalizedParts[i] = quorumParts[i].trim().toLowerCase() + ":" + defaultPort;
-                } else if (urlHasPort == 2) {
-                    normalizedParts[i] = quorumParts[i].trim().toLowerCase();
+                String[] hostAndPort = quorumParts[i].trim().split(":");
+                hostAndPort[0] = hostAndPort[0].replace('~', ':');
+                if (hostAndPort.length == 1) {
+                    normalizedParts[i] = hostAndPort[0].trim().toLowerCase() + ":" + defaultPort;
+                } else if (hostAndPort.length == 2) {
+                    normalizedParts[i] = String.join(":", hostAndPort).trim().toLowerCase();
                 } else {
                     throw getMalFormedUrlException(url);
                 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/ConnectionInfo.java
@@ -537,11 +537,11 @@ public abstract class ConnectionInfo {
             String[] quorumParts = quorum.split(",");
             String[] normalizedParts = new String[quorumParts.length];
             for (int i = 0; i < quorumParts.length; i++) {
-                String[] hostAndPort = quorumParts[i].trim().split(":");
-                hostAndPort[0] = hostAndPort[0].replace("~", ":");
-                if (hostAndPort.length == 1) {
-                    normalizedParts[i] = hostAndPort[0].trim().toLowerCase() + ":" + defaultPort;
-                } else if (hostAndPort.length == 2) {
+                boolean urlHasPort = quorumParts[i].trim().contains(":");
+                quorumParts[i] = quorumParts[i].replace('~', ':');
+                if (!urlHasPort) {
+                    normalizedParts[i] = quorumParts[i].trim().toLowerCase() + ":" + defaultPort;
+                } else if (urlHasPort) {
                     normalizedParts[i] = quorumParts[i].trim().toLowerCase();
                 } else {
                     throw getMalFormedUrlException(url);

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixEmbeddedDriverTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixEmbeddedDriverTest.java
@@ -570,6 +570,65 @@ public class PhoenixEmbeddedDriverTest {
     }
 
     @Test
+    public void testZkIPv6() throws Exception {
+        ConnectionInfo connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "[::1],127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        ReadOnlyProps props = connectionInfo.asProps();
+        assertEquals("127.23.45.678:7634,[::1]:2181,host123.48576:723,v3:1",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "[::1]\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("127.23.45.678:7634,[::1]:2181,host123.48576:723,v3:1",
+
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "[fe:80::],127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("127.23.45.678:7634,[fe:80::]:2181,host123.48576:723,v3:1",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "[fe:80::]\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("127.23.45.678:7634,[fe:80::]:2181,host123.48576:723,v3:1",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "[fe\\:80\\:\\:],127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("127.23.45.678:7634,[fe:80::]:2181,host123.48576:723,v3:1",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "[fe\\:80\\:\\:]\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("127.23.45.678:7634,[fe:80::]:2181,host123.48576:723,v3:1",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "[fe:80::2]\\:2181,[2001:db8:3c4d:15::1a2f:1a2b]\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("[2001:db8:3c4d:15::1a2f:1a2b]:7634,[fe:80::2]:2181,host123.48576:723,v3:1",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+
+        connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
+                + "[fe:80::2]\\:2181,[2001\\:db8\\:3c4d\\:15\\:\\:1a2f\\:1a2b]\\:7634,v3\\:1,host123.48576\\:723:/hbase;"
+                + "test=true", null, null);
+        props = connectionInfo.asProps();
+        assertEquals("[2001:db8:3c4d:15::1a2f:1a2b]:7634,[fe:80::2]:2181,host123.48576:723,v3:1",
+                props.get(HConstants.ZOOKEEPER_QUORUM));
+    }
+
+    @Test
     public void testZkQuorumConfigs() throws Exception {
         ConnectionInfo connectionInfo = ConnectionInfo.create("jdbc:phoenix+zk:"
                 + "localhost\\:2181,127.23.45.678\\:7634,v3\\:1,host123.48576\\:723:/hbase;"


### PR DESCRIPTION
ZK supports using square brackets around the IP address to resolve the colon ambiguity.

Added support for the square bracket notation.
(We still need to escape the colon separating the port from the address.)

i.e. accept:
"phoenix+zk:[fe:80::01]\:2181::/hbase"