### PR TITLE
PHOENIX-7610 Using CAST() on pk columns always result in full table scan

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/expression/CoerceExpression.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/expression/CoerceExpression.java
@@ -147,6 +147,16 @@ public class CoerceExpression extends BaseSingleExpression {
     }
 
     @Override
+    public boolean isStateless() {
+        // It is important to associate the stateless-ness of the CoerceExpression
+        // child with the CoerceExpression. Without this, ComparisonExpression used
+        // by WhereOptimizer would always select Full table scan even for the query
+        // that is supposed to use Range scan or Point lookup on the single row.
+        // Jira: PHOENIX-7610.
+        return getChild().isStateless();
+    }
+
+    @Override
     public boolean evaluate(Tuple tuple, ImmutableBytesWritable ptr) {
         // For CoerceExpression evaluation, lhs is coerced to rhs literal expression. However,
         // in case of variable length binary literal expression, literal value by default

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/expression/CoerceExpression.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/expression/CoerceExpression.java
@@ -150,7 +150,8 @@ public class CoerceExpression extends BaseSingleExpression {
     public boolean isStateless() {
         // It is important to associate the stateless-ness of the CoerceExpression
         // child with the CoerceExpression. Without this, ComparisonExpression and
-        // KeyExpressionVisitor used by WhereOptimizer always select Full table scan
+        // KeyExpressionVisitor will not be evaluated on the client side, and
+        // thus WhereOptimizer will always select Full table scan
         // even for the query that is supposed to use Range scan or Point lookup
         // on the single row.
         // Jira: PHOENIX-7610.

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/expression/CoerceExpression.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/expression/CoerceExpression.java
@@ -149,9 +149,10 @@ public class CoerceExpression extends BaseSingleExpression {
     @Override
     public boolean isStateless() {
         // It is important to associate the stateless-ness of the CoerceExpression
-        // child with the CoerceExpression. Without this, ComparisonExpression used
-        // by WhereOptimizer would always select Full table scan even for the query
-        // that is supposed to use Range scan or Point lookup on the single row.
+        // child with the CoerceExpression. Without this, ComparisonExpression and
+        // KeyExpressionVisitor used by WhereOptimizer always select Full table scan
+        // even for the query that is supposed to use Range scan or Point lookup
+        // on the single row.
         // Jira: PHOENIX-7610.
         return getChild().isStateless();
     }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson4IT.java
@@ -484,9 +484,7 @@ public class Bson4IT extends ParallelStatsDisabledIT {
 
       assertFalse(rs.next());
 
-      // TODO : Fix this separately, using CAST with PK column results into full table scan due
-      //  to bug.
-      // validateExplainPlan(stmt, query, tableName, "POINT LOOKUP ON 1 KEY ");
+      validateExplainPlan(stmt, query, tableName, "POINT LOOKUP ON 1 KEY ");
 
       query = "SELECT * FROM " + tableName +
               " WHERE PK1 != CAST('" + sample1 + "' AS BSON)";


### PR DESCRIPTION
Jira: PHOENIX-7610

For the range scan or point lookup on the single row, it is required to provide either full pk columns with equal comparison (point lookup) or prefix pk columns with equal comparison operator (range scan).

However, when we use SQL CAST() function on pk columns to convert the type of the given column into another data type, the plan generated by where optimizer always performs full table scan instead of range scan or point lookup.