### PR TITLE
PHOENIX-7591 Concurrent updates to tables with indexes can cause data inconsistency

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/hbase/index/util/IndexManagementUtil.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/hbase/index/util/IndexManagementUtil.java
@@ -199,7 +199,7 @@ public class IndexManagementUtil {
         try {
             throw e;
         } catch (IOException | FatalIndexBuildingFailureException e1) {
-            LOGGER.info("Rethrowing " + e);
+            LOGGER.info("Rethrowing ", e);
             throw e1;
         }
         catch (Throwable e1) {

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -230,7 +230,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
         ignoreWritingDeleteColumnsToIndex = ignore;
     }
     public enum BatchMutatePhase {
-        PRE, POST, FAILED
+        INIT, PRE, POST, FAILED
     }
 
     // Hack to get around not being able to save any state between
@@ -245,7 +245,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
     * locks to serialize the access to the BatchMutateContext objects.
     */
     public static class BatchMutateContext {
-        private volatile BatchMutatePhase currentPhase = BatchMutatePhase.PRE;
+        private volatile BatchMutatePhase currentPhase = BatchMutatePhase.INIT;
         // The max of reference counts on the pending rows of this batch at the time this
         // batch arrives.
         private int maxPendingRowCount = 0;
@@ -1468,6 +1468,8 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
             return;
         }
         lockRows(context);
+        // acquired the locks, move to the next phase PRE
+        context.currentPhase = BatchMutatePhase.PRE;
         long onDupCheckTime = 0;
 
         if (context.hasAtomic || context.returnResult || context.hasGlobalIndex
@@ -1637,6 +1639,12 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
           return;
       }
       try {
+          // We add to pending rows only after we have locked all the rows in the batch
+          // If we are in the INIT phase that means we failed to acquire the locks before the
+          // PRE phase
+          if (context.getCurrentPhase() != BatchMutatePhase.INIT) {
+              removePendingRows(context);
+          }
           if (success) {
               context.currentPhase = BatchMutatePhase.POST;
               if ((context.hasAtomic || context.returnResult) && miniBatchOp.size() == 1) {
@@ -1659,7 +1667,6 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
               context.currentPhase = BatchMutatePhase.FAILED;
           }
           context.countDownAllLatches();
-          removePendingRows(context);
           if (context.indexUpdates != null) {
               context.indexUpdates.clear();
           }


### PR DESCRIPTION
Added a new phase which tracks if we were able to acquire the row locks or not and accordingly decrement the reference count in pending rows.