### PR TITLE
PHOENIX-7605 Addendum Fixing IT where table was used after t.close(), passing pool to hbase client based on value.

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/HTableFactory.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/HTableFactory.java
@@ -54,6 +54,8 @@ public interface HTableFactory {
             // There is a difference between these 2 implementations in HBase Client Code and when
             // the pool is terminated on HTable close()
             // So we need to use these 2 implementations based on value of pool.
+            // If Externally provided pool is null, we use the default behavior of
+            // ConnectionImplementation to manage the pool.
             if (pool == null) {
                 return connection.getTable(TableName.valueOf(tableName));
             } else {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/HTableFactory.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/HTableFactory.java
@@ -51,9 +51,6 @@ public interface HTableFactory {
                 throws IOException {
             // If CQSI_THREAD_POOL_ENABLED then we pass ExecutorService created in CQSI to
             // HBase Client, else it is null(default), let the HBase client manage the thread pool
-            // There is a difference between these 2 implementations in HBase Client Code and when
-            // the pool is terminated on HTable close()
-            // So we need to use these 2 implementations based on value of pool.
             return connection.getTable(TableName.valueOf(tableName), pool);
         }
     }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/HTableFactory.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/HTableFactory.java
@@ -54,11 +54,7 @@ public interface HTableFactory {
             // There is a difference between these 2 implementations in HBase Client Code and when
             // the pool is terminated on HTable close()
             // So we need to use these 2 implementations based on value of pool.
-            if (pool == null) {
-                return connection.getTable(TableName.valueOf(tableName));
-            } else {
-                return connection.getTable(TableName.valueOf(tableName), pool);
-            }
+            return connection.getTable(TableName.valueOf(tableName), pool);
         }
     }
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/HTableFactory.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/HTableFactory.java
@@ -51,7 +51,14 @@ public interface HTableFactory {
                 throws IOException {
             // If CQSI_THREAD_POOL_ENABLED then we pass ExecutorService created in CQSI to
             // HBase Client, else it is null(default), let the HBase client manage the thread pool
-            return connection.getTable(TableName.valueOf(tableName), pool);
+            // There is a difference between these 2 implementations in HBase Client Code and when
+            // the pool is terminated on HTable close()
+            // So we need to use these 2 implementations based on value of pool.
+            if (pool == null) {
+                return connection.getTable(TableName.valueOf(tableName));
+            } else {
+                return connection.getTable(TableName.valueOf(tableName), pool);
+            }
         }
     }
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MappingTableDataTypeIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MappingTableDataTypeIT.java
@@ -58,11 +58,9 @@ public class MappingTableDataTypeIT extends ParallelStatsDisabledIT {
         final TableName tableName = TableName.valueOf(mtest);
         Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
         PhoenixConnection conn = DriverManager.getConnection(getUrl(), props).unwrap(PhoenixConnection.class);
-        
 
-        // We should only close the table after we are done using it.
         try(Table t = conn.getQueryServices().getTable(Bytes.toBytes(mtest));
-            Admin admin = conn.getQueryServices().getAdmin();) {
+            Admin admin = conn.getQueryServices().getAdmin()) {
             // Create table then get the single region for our new table.
             TableDescriptorBuilder builder = TableDescriptorBuilder.newBuilder(tableName);
             builder.setColumnFamily(ColumnFamilyDescriptorBuilder.of(Bytes.toBytes("cf1")))

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MappingTableDataTypeIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MappingTableDataTypeIT.java
@@ -100,6 +100,7 @@ public class MappingTableDataTypeIT extends ParallelStatsDisabledIT {
             assertEquals("Column Value", "value2", Bytes.toString(kvs.get(0).getValueArray(), kvs.get(0).getValueOffset(), kvs.get(0).getValueLength()));
             assertNull("Expected single row", results.next());
         } finally {
+            // We should close the table only after we are done using it.
             if(t != null) {
                 t.close();
             }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MappingTableDataTypeIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MappingTableDataTypeIT.java
@@ -59,9 +59,10 @@ public class MappingTableDataTypeIT extends ParallelStatsDisabledIT {
         Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
         PhoenixConnection conn = DriverManager.getConnection(getUrl(), props).unwrap(PhoenixConnection.class);
         
-        Admin admin = conn.getQueryServices().getAdmin();
+
         // We should only close the table after we are done using it.
-        try(Table t = conn.getQueryServices().getTable(Bytes.toBytes(mtest));) {
+        try(Table t = conn.getQueryServices().getTable(Bytes.toBytes(mtest));
+            Admin admin = conn.getQueryServices().getAdmin();) {
             // Create table then get the single region for our new table.
             TableDescriptorBuilder builder = TableDescriptorBuilder.newBuilder(tableName);
             builder.setColumnFamily(ColumnFamilyDescriptorBuilder.of(Bytes.toBytes("cf1")))
@@ -99,8 +100,6 @@ public class MappingTableDataTypeIT extends ParallelStatsDisabledIT {
             assertEquals("Expected single value ", 1, kvs.size());
             assertEquals("Column Value", "value2", Bytes.toString(kvs.get(0).getValueArray(), kvs.get(0).getValueOffset(), kvs.get(0).getValueLength()));
             assertNull("Expected single row", results.next());
-        } finally {
-            admin.close();
         }
     }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MappingTableDataTypeIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MappingTableDataTypeIT.java
@@ -60,15 +60,15 @@ public class MappingTableDataTypeIT extends ParallelStatsDisabledIT {
         PhoenixConnection conn = DriverManager.getConnection(getUrl(), props).unwrap(PhoenixConnection.class);
         
         Admin admin = conn.getQueryServices().getAdmin();
+        Table t = null;
         try {
             // Create table then get the single region for our new table.
             TableDescriptorBuilder builder = TableDescriptorBuilder.newBuilder(tableName);
             builder.setColumnFamily(ColumnFamilyDescriptorBuilder.of(Bytes.toBytes("cf1")))
                     .setColumnFamily(ColumnFamilyDescriptorBuilder.of(Bytes.toBytes("cf2")));
             admin.createTable(builder.build());
-            Table t = conn.getQueryServices().getTable(Bytes.toBytes(mtest));
+            t = conn.getQueryServices().getTable(Bytes.toBytes(mtest));
             insertData(tableName.getName(), admin, t);
-            t.close();
             // create phoenix table that maps to existing HBase table
             createPhoenixTable(mtest);
             
@@ -100,6 +100,9 @@ public class MappingTableDataTypeIT extends ParallelStatsDisabledIT {
             assertEquals("Column Value", "value2", Bytes.toString(kvs.get(0).getValueArray(), kvs.get(0).getValueOffset(), kvs.get(0).getValueLength()));
             assertNull("Expected single row", results.next());
         } finally {
+            if(t != null) {
+                t.close();
+            }
             admin.close();
         }
     }


### PR DESCRIPTION
We use Connection.getTable in org.apache.phoenix.query.HTableFactory. There are 2 flavors of this getTable method and the issue comes from the implementation of this method.
getTable(tableName) -> This one has a default implementation which calls getTable(tableName, null) The null here is executorService.
But in org.apache.hadoop.hbase.client.ConnectionImplementation implementation of getTable(tableName) it calls getTable(tableName, getBatchPool()) . This pool is managed by hbase code and it cleans up the pool on close() -> [link](https://github.com/enis/hbase-sal/blob/master/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HTable.java#L171-L176)


Note that in existing implementation of this change we were calling HTable.close() which was closing the threadpool managed by HTable. Ideally the table should be closed only after using it but in this case the scanner was working as ConnectionImplementation was creating the batchpool [here](https://git.soma.salesforce.com/bigdata-packaging/hbase/blob/2.5.10-sfdc-13/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java#L454) and passing it to HTable which was not closing it when HTable.close() was called.
Refer [link](https://github.com/enis/hbase-sal/blob/master/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HTable.java#L171-L176)

Now, we are safeguarding from this behavior by checking if pool passed to ConnectionImplementation is null or not.