### PR TITLE
PHOENIX-7616 NPE when there are Conditional expressions on indexed columns

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/CompiledConditionalTTLExpression.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/CompiledConditionalTTLExpression.java
@@ -216,7 +216,7 @@ public class CompiledConditionalTTLExpression implements CompiledTTLExpression {
             return false;
         }
         Object value = PBoolean.INSTANCE.toObject(ptr);
-        return value != null ? value.equals(Boolean.TRUE) : false;
+        return Boolean.TRUE.equals(value);
     }
 
     /**

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/CompiledConditionalTTLExpression.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/CompiledConditionalTTLExpression.java
@@ -216,7 +216,7 @@ public class CompiledConditionalTTLExpression implements CompiledTTLExpression {
             return false;
         }
         Object value = PBoolean.INSTANCE.toObject(ptr);
-        return value.equals(Boolean.TRUE);
+        return value != null ? value.equals(Boolean.TRUE) : false;
     }
 
     /**


### PR DESCRIPTION
NPE when the row key had a column with a null value and that column was part of a conditional TTL expression.