### PR TITLE
PHOENIX-7636 CDC on table with case-sensitive pk columns fails to read change records

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -2022,11 +2022,14 @@ public class MetaDataClient {
         int pkOffset = dataTable.getBucketNum() != null ? 1 : 0;
         for (int i = pkOffset; i < pkColumns.size(); ++i) {
             PColumn pcol = pkColumns.get(i);
-            columnDefs.add(FACTORY.columnDef(FACTORY.columnName(pcol.getName().getString()),
-                    pcol.getDataType().getSqlTypeName(), false, null, false, pcol.getMaxLength(),
-                    pcol.getScale(), false, pcol.getSortOrder(), "", null, false));
+            columnDefs.add(
+                    FACTORY.columnDef(FACTORY.columnName("\"" + pcol.getName().getString() + "\""),
+                            pcol.getDataType().getSqlTypeName(), false, null, false,
+                            pcol.getMaxLength(), pcol.getScale(), false,
+                            pcol.getSortOrder(), "", null, false));
             pkColumnDefs.add(FACTORY.columnDefInPkConstraint(FACTORY.columnName(
-                    pcol.getName().getString()), pcol.getSortOrder(), pcol.isRowTimestamp()));
+                            "\"" + pcol.getName().getString() + "\""), pcol.getSortOrder(),
+                    pcol.isRowTimestamp()));
         }
         columnDefs.add(FACTORY.columnDef(FACTORY.columnName(QueryConstants.CDC_JSON_COL_NAME),
                 PVarchar.INSTANCE.getSqlTypeName(), false, null, true, null,


### PR DESCRIPTION
Jira: PHOENIX-7636

While creating CDC object on table with case-sensitive pk columns, the CDC PTable definition does not include case-sensitive pk columns of the data table. Therefore, reading of the CDC records fails as the query optimizer cannot select any plan.

e.g. 

SQL statements:
```
CREATE TABLE XYZ."test.table" ("key1" VARCHAR NOT NULL, COL BSON CONSTRAINT pk PRIMARY KEY ("key1"));

CREATE CDC "CDC_test.table" on XYZ."test.table";

UPSERT INTO XYZ."test.table" VALUES (?,?);

SELECT /*+ CDC_INCLUDE(PRE, POST) */ *  FROM XYZ."CDC_test.table" WHERE PARTITION_ID() = ?  AND PHOENIX_ROW_TIMESTAMP() >= CAST(CAST(? AS BIGINT) AS TIMESTAMP) LIMIT ?;
```
causes
```
Caused by: org.apache.phoenix.schema.RowValueConstructorOffsetNotCoercibleException: ERROR 2014 (INT16): Row Value Constructor Offset Not Coercible to a Primary or Indexed RowKey. No table or index could be coerced to the PK as the offset. Or an uncovered index was attempted
	at org.apache.phoenix.optimize.QueryOptimizer.getApplicablePlansForSingleFlatQuery(QueryOptimizer.java:331) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.optimize.QueryOptimizer.getApplicablePlans(QueryOptimizer.java:142) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.optimize.QueryOptimizer.optimize(QueryOptimizer.java:120) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.optimize.QueryOptimizer.optimize(QueryOptimizer.java:106) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.jdbc.PhoenixStatement$1.call(PhoenixStatement.java:392) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.jdbc.PhoenixStatement$1.call(PhoenixStatement.java:360) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.call.CallRunner.run(CallRunner.java:53) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.jdbc.PhoenixStatement.executeQuery(PhoenixStatement.java:360) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.jdbc.PhoenixStatement.executeQuery(PhoenixStatement.java:342) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.jdbc.PhoenixPreparedStatement.executeQuery(PhoenixPreparedStatement.java:197) ~[phoenix-core-client-5.3.0-sfdc-13.0.24.jar:5.3.0-sfdc-13.0.24]
	at org.apache.phoenix.ddb.service.GetRecordsService.getRecords(GetRecordsService.java:71) ~[classes/:?]
	at org.apache.phoenix.ddb.rest.RootResource.get(RootResource.java:196) ~[classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_362]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_362]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_362]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_362]
```