### PR TITLE
Phoenix-7632 Adding ReplicationLogProcessor Component

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessor.java
@@ -36,9 +36,11 @@ public interface MetricsReplicationLogProcessor extends BaseSource {
     String LOG_FILE_REPLAY_SUCCESS_COUNT = "logFileReplaySuccessCount";
     String LOG_FILE_REPLAY_SUCCESS_COUNT_DESC = "Number of files successfully to replayed";
     String BATCH_REPLAY_TIME = "batchReplayTimeMs";
-    String BATCH_REPLAY_TIME_DESC = "Histogram of time taken for replaying a batch of log file in milliseconds";
+    String BATCH_REPLAY_TIME_DESC = 
+        "Histogram of time taken for replaying a batch of log file in milliseconds";
     String LOG_FILE_REPLAY_TIME = "logFileReplayTimeMs";
-    String LOG_FILE_REPLAY_TIME_DESC = "Histogram of time taken for replaying a log file in milliseconds";
+    String LOG_FILE_REPLAY_TIME_DESC = 
+        "Histogram of time taken for replaying a log file in milliseconds";
 
     /**
      * Increments the counter for failed mutations.

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessor.java
@@ -1,0 +1,69 @@
+package org.apache.phoenix.replication.metrics;
+
+import org.apache.hadoop.hbase.metrics.BaseSource;
+
+/** Interface for metrics related to ReplicationLogProcessor operations. */
+public interface MetricsReplicationLogProcessor extends BaseSource {
+
+    String METRICS_NAME = "ReplicationLogProcessor";
+    String METRICS_CONTEXT = "phoenix";
+    String METRICS_DESCRIPTION = "Metrics about Replication Log Processor for an HA Group";
+    String METRICS_JMX_CONTEXT = "RegionServer,sub=" + METRICS_NAME;
+
+    String FAILED_MUTATIONS_COUNT = "failedMutationsCount";
+    String FAILED_MUTATIONS_COUNT_DESC = "Number of failed mutations";
+    String FAILED_BATCH_COUNT = "failedBatchCount";
+    String FAILED_BATCH_COUNT_DESC = "Number of failed batches";
+    String LOG_FILE_REPLAY_FAILURE_COUNT = "logFileReplayFailureCount";
+    String LOG_FILE_REPLAY_FAILURE_COUNT_DESC = "Number of files failed to replay";
+    String LOG_FILE_REPLAY_SUCCESS_COUNT = "logFileReplaySuccessCount";
+    String LOG_FILE_REPLAY_SUCCESS_COUNT_DESC = "Number of files successfully to replayed";
+    String BATCH_REPLAY_TIME = "batchReplayTimeMs";
+    String BATCH_REPLAY_TIME_DESC = "Histogram of time taken for replaying a batch of log file in milliseconds";
+    String LOG_FILE_REPLAY_TIME = "logFileReplayTimeMs";
+    String LOG_FILE_REPLAY_TIME_DESC = "Histogram of time taken for replaying a log file in milliseconds";
+
+    /**
+     * Increments the counter for failed mutations.
+     * This counter tracks the number of mutations that failed during processing.
+     */
+    void incrementFailedMutationsCount(long delta);
+
+    /**
+     * Increments the counter for log file replay failures.
+     * This counter tracks the number of log files that failed to replay.
+     */
+    void incrementFailedBatchCount();
+
+    /**
+     * Increments the counter for log file replay failures.
+     * This counter tracks the number of log files that failed to replay.
+     */
+    void incrementLogFileReplayFailureCount();
+
+    /**
+     * Increments the counter for log file replay successes.
+     * This counter tracks the number of log files that were successfully replayed.
+     */
+    void incrementLogFileReplaySuccessCount();
+
+    /**
+     * Update the time taken for replaying a batch of mutations in milliseconds.
+     * @param timeMs Time taken in milliseconds
+     */
+    void updateBatchReplayTime(long timeMs);
+
+    /**
+     * Update the time taken for replaying a log file in milliseconds.
+     * @param timeMs Time taken in milliseconds
+     */
+    void updateLogFileReplayTime(long timeMs);
+
+    /**
+     * Unregister this metrics source.
+     */
+    void close();
+
+    // Get current values for testing
+    ReplicationLogProcessorMetricValues getCurrentMetricValues();
+}

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessor.java
@@ -36,10 +36,10 @@ public interface MetricsReplicationLogProcessor extends BaseSource {
     String LOG_FILE_REPLAY_SUCCESS_COUNT = "logFileReplaySuccessCount";
     String LOG_FILE_REPLAY_SUCCESS_COUNT_DESC = "Number of files successfully to replayed";
     String BATCH_REPLAY_TIME = "batchReplayTimeMs";
-    String BATCH_REPLAY_TIME_DESC = 
+    String BATCH_REPLAY_TIME_DESC =
         "Histogram of time taken for replaying a batch of log file in milliseconds";
     String LOG_FILE_REPLAY_TIME = "logFileReplayTimeMs";
-    String LOG_FILE_REPLAY_TIME_DESC = 
+    String LOG_FILE_REPLAY_TIME_DESC =
         "Histogram of time taken for replaying a log file in milliseconds";
 
     /**

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.phoenix.replication.metrics;
 
 import org.apache.hadoop.hbase.metrics.BaseSource;

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.phoenix.replication.metrics;
 
 import org.apache.hadoop.hbase.metrics.BaseSourceImpl;

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.metrics2.lib.MutableFastCounter;
 import org.apache.hadoop.metrics2.lib.MutableHistogram;
 
 /** Implementation of metrics source for ReplicationLogProcessor operations. */
-public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl 
+public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl
         implements MetricsReplicationLogProcessor {
 
     private String groupMetricsContext;
@@ -35,12 +35,12 @@ public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl
     private final MutableHistogram logFileReplayTime;
 
     public MetricsReplicationLogProcessorImpl(final String haGroupName) {
-        this(METRICS_NAME, METRICS_DESCRIPTION, METRICS_CONTEXT, 
+        this(METRICS_NAME, METRICS_DESCRIPTION, METRICS_CONTEXT,
             METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName);
         groupMetricsContext = METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName;
     }
 
-    public MetricsReplicationLogProcessorImpl(String metricsName, String metricsDescription, 
+    public MetricsReplicationLogProcessorImpl(String metricsName, String metricsDescription,
             String metricsContext, String metricsJmxContext) {
         super(metricsName, metricsDescription, metricsContext, metricsJmxContext);
         failedMutationsCount = getMetricsRegistry().newCounter(FAILED_MUTATIONS_COUNT,
@@ -51,9 +51,9 @@ public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl
             LOG_FILE_REPLAY_FAILURE_COUNT_DESC, 0L);
         logFileReplaySuccessCount = getMetricsRegistry().newCounter(LOG_FILE_REPLAY_SUCCESS_COUNT,
             LOG_FILE_REPLAY_SUCCESS_COUNT_DESC, 0L);
-        batchReplayTime = getMetricsRegistry().newHistogram(BATCH_REPLAY_TIME, 
+        batchReplayTime = getMetricsRegistry().newHistogram(BATCH_REPLAY_TIME,
             BATCH_REPLAY_TIME_DESC);
-        logFileReplayTime = getMetricsRegistry().newHistogram(LOG_FILE_REPLAY_TIME, 
+        logFileReplayTime = getMetricsRegistry().newHistogram(LOG_FILE_REPLAY_TIME,
             LOG_FILE_REPLAY_TIME_DESC);
     }
 

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
@@ -1,0 +1,89 @@
+package org.apache.phoenix.replication.metrics;
+
+import org.apache.hadoop.hbase.metrics.BaseSourceImpl;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MutableFastCounter;
+import org.apache.hadoop.metrics2.lib.MutableHistogram;
+
+/** Implementation of metrics source for ReplicationLogProcessor operations. */
+public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl implements MetricsReplicationLogProcessor {
+
+    private String groupMetricsContext;
+    private final MutableFastCounter failedMutationsCount;
+    private final MutableFastCounter failedBatchCount;
+    private final MutableFastCounter logFileReplayFailureCount;
+    private final MutableFastCounter logFileReplaySuccessCount;
+    private final MutableHistogram batchReplayTime;
+    private final MutableHistogram logFileReplayTime;
+
+    public MetricsReplicationLogProcessorImpl(final String haGroupId) {
+        this(METRICS_NAME, METRICS_DESCRIPTION, METRICS_CONTEXT, METRICS_JMX_CONTEXT + ",haGroup=" + haGroupId);
+        groupMetricsContext = METRICS_JMX_CONTEXT + ",haGroup=" + haGroupId;
+    }
+
+    public MetricsReplicationLogProcessorImpl(String metricsName, String metricsDescription, String metricsContext, String metricsJmxContext) {
+        super(metricsName, metricsDescription, metricsContext, metricsJmxContext);
+        failedMutationsCount = getMetricsRegistry().newCounter(FAILED_MUTATIONS_COUNT,
+            FAILED_MUTATIONS_COUNT_DESC, 0L);
+        failedBatchCount = getMetricsRegistry().newCounter(FAILED_BATCH_COUNT,
+                FAILED_BATCH_COUNT_DESC, 0L);
+        logFileReplayFailureCount = getMetricsRegistry().newCounter(LOG_FILE_REPLAY_FAILURE_COUNT,
+            LOG_FILE_REPLAY_FAILURE_COUNT_DESC, 0L);
+        logFileReplaySuccessCount = getMetricsRegistry().newCounter(LOG_FILE_REPLAY_SUCCESS_COUNT,
+            LOG_FILE_REPLAY_SUCCESS_COUNT_DESC, 0L);
+        batchReplayTime = getMetricsRegistry().newHistogram(BATCH_REPLAY_TIME, BATCH_REPLAY_TIME_DESC);
+        logFileReplayTime = getMetricsRegistry().newHistogram(LOG_FILE_REPLAY_TIME, LOG_FILE_REPLAY_TIME_DESC);
+    }
+
+    @Override
+    public void incrementFailedMutationsCount(long delta) {
+        failedMutationsCount.incr(delta);
+    }
+
+    @Override
+    public void incrementFailedBatchCount() {
+        failedBatchCount.incr();
+    }
+
+    @Override
+    public void incrementLogFileReplayFailureCount() {
+        logFileReplayFailureCount.incr();
+    }
+
+    @Override
+    public void incrementLogFileReplaySuccessCount() {
+        logFileReplaySuccessCount.incr();
+    }
+
+    @Override
+    public void updateBatchReplayTime(long timeMs) {
+        batchReplayTime.add(timeMs);
+    }
+
+    @Override
+    public void updateLogFileReplayTime(long timeMs) {
+        logFileReplayTime.add(timeMs);
+    }
+
+    @Override
+    public void close() {
+        // Unregister this metrics source
+        DefaultMetricsSystem.instance().unregisterSource(groupMetricsContext);
+    }
+
+    @Override
+    public ReplicationLogProcessorMetricValues getCurrentMetricValues() {
+        return new ReplicationLogProcessorMetricValues(
+            failedMutationsCount.value(),
+            logFileReplayFailureCount.value(),
+            logFileReplaySuccessCount.value(),
+            logFileReplayTime.getMax(),
+            batchReplayTime.getMax()
+        );
+    }
+
+    @Override
+    public String getMetricsContext() {
+        return groupMetricsContext;
+    }
+}

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
@@ -34,10 +34,10 @@ public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl
     private final MutableHistogram batchReplayTime;
     private final MutableHistogram logFileReplayTime;
 
-    public MetricsReplicationLogProcessorImpl(final String haGroupId) {
+    public MetricsReplicationLogProcessorImpl(final String haGroupName) {
         this(METRICS_NAME, METRICS_DESCRIPTION, METRICS_CONTEXT, 
-            METRICS_JMX_CONTEXT + ",haGroup=" + haGroupId);
-        groupMetricsContext = METRICS_JMX_CONTEXT + ",haGroup=" + haGroupId;
+            METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName);
+        groupMetricsContext = METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName;
     }
 
     public MetricsReplicationLogProcessorImpl(String metricsName, String metricsDescription, 

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
@@ -23,7 +23,8 @@ import org.apache.hadoop.metrics2.lib.MutableFastCounter;
 import org.apache.hadoop.metrics2.lib.MutableHistogram;
 
 /** Implementation of metrics source for ReplicationLogProcessor operations. */
-public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl implements MetricsReplicationLogProcessor {
+public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl 
+        implements MetricsReplicationLogProcessor {
 
     private String groupMetricsContext;
     private final MutableFastCounter failedMutationsCount;
@@ -34,22 +35,26 @@ public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl implement
     private final MutableHistogram logFileReplayTime;
 
     public MetricsReplicationLogProcessorImpl(final String haGroupId) {
-        this(METRICS_NAME, METRICS_DESCRIPTION, METRICS_CONTEXT, METRICS_JMX_CONTEXT + ",haGroup=" + haGroupId);
+        this(METRICS_NAME, METRICS_DESCRIPTION, METRICS_CONTEXT, 
+            METRICS_JMX_CONTEXT + ",haGroup=" + haGroupId);
         groupMetricsContext = METRICS_JMX_CONTEXT + ",haGroup=" + haGroupId;
     }
 
-    public MetricsReplicationLogProcessorImpl(String metricsName, String metricsDescription, String metricsContext, String metricsJmxContext) {
+    public MetricsReplicationLogProcessorImpl(String metricsName, String metricsDescription, 
+            String metricsContext, String metricsJmxContext) {
         super(metricsName, metricsDescription, metricsContext, metricsJmxContext);
         failedMutationsCount = getMetricsRegistry().newCounter(FAILED_MUTATIONS_COUNT,
             FAILED_MUTATIONS_COUNT_DESC, 0L);
         failedBatchCount = getMetricsRegistry().newCounter(FAILED_BATCH_COUNT,
-                FAILED_BATCH_COUNT_DESC, 0L);
+            FAILED_BATCH_COUNT_DESC, 0L);
         logFileReplayFailureCount = getMetricsRegistry().newCounter(LOG_FILE_REPLAY_FAILURE_COUNT,
             LOG_FILE_REPLAY_FAILURE_COUNT_DESC, 0L);
         logFileReplaySuccessCount = getMetricsRegistry().newCounter(LOG_FILE_REPLAY_SUCCESS_COUNT,
             LOG_FILE_REPLAY_SUCCESS_COUNT_DESC, 0L);
-        batchReplayTime = getMetricsRegistry().newHistogram(BATCH_REPLAY_TIME, BATCH_REPLAY_TIME_DESC);
-        logFileReplayTime = getMetricsRegistry().newHistogram(LOG_FILE_REPLAY_TIME, LOG_FILE_REPLAY_TIME_DESC);
+        batchReplayTime = getMetricsRegistry().newHistogram(BATCH_REPLAY_TIME, 
+            BATCH_REPLAY_TIME_DESC);
+        logFileReplayTime = getMetricsRegistry().newHistogram(LOG_FILE_REPLAY_TIME, 
+            LOG_FILE_REPLAY_TIME_DESC);
     }
 
     @Override

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/ReplicationLogProcessorMetricValues.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/ReplicationLogProcessorMetricValues.java
@@ -26,7 +26,9 @@ public class ReplicationLogProcessorMetricValues {
     private final long logFileReplayTime;
     private final long logFileBatchReplayTime;
 
-    public ReplicationLogProcessorMetricValues(long failedMutationsCount, long logFileReplayFailureCount, long logFileReplaySuccessCount, long logFileReplayTime, long logFileBatchReplayTime) {
+    public ReplicationLogProcessorMetricValues(long failedMutationsCount, 
+            long logFileReplayFailureCount, long logFileReplaySuccessCount, 
+            long logFileReplayTime, long logFileBatchReplayTime) {
         this.failedMutationsCount = failedMutationsCount;
         this.logFileReplayFailureCount = logFileReplayFailureCount;
         this.logFileReplaySuccessCount = logFileReplaySuccessCount;

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/ReplicationLogProcessorMetricValues.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/ReplicationLogProcessorMetricValues.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.phoenix.replication.metrics;
 
 /** Class to hold the values of all metrics tracked by the ReplicationLogProcessor metric source. */

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/ReplicationLogProcessorMetricValues.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/ReplicationLogProcessorMetricValues.java
@@ -1,0 +1,39 @@
+package org.apache.phoenix.replication.metrics;
+
+/** Class to hold the values of all metrics tracked by the ReplicationLogProcessor metric source. */
+public class ReplicationLogProcessorMetricValues {
+
+    private final long failedMutationsCount;
+    private final long logFileReplayFailureCount;
+    private final long logFileReplaySuccessCount;
+    private final long logFileReplayTime;
+    private final long logFileBatchReplayTime;
+
+    public ReplicationLogProcessorMetricValues(long failedMutationsCount, long logFileReplayFailureCount, long logFileReplaySuccessCount, long logFileReplayTime, long logFileBatchReplayTime) {
+        this.failedMutationsCount = failedMutationsCount;
+        this.logFileReplayFailureCount = logFileReplayFailureCount;
+        this.logFileReplaySuccessCount = logFileReplaySuccessCount;
+        this.logFileReplayTime = logFileReplayTime;
+        this.logFileBatchReplayTime = logFileBatchReplayTime;
+    }
+
+    public long getFailedMutationsCount() {
+        return failedMutationsCount;
+    }
+
+    public long getLogFileReplayFailureCount() {
+        return logFileReplayFailureCount;
+    }
+
+    public long getLogFileReplaySuccessCount() {
+        return logFileReplaySuccessCount;
+    }
+
+    public long getLogFileReplayTime() {
+        return logFileReplayTime;
+    }
+
+    public long getLogFileBatchReplayTime() {
+        return logFileBatchReplayTime;
+    }
+}

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/ReplicationLogProcessorMetricValues.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/ReplicationLogProcessorMetricValues.java
@@ -26,8 +26,8 @@ public class ReplicationLogProcessorMetricValues {
     private final long logFileReplayTime;
     private final long logFileBatchReplayTime;
 
-    public ReplicationLogProcessorMetricValues(long failedMutationsCount, 
-            long logFileReplayFailureCount, long logFileReplaySuccessCount, 
+    public ReplicationLogProcessorMetricValues(long failedMutationsCount,
+            long logFileReplayFailureCount, long logFileReplaySuccessCount,
             long logFileReplayTime, long logFileBatchReplayTime) {
         this.failedMutationsCount = failedMutationsCount;
         this.logFileReplayFailureCount = logFileReplayFailureCount;

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.replication.reader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AsyncConnection;
+import org.apache.hadoop.hbase.client.AsyncTable;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.RetriesExhaustedException;
+import org.apache.hadoop.hbase.util.FutureUtils;
+import org.apache.phoenix.replication.log.LogFile;
+import org.apache.phoenix.replication.log.LogFileReader;
+import org.apache.phoenix.replication.log.LogFileReaderContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReplicationLogProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReplicationLogProcessor.class);
+
+    /**
+     * The maximum count of mutations to process in single batch while reading replication log file
+     */
+    public static final String REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE =
+            "phoenix.replication.log.standby.replay.batch.size";
+
+    /**
+     * The default batch size for reading the replication log file.
+     * Assuming each log record to be 10 KB (un-compressed) and allow at max 64 MB of
+     * in-memory records to be processed
+     */
+    public static final int DEFAULT_REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE = 6400;
+
+    /**
+     * The maximum number of retries for HBase client operations while applying the mutations
+     */
+    public static final String REPLICATION_STANDBY_HBASE_CLIENT_RETRIES_COUNT =
+            "phoenix.replication.standby.hbase.client.retries.number";
+
+    /**
+     * The default number of retries for HBase client operations while applying the mutations.
+     */
+    public static final int DEFAULT_REPLICATION_STANDBY_HBASE_CLIENT_RETRIES_COUNT = 4;
+
+    /**
+     * The timeout for HBase client operations while applying the mutations.
+     */
+    public static final String REPLICATION_STANDBY_HBASE_CLIENT_OPERATION_TIMEOUT_MS =
+            "phoenix.replication.standby.hbase.client.operations.timeout";
+
+    /**
+     * The default timeout for HBase client operations while applying the mutations.
+     */
+    public static final int DEFAULT_REPLICATION_STANDBY_HBASE_CLIENT_OPERATION_TIMEOUT_MS = 10000;
+
+    private final Configuration conf;
+
+    private final ExecutorService executorService;
+
+    /**
+     * This {@link AsyncConnection} is used for handling mutations
+     */
+    private volatile AsyncConnection asyncConnection;
+
+    private final Object asyncConnectionLock = new Object();
+
+    private final int batchSize;
+
+    /**
+     * Creates a new ReplicationLogProcessor with the given configuration and executor service.
+     * @param conf The configuration to use
+     * @param executorService The executor service for processing mutations
+     * @throws IOException if initialization fails
+     */
+    public ReplicationLogProcessor(final Configuration conf,
+            final ExecutorService executorService) {
+        // Create a copy of configuration as some of the properties would be
+        // overridden
+        this.conf = HBaseConfiguration.create(conf);
+        this.executorService = executorService;
+        this.batchSize = this.conf.getInt(REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE,
+                DEFAULT_REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE);
+        decorateConf();
+    }
+
+    /**
+     * Decorate the Configuration object to make replication more receptive to delays by
+     * reducing the timeout and number of retries.
+     */
+    private void decorateConf() {
+        this.conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER,
+                this.conf.getInt(REPLICATION_STANDBY_HBASE_CLIENT_RETRIES_COUNT,
+                        DEFAULT_REPLICATION_STANDBY_HBASE_CLIENT_RETRIES_COUNT));
+        this.conf.setInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT,
+                this.conf.getInt(REPLICATION_STANDBY_HBASE_CLIENT_OPERATION_TIMEOUT_MS,
+                        DEFAULT_REPLICATION_STANDBY_HBASE_CLIENT_OPERATION_TIMEOUT_MS));
+    }
+
+    public void processLogFile(FileSystem fs, Path filePath) throws IOException {
+
+        // Map from Table Name to List of Mutations
+        Map<String, List<Mutation>> tableToMutationsMap = new HashMap<>();
+
+        // Track the total number of processed records from input log file
+        long totalProcessed = 0;
+
+        // Track the current batch size as records will be processed in batch size of
+        // {@link REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE}
+        long currentBatchSize = 0;
+
+        LogFileReader logFileReader = null;
+
+        try {
+            // Create the LogFileReader for given path
+            logFileReader = createLogFileReader(fs, filePath);
+
+            for (LogFile.Record record : logFileReader) {
+
+                final String tableName = record.getHBaseTableName();
+                final Mutation mutation = record.getMutation();
+
+                tableToMutationsMap.computeIfAbsent(tableName, k -> new ArrayList<>())
+                        .add(mutation);
+                currentBatchSize++;
+
+                // Process when we reach the batch size and reset the batch size and
+                // table to mutations map
+                if (currentBatchSize >= getBatchSize()) {
+                    processReplicationLogBatch(tableToMutationsMap);
+                    totalProcessed += currentBatchSize;
+                    tableToMutationsMap.clear();
+                    currentBatchSize = 0;
+                }
+            }
+
+            // Process any remaining mutations
+            if (currentBatchSize > 0) {
+                processReplicationLogBatch(tableToMutationsMap);
+                totalProcessed += currentBatchSize;
+            }
+
+            LOG.info("Completed processing log file {}. Total mutations processed: {}",
+                    logFileReader.getContext().getFilePath(), totalProcessed);
+
+        } catch (Exception e) {
+            LOG.error("Error while processing replication log file", e);
+            throw new IOException("Failed to process log file " + filePath, e);
+        } finally {
+            closeReader(logFileReader);
+        }
+    }
+
+    protected LogFileReader createLogFileReader(FileSystem fs, Path filePath) throws IOException {
+        // Ensure that file exists. If we face exception while checking the path itself,
+        // method would throw same exception back to the caller
+        if (!fs.exists(filePath)) {
+            throw new IOException("Log file does not exist: " + filePath);
+        }
+        LogFileReader logFileReader = new LogFileReader();
+        try {
+            LogFileReaderContext logFileReaderContext = new LogFileReaderContext(conf)
+                    .setFileSystem(fs).setFilePath(filePath);
+            logFileReader.init(logFileReaderContext);
+        } catch (IOException exception) {
+            LOG.error("Failed to initialize new LogFileReader for path {}",
+                    filePath, exception);
+            throw exception;
+        }
+        return logFileReader;
+    }
+
+    /**
+     * Closes the given writer, logging any errors that occur during close.
+     */
+    protected  void closeReader(LogFileReader logFileReader) {
+        if (logFileReader == null) {
+            return;
+        }
+        try {
+            logFileReader.close();
+        } catch (IOException exception) {
+            LOG.error("Error while closing LogFileReader: {}",
+                    logFileReader, exception);
+        }
+    }
+
+    protected void processReplicationLogBatch(
+            Map<String, List<Mutation>> tableMutationMap) throws IOException {
+
+        if (tableMutationMap == null || tableMutationMap.isEmpty()) {
+            return;
+        }
+
+        List<Future<?>> futures = new ArrayList<>();
+        for (Map.Entry<String, List<Mutation>> entry : tableMutationMap.entrySet()) {
+            String tableName = entry.getKey();
+            List<Mutation> mutations = entry.getValue();
+            AsyncTable<?> table = getAsyncConnection()
+                    .getTable(TableName.valueOf(tableName), executorService);
+            futures.add(table.batchAll(mutations));
+        }
+
+        IOException error = null;
+
+        for (Future<?> future : futures) {
+            try {
+                FutureUtils.get(future);
+            } catch (RetriesExhaustedException e) {
+                IOException ioe = e;
+                if (error == null) {
+                    error = ioe;
+                } else {
+                    error.addSuppressed(ioe);
+                }
+            }
+        }
+
+        if (error != null) {
+            throw error;
+        }
+    }
+
+    public int getBatchSize() {
+        return this.batchSize;
+    }
+
+    public int getHBaseClientRetriesCount() {
+        return this.conf.getInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER,
+                DEFAULT_REPLICATION_STANDBY_HBASE_CLIENT_RETRIES_COUNT);
+    }
+
+    public int getHBaseClientOperationTimeout() {
+        return this.conf.getInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT,
+                DEFAULT_REPLICATION_STANDBY_HBASE_CLIENT_OPERATION_TIMEOUT_MS);
+    }
+
+    /**
+     * Return the {@link AsyncConnection} which is used for applying mutations.
+     * It ensures to create a new connection ONLY when it's not previously initialized
+     * or was closed
+     */
+    private AsyncConnection getAsyncConnection() throws IOException {
+        AsyncConnection asyncConnection = this.asyncConnection;
+        if (asyncConnection == null || asyncConnection.isClosed()) {
+            synchronized (asyncConnectionLock) {
+                asyncConnection = this.asyncConnection;
+                if (asyncConnection == null || asyncConnection.isClosed()) {
+                    /**
+                     * Get the AsyncConnection immediately.
+                     */
+                    asyncConnection = FutureUtils.get(
+                            ConnectionFactory.createAsyncConnection(conf));
+                    this.asyncConnection = asyncConnection;
+                }
+            }
+        }
+        return asyncConnection;
+    }
+}

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
@@ -504,8 +504,8 @@ public class ReplicationLogProcessor implements Closeable {
 
         public ApplyMutationBatchResult(Map<TableName, List<Mutation>> failedMutations,
                 Exception exception) {
-            this.failedMutations = failedMutations != null ?
-                failedMutations : Collections.emptyMap();
+            this.failedMutations = failedMutations != null
+                    ? failedMutations : Collections.emptyMap();
             this.exception = exception;
         }
 

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
@@ -67,7 +67,8 @@ public class ReplicationLogProcessor implements Closeable {
     public static final int DEFAULT_REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE = 6400;
 
     /**
-     * The maximum total size of mutations to process in single batch while reading replication log file
+     * The maximum total size of mutations to process in single batch while reading
+     * replication log file
      */
     public static final String REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE_BYTES =
             "phoenix.replication.log.standby.replay.batch.size.bytes";
@@ -75,7 +76,8 @@ public class ReplicationLogProcessor implements Closeable {
     /**
      * The default batch size in bytes for reading the replication log file (64 MB)
      */
-    public static final long DEFAULT_REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE_BYTES = 64 * 1024 * 1024L;
+    public static final long DEFAULT_REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE_BYTES =
+            64 * 1024 * 1024L;
 
     /**
      * The number of threads to apply mutations via async hbase client
@@ -245,7 +247,8 @@ public class ReplicationLogProcessor implements Closeable {
                 currentBatchSizeBytes += mutation.heapSize();
 
                 // Process when we reach either the batch count or size limit
-                if (currentBatchSize >= getBatchSize() || currentBatchSizeBytes >= getBatchSizeBytes()) {
+                if (currentBatchSize >= getBatchSize() ||
+                    currentBatchSizeBytes >= getBatchSizeBytes()) {
                     processReplicationLogBatch(tableToMutationsMap);
                     totalProcessed += currentBatchSize;
                     tableToMutationsMap.clear();

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
@@ -247,8 +247,8 @@ public class ReplicationLogProcessor implements Closeable {
                 currentBatchSizeBytes += mutation.heapSize();
 
                 // Process when we reach either the batch count or size limit
-                if (currentBatchSize >= getBatchSize() ||
-                    currentBatchSizeBytes >= getBatchSizeBytes()) {
+                if (currentBatchSize >= getBatchSize()
+                        || currentBatchSizeBytes >= getBatchSizeBytes()) {
                     processReplicationLogBatch(tableToMutationsMap);
                     totalProcessed += currentBatchSize;
                     tableToMutationsMap.clear();

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
@@ -121,7 +121,7 @@ public class ReplicationLogProcessor implements Closeable {
      */
     public static final long DEFAULT_REPLICATION_STANDBY_BATCH_RETRY_MAX_DELAY_MS = 10000;
 
-    private final String haGroupId;
+    private final String haGroupName;
 
     private final Configuration conf;
 
@@ -148,24 +148,24 @@ public class ReplicationLogProcessor implements Closeable {
      * Get or create a ReplicationLogProcessor instance for the given HA Group.
      *
      * @param conf Configuration object
-     * @param haGroupId The HA Group identifier
+     * @param haGroupName The HA Group name
      * @return ReplicationLogProcessor instance
      */
-    public static ReplicationLogProcessor get(Configuration conf, String haGroupId) {
-        return INSTANCES.computeIfAbsent(haGroupId, 
-            k -> new ReplicationLogProcessor(conf, haGroupId));
+    public static ReplicationLogProcessor get(Configuration conf, String haGroupName) {
+        return INSTANCES.computeIfAbsent(haGroupName,
+            k -> new ReplicationLogProcessor(conf, haGroupName));
     }
 
     /**
      * Creates a new ReplicationLogProcessor with the given configuration and executor service.
      * @param conf The configuration to use
-     * @param haGroupId The HA group id
+     * @param haGroupName The HA group id
      */
-    protected ReplicationLogProcessor(final Configuration conf, final String haGroupId) {
+    protected ReplicationLogProcessor(final Configuration conf, final String haGroupName) {
         // Create a copy of configuration as some of the properties would be
         // overridden
         this.conf = HBaseConfiguration.create(conf);
-        this.haGroupId = haGroupId;
+        this.haGroupName = haGroupName;
         this.batchSize = this.conf.getInt(REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE,
                 DEFAULT_REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE);
         this.batchRetryCount = this.conf.getInt(REPLICATION_STANDBY_BATCH_RETRY_COUNT,
@@ -178,7 +178,7 @@ public class ReplicationLogProcessor implements Closeable {
         this.metrics = createMetricsSource();
         this.executorService = Executors.newFixedThreadPool(threadPoolSize, 
             new ThreadFactoryBuilder()
-                .setNameFormat("Phoenix-Replication-Log-Processor-" + haGroupId + "-%d")
+                .setNameFormat("Phoenix-Replication-Log-Processor-" + haGroupName + "-%d")
                 .build());
     }
 
@@ -451,13 +451,13 @@ public class ReplicationLogProcessor implements Closeable {
                 executorService.shutdownNow();
             }
             // Remove the instance from cache
-            INSTANCES.remove(haGroupId);
+            INSTANCES.remove(haGroupName);
         }
     }
 
     /** Creates a new metrics source for monitoring operations. */
     protected MetricsReplicationLogProcessor createMetricsSource() {
-        return new MetricsReplicationLogProcessorImpl(haGroupId);
+        return new MetricsReplicationLogProcessorImpl(haGroupName);
     }
 
     /** Returns the metrics source for monitoring replication log operations. */
@@ -487,8 +487,8 @@ public class ReplicationLogProcessor implements Closeable {
         return this.maxRetryDelayMs;
     }
 
-    public String getHaGroupId() {
-        return this.haGroupId;
+    public String getHaGroupName() {
+        return this.haGroupName;
     }
 
     protected ExecutorService getExecutorService() {

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
@@ -176,7 +176,7 @@ public class ReplicationLogProcessor implements Closeable {
                 DEFAULT_REPLICATION_STANDBY_LOG_REPLAY_THREAD_POOL_SIZE);
         decorateConf();
         this.metrics = createMetricsSource();
-        this.executorService = Executors.newFixedThreadPool(threadPoolSize, 
+        this.executorService = Executors.newFixedThreadPool(threadPoolSize,
             new ThreadFactoryBuilder()
                 .setNameFormat("Phoenix-Replication-Log-Processor-" + haGroupName + "-%d")
                 .build());
@@ -256,7 +256,7 @@ public class ReplicationLogProcessor implements Closeable {
 
     /**
      * Creates a LogFileReader for the specified file path.
-     * Validates that the file exists and initializes the reader with the given 
+     * Validates that the file exists and initializes the reader with the given
      * file system and path.
      * @param fs The file system to use for reading
      * @param filePath The path to the log file
@@ -502,9 +502,9 @@ public class ReplicationLogProcessor implements Closeable {
         private final Map<TableName, List<Mutation>> failedMutations;
         private final Exception exception;
 
-        public ApplyMutationBatchResult(Map<TableName, List<Mutation>> failedMutations, 
+        public ApplyMutationBatchResult(Map<TableName, List<Mutation>> failedMutations,
                 Exception exception) {
-            this.failedMutations = failedMutations != null ? 
+            this.failedMutations = failedMutations != null ?
                 failedMutations : Collections.emptyMap();
             this.exception = exception;
         }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
@@ -140,7 +140,7 @@ public class ReplicationLogProcessor implements Closeable {
 
     private final MetricsReplicationLogProcessor metrics;
 
-    /** Cache of ReplicationLogGroup instances by HA Group ID */
+    /** Cache of ReplicationLogGroup instances by HA Group Name */
     private static final ConcurrentHashMap<String, ReplicationLogProcessor> INSTANCES =
             new ConcurrentHashMap<>();
 
@@ -159,7 +159,7 @@ public class ReplicationLogProcessor implements Closeable {
     /**
      * Creates a new ReplicationLogProcessor with the given configuration and executor service.
      * @param conf The configuration to use
-     * @param haGroupName The HA group id
+     * @param haGroupName The HA group name
      */
     protected ReplicationLogProcessor(final Configuration conf, final String haGroupName) {
         // Create a copy of configuration as some of the properties would be

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogProcessor.java
@@ -316,12 +316,12 @@ public class ReplicationLogProcessor implements Closeable {
             try {
                 // Apply mutations and get any failed operations
                 ApplyMutationBatchResult result = applyMutations(currentOperations);
-                
+
                 // If no failures, we're done
                 if (!result.hasFailures()) {
                     return;
                 }
-                
+
                 // Update current operations for next retry
                 currentOperations = result.getFailedMutations();
                 lastError = new IOException("Failed to apply the mutations", result.getException());
@@ -347,7 +347,7 @@ public class ReplicationLogProcessor implements Closeable {
 
         // If we still have failed operations after all retries, throw the last error
         if (!currentOperations.isEmpty() && lastError != null) {
-            LOG.error("Failed to process batch operations after {} retries. Failed tables: {}", 
+            LOG.error("Failed to process batch operations after {} retries. Failed tables: {}",
                     batchRetryCount, currentOperations.keySet());
             throw lastError;
         }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/package-info.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains classes and utilities for reading replication log files
+ * and applying mutations on target cluster
+ */
+package org.apache.phoenix.replication.reader;

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/reader/ReplicationLogProcessorTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/reader/ReplicationLogProcessorTest.java
@@ -584,7 +584,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
             writer.append(tableName, i, put);
         }
 
-        // Add 1 big mutation that will cross the byte size threshold before count threashold
+        // Add 1 big mutation that will cross the byte size threshold before count threshold
         Put bigPut = new Put(Bytes.toBytes("bigRow"));
         bigPut.addColumn(Bytes.toBytes("cf"), Bytes.toBytes("qual"),
             Bytes.toBytes("This is a very large mutation that will exceed the size limit. " +

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/reader/ReplicationLogProcessorTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/reader/ReplicationLogProcessorTest.java
@@ -1,0 +1,696 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.replication.reader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellBuilderFactory;
+import org.apache.hadoop.hbase.CellBuilderType;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Pair;
+import org.apache.phoenix.end2end.ParallelStatsDisabledIT;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.replication.log.LogFileReader;
+import org.apache.phoenix.replication.log.LogFileReaderContext;
+import org.apache.phoenix.replication.log.LogFileTestUtil;
+import org.apache.phoenix.replication.log.LogFileWriter;
+import org.apache.phoenix.replication.log.LogFileWriterContext;
+import org.apache.phoenix.util.PropertiesUtil;
+import org.apache.phoenix.util.QueryUtil;
+import org.apache.phoenix.util.StringUtil;
+import org.apache.phoenix.util.TestUtil;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReplicationLogProcessorTest.class);
+
+    private static final String CREATE_TABLE_SQL_STATEMENT = "CREATE TABLE %s (ID VARCHAR PRIMARY KEY, " +
+            "COL_1 VARCHAR, COL_2 VARCHAR, COL_3 BIGINT)";
+
+    private static final String UPSERT_SQL_STATEMENT = "upsert into %s values ('%s', '%s', '%s', %s)";
+
+    private static final String PRINCIPAL = "replicationLogProcessor";
+
+    @ClassRule
+    public static TemporaryFolder testFolder = new TemporaryFolder();
+
+    private static Configuration conf;
+    private static FileSystem localFs;
+    private static ExecutorService executorService;
+
+    @BeforeClass
+    public static void setupBeforeClass() throws Exception {
+        conf = getUtility().getConfiguration();
+        localFs = FileSystem.getLocal(conf);
+        executorService = Executors.newSingleThreadExecutor();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        if(executorService != null) {
+            executorService.shutdown();
+        }
+    }
+
+    /**
+     * Tests successful creation of LogFileReader with a properly formatted log file.
+     */
+    @Test
+    public void testCreateLogFileReaderWithValidLogFile() throws IOException {
+        // Test with valid log file
+        Path validFilePath = new Path(testFolder.newFile("valid_log_file").toURI());
+        String tableName = "T_" + generateUniqueName();
+
+        // Create a valid log file with proper structure and one record
+        LogFileWriter writer = initLogFileWriter(validFilePath);
+
+        // Add a mutation to make it a proper log file with data
+        Mutation put = LogFileTestUtil.newPut("testRow", 1, 1);
+        writer.append(tableName, 1, put);
+        writer.sync();
+        writer.close();
+
+        // Verify file exists and has content
+        assertTrue("Valid log file should exist", localFs.exists(validFilePath));
+        assertTrue("Valid log file should have content", localFs.getFileStatus(validFilePath).getLen() > 0);
+
+        // Test createLogFileReader with valid file - should succeed
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+        LogFileReader reader = replicationLogProcessor.createLogFileReader(localFs, validFilePath);
+
+        // Verify reader is created successfully
+        assertNotNull("Reader should not be null for valid file", reader);
+        assertNotNull("Reader context should not be null", reader.getContext());
+        assertEquals("File path should match", validFilePath, reader.getContext().getFilePath());
+        assertEquals("File system should match", localFs, reader.getContext().getFileSystem());
+
+        // Verify we can read from the reader
+        assertTrue("Reader should have records", reader.iterator().hasNext());
+
+        // Clean up
+        reader.close();
+    }
+
+    /**
+     * Tests error handling when attempting to create LogFileReader with a non-existent file.
+     */
+    @Test
+    public void testCreateLogFileReaderWithNonExistentFile() {
+        Path nonExistentPath = new Path(testFolder.toString(), "non_existent_file");
+        try {
+            ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+            replicationLogProcessor.createLogFileReader(localFs, nonExistentPath);
+            fail("Should throw IOException for non-existent file");
+        } catch (IOException e) {
+            assertTrue("Error message should mention file does not exist and file path name",
+                    e.getMessage().contains("Log file does not exist: " + nonExistentPath));
+        }
+    }
+
+    /**
+     * Tests error handling when attempting to create LogFileReader with an invalid/corrupted file.
+     */
+    @Test
+    public void testCreateLogFileReaderWithInvalidLogFile() throws IOException {
+        Path invalidFilePath = new Path(testFolder.newFile("invalid_file").toURI());
+        localFs.create(invalidFilePath).close(); // Create empty file
+        try {
+            ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+            replicationLogProcessor.createLogFileReader(localFs, invalidFilePath);
+            fail("Should throw IOException for invalid file");
+        } catch (IOException e) {
+            // Should throw some kind of IOException when trying to read header
+            assertTrue("Should throw IOException", true);
+        } finally {
+            // Delete the invalid file
+            localFs.delete(invalidFilePath);
+        }
+    }
+
+    /**
+     * Tests the closeReader method with both null and valid LogFileReader instances.
+     */
+    @Test
+    public void testCloseReader() throws IOException {
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+        replicationLogProcessor.closeReader(null);
+        Path filePath = new Path(testFolder.newFile("testCloseReader").toURI());
+        String tableName = "T_" + generateUniqueName();
+
+        // Create a valid log file with proper structure and one record
+        LogFileWriter writer = initLogFileWriter(filePath);
+
+        // Add a mutation to make it a proper log file with data
+        Mutation put = LogFileTestUtil.newPut("testRow", 1, 1);
+        writer.append(tableName, 1, put);
+        writer.sync();
+        writer.close();
+
+        // Test with valid reader
+        LogFileReader reader = Mockito.spy(new LogFileReader());
+
+        reader.init(new LogFileReaderContext(conf)
+                .setFileSystem(localFs)
+                .setFilePath(filePath));
+
+        replicationLogProcessor.closeReader(reader);
+
+        // Ensure reader's close method is called only once
+        Mockito.verify(reader, Mockito.times(1)).close();
+    }
+
+    /**
+     * Tests processing an empty mutation map - should complete without errors.
+     */
+    @Test
+    public void testProcessReplicationLogBatchWithEmptyMap() {
+        Map<String, List<Mutation>> emptyMap = new HashMap<>();
+
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+        // Process empty batch - should not throw any exceptions and should return immediately
+        try {
+            replicationLogProcessor.processReplicationLogBatch(emptyMap);
+            // If we reach here, the empty map was processed successfully
+            assertTrue("Processing empty map should complete without errors", true);
+        } catch (Exception e) {
+            fail("Processing empty map should not throw exception: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Tests exception handling when attempting to process mutations for non-existent tables.
+     */
+    @Test
+    public void testProcessReplicationLogBatchExceptionsMessageIsCorrect() {
+        Map<String, List<Mutation>> tableMutationsMap = new HashMap<>();
+        Mutation mutation = LogFileTestUtil.newPut("abc", 6L, 5);
+        tableMutationsMap.put("NON_EXISTENT_TABLE", Collections.singletonList(mutation));
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+        try {
+            replicationLogProcessor.processReplicationLogBatch(tableMutationsMap);
+            fail("Should throw TableNotFoundException for non-existent table");
+        } catch (IOException exception) {
+            assertTrue("Error message should mention file does not exist and file path name",
+                    exception.getMessage().contains("TableNotFoundException"));
+        }
+    }
+
+    /**
+     * Tests behavior when HBase operations fail (simulated by disabling table).
+     */
+    @Test
+    public void testProcessReplicationLogBatchWithHBaseFailure() throws Exception {
+        final String tableName = "T_" + generateUniqueName();
+        Map<String, List<Mutation>> tableMutationsMap = new HashMap<>();
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            // Create table first
+            conn.createStatement().execute(String.format(CREATE_TABLE_SQL_STATEMENT, tableName));
+            PhoenixConnection phoenixConnection = conn.unwrap(PhoenixConnection.class);
+            // Generate some mutations for the table
+            List<Mutation> mutations = generateHBaseMutations(phoenixConnection, 2, tableName, 10L);
+            tableMutationsMap.put(tableName, mutations);
+            TableName hbaseTableName = TableName.valueOf(tableName);
+            try (Admin admin = phoenixConnection.getQueryServices().getAdmin()) {
+                // Disable the table to simulate HBase failure
+                admin.disableTable(hbaseTableName);
+                LOG.info("Disabled table {} to simulate HBase failure", tableName);
+
+                ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+                // Attempt to process mutations on disabled table - should fail
+                try {
+                    replicationLogProcessor.processReplicationLogBatch(tableMutationsMap);
+                    fail("Should throw IOException when trying to apply mutations to disabled table");
+                } catch (IOException e) {
+                    // Expected behavior - disabled table should cause IOException
+                    assertTrue("Should throw IOException for disabled table", true);
+                    LOG.info("Expected IOException caught when processing mutations on disabled table: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests end-to-end processing of a valid log file with mutations for multiple tables.
+     */
+    @Test
+    public void testProcessLogFileForValidLogFile() throws Exception {
+        final String table1Name = "T_" + generateUniqueName();
+        final String table2Name = "T_" + generateUniqueName();
+        final Path filePath = new Path(testFolder.newFile("testProcessLogFileEnd2End").toURI());
+        LogFileWriter writer = initLogFileWriter(filePath);
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            conn.createStatement().execute(String.format(CREATE_TABLE_SQL_STATEMENT, table1Name));
+            conn.createStatement().execute(String.format(CREATE_TABLE_SQL_STATEMENT, table2Name));
+            PhoenixConnection phoenixConnection = conn.unwrap(PhoenixConnection.class);
+
+            List<Mutation> table1Mutations = generateHBaseMutations(phoenixConnection, 2, table1Name, 100L);
+            List<Mutation> table2Mutations = generateHBaseMutations(phoenixConnection, 5, table2Name, 101L);
+            table1Mutations.forEach(mutation -> {
+                try {
+                    writer.append(table1Name, mutation.hashCode(), mutation);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            table2Mutations.forEach(mutation -> {
+                try {
+                    writer.append(table2Name, mutation.hashCode(), mutation);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.sync();
+            writer.close();
+
+            ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+            replicationLogProcessor.processLogFile(localFs, filePath);
+
+            validate(table1Name, table1Mutations);
+            validate(table2Name, table2Mutations);
+        }
+    }
+
+    /**
+     * Tests error handling when attempting to process a non-existent log file.
+     */
+    @Test
+    public void testProcessLogFileWithNonExistentFile() throws Exception {
+        // Create a path to a file that doesn't exist
+        Path nonExistentFilePath = new Path(testFolder.getRoot().getAbsolutePath(), "non_existent_log_file.log");
+        // Verify the file doesn't exist
+        assertFalse("Non-existent file should not exist", localFs.exists(nonExistentFilePath));
+
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+        // Attempt to process non-existent file - should throw IOException
+        try {
+            replicationLogProcessor.processLogFile(localFs, nonExistentFilePath);
+            fail("Should throw IOException for non-existent file");
+        } catch (IOException e) {
+            // Expected behavior - non-existent file should cause IOException
+            assertTrue("Should throw IOException for non-existent file", true);
+        }
+    }
+
+    /**
+     * Tests batching logic when processing log files with mutations for multiple tables.
+     */
+    @Test
+    public void testProcessLogFileBatchingWithMultipleTables() throws Exception {
+        final Path multiTableBatchFilePath = new Path(testFolder.newFile("testMultiTableBatch").toURI());
+        final String table1Name = "T1_" + generateUniqueName();
+        final String table2Name = "T2_" + generateUniqueName();
+        final int batchSize = 4;
+        final int recordsPerTable = 3;
+        final int totalRecords = recordsPerTable * 2; // 6 total records
+        final int expectedBatchCalls = (totalRecords + batchSize - 1) / batchSize; // 2 calls
+        // Create log file with mutations for multiple tables
+        LogFileWriter writer = initLogFileWriter(multiTableBatchFilePath);
+        // Add mutations alternating between tables using LogFileTestUtil
+        for (int i = 0; i < recordsPerTable; i++) {
+            // Add mutation for table1
+            Mutation put1 = LogFileTestUtil.newPut("row1_" + i, (i * 2) + 1, (i * 2) + 1);
+            writer.append(table1Name, (i * 2) + 1, put1);
+            writer.sync();
+            // Add mutation for table2
+            Mutation put2 = LogFileTestUtil.newPut("row2_" + i, (i * 2) + 2, (i * 2) + 2);
+            writer.append(table2Name, (i * 2) + 2, put2);
+            writer.sync();
+        }
+        writer.close();
+        // Create processor with custom batch size and spy on it
+        Configuration testConf = new Configuration(conf);
+        testConf.setInt(ReplicationLogProcessor.REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE, batchSize);
+
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(testConf, executorService);
+        // Validate that the batch size is correctly set
+        assertEquals("Batch size should be set correctly", batchSize, replicationLogProcessor.getBatchSize());
+        ReplicationLogProcessor spyProcessor = Mockito.spy(replicationLogProcessor);
+        // Mock the processReplicationLogBatch method
+        Mockito.doNothing().when(spyProcessor).processReplicationLogBatch(Mockito.any(Map.class));
+        // Process the log file
+        spyProcessor.processLogFile(localFs, multiTableBatchFilePath);
+        // Verify processReplicationLogBatch was called the expected number of times
+        Mockito.verify(spyProcessor, Mockito.times(expectedBatchCalls))
+            .processReplicationLogBatch(Mockito.any(Map.class));
+    }
+
+    /**
+     * Tests processing of empty log files (files with header/trailer but no mutation records).
+     */
+    @Test
+    public void testProcessLogFileWithEmptyFile() throws Exception {
+        final Path emptyFilePath = new Path(testFolder.newFile("testProcessLogFileEmpty").toURI());
+        LogFileWriter writer = initLogFileWriter(emptyFilePath);
+
+        // Close the writer without adding any records - this creates a valid empty log file
+        writer.close();
+
+        // Verify file exists and has some content (header + trailer)
+        assertTrue("Empty log file should exist", localFs.exists(emptyFilePath));
+        assertTrue("Empty log file should have header/trailer content", localFs.getFileStatus(emptyFilePath).getLen() > 0);
+
+        // Process the empty log file - should not throw any exceptions
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, executorService);
+        try {
+            replicationLogProcessor.processLogFile(localFs, emptyFilePath);
+            // If we reach here, the empty file was processed successfully
+            assertTrue("Processing empty log file should complete without errors", true);
+        } catch (Exception e) {
+            fail("Processing empty log file should not throw exception: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Tests that configuration parameters are properly read and applied.
+     */
+    @Test
+    public void testReplicationLogProcessorConfiguration() {
+        // Test that all default configurations are used when no custom configuration is provided
+        ReplicationLogProcessor defaultProcessor = new ReplicationLogProcessor(conf, executorService);
+
+        // Validate default batch size
+        assertEquals("Default batch size should be used",
+                ReplicationLogProcessor.DEFAULT_REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE,
+                defaultProcessor.getBatchSize());
+
+        // Validate default HBase client retries count
+        assertEquals("Default HBase client retries count should be used",
+                ReplicationLogProcessor.DEFAULT_REPLICATION_STANDBY_HBASE_CLIENT_RETRIES_COUNT,
+                defaultProcessor.getHBaseClientRetriesCount());
+
+        // Validate default HBase client operation timeout
+        assertEquals("Default HBase client operation timeout should be used",
+                ReplicationLogProcessor.DEFAULT_REPLICATION_STANDBY_HBASE_CLIENT_OPERATION_TIMEOUT_MS,
+                defaultProcessor.getHBaseClientOperationTimeout());
+
+        // Test that all custom configurations are honored
+        Configuration customConf = new Configuration(conf);
+
+        // Set custom values for all configuration parameters
+        int customBatchSize = 1000;
+        int customRetriesCount = 6;
+        int customOperationTimeout = 15000;
+
+        customConf.setInt(ReplicationLogProcessor.REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE, customBatchSize);
+        customConf.setInt(ReplicationLogProcessor.REPLICATION_STANDBY_HBASE_CLIENT_RETRIES_COUNT, customRetriesCount);
+        customConf.setInt(ReplicationLogProcessor.REPLICATION_STANDBY_HBASE_CLIENT_OPERATION_TIMEOUT_MS, customOperationTimeout);
+
+        ReplicationLogProcessor customProcessor = new ReplicationLogProcessor(customConf, executorService);
+
+        // Validate all custom configurations are honored
+        assertEquals("Custom batch size should be honored",
+                customBatchSize, customProcessor.getBatchSize());
+
+        assertEquals("Custom HBase client retries count should be honored",
+                customRetriesCount, customProcessor.getHBaseClientRetriesCount());
+
+        assertEquals("Custom HBase client operation timeout should be honored",
+                customOperationTimeout, customProcessor.getHBaseClientOperationTimeout());
+    }
+
+    /**
+     * Tests batching logic with various record counts and batch sizes.
+     */
+    @Test
+    public void testProcessLogFileBatchingLogic() throws Exception {
+        // Test multiple batching scenarios to ensure the logic works correctly
+
+        // Test case 1: General case where total records don't align perfectly with batch size
+        testProcessLogFileBatching(10, 3);
+
+        // Test case 2: Edge case where total records exactly matches batch size
+        testProcessLogFileBatching(5, 5);
+
+        // Test case 3: Single record with large batch size
+        testProcessLogFileBatching(1, 10);
+
+        // Test case 4: Multiple full batches
+        testProcessLogFileBatching(12, 4);
+    }
+
+    /**
+     * Helper method to test batching scenarios with different record counts and batch sizes
+     */
+    private void testProcessLogFileBatching(int totalRecords, int batchSize) throws Exception {
+        final Path batchTestFilePath = new Path(testFolder.newFile("test_" + new Random(1000)).toURI());
+        final String tableName = "T_" + generateUniqueName();
+        final int expectedBatchCalls = (totalRecords + batchSize - 1) / batchSize; // Ceiling division
+
+        // Create log file with specific number of records
+        LogFileWriter writer = initLogFileWriter(batchTestFilePath);
+
+        // Add exactly totalRecords mutations to the log file using LogFileTestUtil
+        for (int i = 0; i < totalRecords; i++) {
+            Mutation put = LogFileTestUtil.newPut("row" + i, i + 1, i + 1);
+            writer.append(tableName, i + 1, put);
+            writer.sync();
+        }
+        writer.close();
+
+        // Create a configuration with custom batch size
+        Configuration testConf = new Configuration(conf);
+        testConf.setInt(ReplicationLogProcessor.REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE, batchSize);
+
+        // Create processor with custom batch size and spy on it
+        ReplicationLogProcessor testProcessor = new ReplicationLogProcessor(testConf, executorService);
+
+        // Validate that the batch size is correctly set
+        assertEquals("Batch size incorrectly set", batchSize, testProcessor.getBatchSize());
+
+        ReplicationLogProcessor spyProcessor = Mockito.spy(testProcessor);
+
+        // Mock the processReplicationLogBatch method to do nothing but track calls
+        Mockito.doNothing().when(spyProcessor).processReplicationLogBatch(Mockito.any(Map.class));
+
+        // Process the log file
+        spyProcessor.processLogFile(localFs, batchTestFilePath);
+
+        // Verify processReplicationLogBatch was called the expected number of times
+        Mockito.verify(spyProcessor, Mockito.times(expectedBatchCalls))
+                .processReplicationLogBatch(Mockito.any(Map.class));
+    }
+
+    private LogFileWriter initLogFileWriter(Path filePath) throws IOException {
+        LogFileWriter writer = new LogFileWriter();
+        LogFileWriterContext writerContext = new LogFileWriterContext(conf).setFileSystem(localFs)
+                .setFilePath(filePath);
+        writer.init(writerContext);
+        return writer;
+    }
+
+    private Connection getConnection() throws Exception {
+        return getConnection(PropertiesUtil.deepCopy(TestUtil.TEST_PROPERTIES));
+    }
+
+    private List<Mutation> generateHBaseMutations(final PhoenixConnection phoenixConnection, final int rows, final String tableName, final long timestamp) throws Exception {
+        List<Mutation> mutations = new ArrayList<>();
+        int randomNumber = new Random().nextInt(1000000);
+        for(int i = 0; i<rows; i++) {
+            final String dml = String.format(UPSERT_SQL_STATEMENT, tableName, "a"+randomNumber+i, "b"+randomNumber+i, "c"+randomNumber+i, i+1);
+            phoenixConnection.createStatement().execute(dml);
+            Iterator<Pair<byte[], List<Mutation>>> iterator = phoenixConnection.getMutationState().toMutations();
+            while (iterator.hasNext()) {
+                Pair<byte[], List<Mutation>> mutationPair = iterator.next();
+                mutationPair.getSecond().forEach(mutation -> mutation.setTimestamp(timestamp));
+                mutations.addAll(mutationPair.getSecond());
+            }
+        }
+        return mutations;
+    }
+
+    private Connection getConnection(Properties props) throws Exception {
+        props.setProperty(QueryServices.DROP_METADATA_ATTRIB, Boolean.toString(true));
+        // Force real driver to be used as the test one doesn't handle creating
+        // more than one ConnectionQueryService
+        props.setProperty(QueryServices.EXTRA_JDBC_ARGUMENTS_ATTRIB, StringUtil.EMPTY_STRING);
+        // Create new ConnectionQueryServices so that we can set DROP_METADATA_ATTRIB
+        String url = QueryUtil.getConnectionUrl(props, config, PRINCIPAL);
+        return DriverManager.getConnection(url, props);
+    }
+
+    /**
+     * Validates that the given mutations have been correctly applied to the specified table
+     * by creating a temporary table, applying the mutations, and comparing the results.
+     */
+    private void validate(String tableName, List<Mutation> mutations) throws IOException {
+        // Create a temporary table with the same schema
+        String tempTableName = tableName + "_temp";
+        try (Connection conn = getConnection()) {
+            // Get the table descriptor of the original table
+            Table originalTable = conn.unwrap(PhoenixConnection.class).getQueryServices().getTable(Bytes.toBytes(tableName));
+            TableDescriptor originalDesc = originalTable.getDescriptor();
+
+            // Create temporary table with same schema
+            Admin admin = conn.unwrap(PhoenixConnection.class).getQueryServices().getAdmin();
+            TableDescriptorBuilder builder = TableDescriptorBuilder.newBuilder(TableName.valueOf(tempTableName));
+            for (ColumnFamilyDescriptor cf : originalDesc.getColumnFamilies()) {
+                builder.setColumnFamily(cf);
+            }
+            admin.createTable(builder.build());
+
+            // Apply mutations to temporary table
+            Table tempTable = conn.unwrap(PhoenixConnection.class).getQueryServices().getTable(Bytes.toBytes(tempTableName));
+
+            // Create new mutations with cell timestamps set to mutation timestamp
+            List<Mutation> newMutations = new ArrayList<>();
+            for (Mutation mutation : mutations) {
+                if (mutation instanceof Put) {
+                    Put put = (Put) mutation;
+                    Put newPut = new Put(put.getRow());
+                    newPut.setTimestamp(put.getTimestamp());
+                    // Copy cells with mutation timestamp
+                    for (Cell cell : put.getFamilyCellMap().values().stream().flatMap(List::stream).collect(Collectors.toList())) {
+                        newPut.add(cloneCellWithCustomTimestamp(cell, mutation.getTimestamp()));
+                    }
+                    newMutations.add(newPut);
+                } else if (mutation instanceof Delete) {
+                    Delete delete = (Delete) mutation;
+                    Delete newDelete = new Delete(delete.getRow());
+                    newDelete.setTimestamp(delete.getTimestamp());
+                    // Copy cells with mutation timestamp
+                    for (Cell cell : delete.getFamilyCellMap().values().stream().flatMap(List::stream).collect(Collectors.toList())) {
+                        newDelete.add(cloneCellWithCustomTimestamp(cell, mutation.getTimestamp()));
+                    }
+                    newMutations.add(newDelete);
+                }
+            }
+
+            // Apply all mutations in a batch
+            tempTable.batch(newMutations, null);
+
+            // Compare data between original and temporary tables
+            Scan scan = new Scan();
+            scan.setRaw(true); // Enable raw scan to see delete markers
+
+            ResultScanner originalScanner = originalTable.getScanner(scan);
+            ResultScanner tempScanner = tempTable.getScanner(scan);
+
+            Map<String, Result> originalResults = new HashMap<>();
+            Map<String, Result> tempResults = new HashMap<>();
+
+            // Collect results from original table
+            for (Result result : originalScanner) {
+                String rowKey = Bytes.toString(result.getRow());
+                originalResults.put(rowKey, result);
+            }
+
+            // Collect results from temporary table
+            for (Result result : tempScanner) {
+                String rowKey = Bytes.toString(result.getRow());
+                tempResults.put(rowKey, result);
+            }
+
+            // Compare results
+            assertEquals("Number of rows should match", originalResults.size(), tempResults.size());
+
+            for (Map.Entry<String, Result> entry : originalResults.entrySet()) {
+                String rowKey = entry.getKey();
+                Result originalResult = entry.getValue();
+                Result tempResult = tempResults.get(rowKey);
+
+                assertNotNull("Row " + rowKey + " should exist in temporary table", tempResult);
+
+                // Compare cells using sets approach for better performance
+                Cell[] originalCells = originalResult.rawCells();
+                Cell[] tempCells = tempResult.rawCells();
+
+                assertEquals("Number of cells should match for row " + rowKey,
+                        originalCells.length, tempCells.length);
+
+                // Use sets comparison approach - convert cells to comparable format
+                java.util.Set<String> originalCellSet = new java.util.HashSet<>();
+                java.util.Set<String> tempCellSet = new java.util.HashSet<>();
+
+                // Create string representations of cells for set comparison
+                for (Cell cell : originalCells) {
+                    originalCellSet.add(CellUtil.toString(cell, false));
+                }
+
+                for (Cell cell : tempCells) {
+                    tempCellSet.add(CellUtil.toString(cell, false));
+                }
+
+                // Compare sets directly
+                assertEquals("Cell sets do not match for row " + rowKey, originalCellSet, tempCellSet);
+            }
+
+            // Cleanup
+            originalScanner.close();
+            tempScanner.close();
+            originalTable.close();
+            tempTable.close();
+            admin.disableTable(TableName.valueOf(tempTableName));
+            admin.deleteTable(TableName.valueOf(tempTableName));
+        } catch (Exception e) {
+            throw new IOException("Failed to validate mutations: " + e.getMessage(), e);
+        }
+    }
+
+    private Cell cloneCellWithCustomTimestamp(Cell cell, long timestamp) {
+        return CellBuilderFactory.create(CellBuilderType.DEEP_COPY)
+                .setRow(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength())
+                .setFamily(cell.getFamilyArray(), cell.getFamilyOffset(), cell.getFamilyLength())
+                .setQualifier(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength())
+                .setTimestamp(timestamp) // Use mutation timestamp for all cells
+                .setType(cell.getType())
+                .setValue(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength())
+                .build();
+    }
+}

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/reader/ReplicationLogProcessorTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/reader/ReplicationLogProcessorTest.java
@@ -94,7 +94,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
 
     private static final String PRINCIPAL = "replicationLogProcessor";
 
-    private final String testHAGroupId = "testHAGroupId";
+    private final String testHAGroupName = "testHAGroupName";
 
     @ClassRule
     public static TemporaryFolder testFolder = new TemporaryFolder();
@@ -131,7 +131,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         assertTrue("Valid log file should have content", localFs.getFileStatus(validFilePath).getLen() > 0);
 
         // Test createLogFileReader with valid file - should succeed
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         LogFileReader reader = replicationLogProcessor.createLogFileReader(localFs, validFilePath);
 
         // Verify reader is created successfully
@@ -154,7 +154,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
     @Test
     public void testCreateLogFileReaderWithNonExistentFile() throws IOException {
         Path nonExistentPath = new Path(testFolder.toString(), "non_existent_file");
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         try {
             replicationLogProcessor.createLogFileReader(localFs, nonExistentPath);
             fail("Should throw IOException for non-existent file");
@@ -173,7 +173,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
     public void testCreateLogFileReaderWithInvalidLogFile() throws IOException {
         Path invalidFilePath = new Path(testFolder.newFile("invalid_file").toURI());
         localFs.create(invalidFilePath).close(); // Create empty file
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         try {
             replicationLogProcessor.createLogFileReader(localFs, invalidFilePath);
             fail("Should throw IOException for invalid file");
@@ -192,7 +192,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
      */
     @Test
     public void testCloseReader() throws IOException {
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         replicationLogProcessor.closeReader(null);
         Path filePath = new Path(testFolder.newFile("testCloseReader").toURI());
         String tableName = "T_" + generateUniqueName();
@@ -226,7 +226,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
     @Test
     public void testCalculateRetryDelay() throws IOException {
         // Test with default configuration
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
 
         // Test exponential backoff pattern with default max delay (10 seconds)
         assertEquals("First retry should have 1 second delay", 1000L, replicationLogProcessor.calculateRetryDelay(0));
@@ -244,7 +244,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         long customMaxDelay = 5000L; // 5 seconds
         customConf.setLong(ReplicationLogProcessor.REPLICATION_STANDBY_BATCH_RETRY_MAX_DELAY_MS, customMaxDelay);
 
-        ReplicationLogProcessor customProcessor = new ReplicationLogProcessor(customConf, testHAGroupId);
+        ReplicationLogProcessor customProcessor = new ReplicationLogProcessor(customConf, testHAGroupName);
 
         // Test exponential backoff pattern with custom max delay
         assertEquals("First retry should have 1 second delay", 1000L, customProcessor.calculateRetryDelay(0));
@@ -261,7 +261,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         long smallMaxDelay = 1500L; // 1.5 seconds
         smallDelayConf.setLong(ReplicationLogProcessor.REPLICATION_STANDBY_BATCH_RETRY_MAX_DELAY_MS, smallMaxDelay);
 
-        ReplicationLogProcessor smallDelayProcessor = new ReplicationLogProcessor(smallDelayConf, testHAGroupId);
+        ReplicationLogProcessor smallDelayProcessor = new ReplicationLogProcessor(smallDelayConf, testHAGroupName);
 
         assertEquals("First retry should have 1 second delay", 1000L, smallDelayProcessor.calculateRetryDelay(0));
         assertEquals("Second retry should be capped at 1.5 seconds", 1500L, smallDelayProcessor.calculateRetryDelay(1));
@@ -277,7 +277,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
     @Test
     public void testReplicationLogProcessorConfiguration() throws IOException {
         // Test that all default configurations are used when no custom configuration is provided
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
 
         // Validate default batch size
         assertEquals("Default batch size should be used",
@@ -332,7 +332,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         customConf.setLong(ReplicationLogProcessor.REPLICATION_STANDBY_BATCH_RETRY_MAX_DELAY_MS, customMaxRetryDelay);
         customConf.setInt(ReplicationLogProcessor.REPLICATION_STANDBY_LOG_REPLAY_THREAD_POOL_SIZE, customThreadPoolSize);
 
-        ReplicationLogProcessor customProcessor = new ReplicationLogProcessor(customConf, testHAGroupId);
+        ReplicationLogProcessor customProcessor = new ReplicationLogProcessor(customConf, testHAGroupName);
 
         // Validate all custom configurations are honored
         assertEquals("Custom batch size should be honored",
@@ -369,7 +369,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         final String table2Name = "T_" + generateUniqueName();
         final Path filePath = new Path(testFolder.newFile("testProcessLogFileEnd2End").toURI());
         LogFileWriter writer = initLogFileWriter(filePath);
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         try (Connection conn = DriverManager.getConnection(getUrl())) {
             conn.createStatement().execute(String.format(CREATE_TABLE_SQL_STATEMENT, table1Name));
             conn.createStatement().execute(String.format(CREATE_TABLE_SQL_STATEMENT, table2Name));
@@ -420,7 +420,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         // Verify the file doesn't exist
         assertFalse("Non-existent file should not exist", localFs.exists(nonExistentFilePath));
 
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         // Attempt to process non-existent file - should throw IOException
         try {
             replicationLogProcessor.processLogFile(localFs, nonExistentFilePath);
@@ -453,7 +453,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         assertTrue("Empty log file should have header/trailer content", localFs.getFileStatus(emptyFilePath).getLen() > 0);
 
         // Process the empty log file - should not throw any exceptions
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         try {
             replicationLogProcessor.processLogFile(localFs, emptyFilePath);
             // If we reach here, the empty file was processed successfully
@@ -484,7 +484,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         writer.append(tableNameString, 1, put);
         writer.sync();
 
-        ReplicationLogProcessor spyProcessor = Mockito.spy(new ReplicationLogProcessor(conf, testHAGroupId));
+        ReplicationLogProcessor spyProcessor = Mockito.spy(new ReplicationLogProcessor(conf, testHAGroupName));
 
         // Create argument captor to capture the actual parameters passed to processReplicationLogBatch
         ArgumentCaptor<Map<TableName, List<Mutation>>> mapCaptor =
@@ -582,7 +582,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         Configuration testConf = new Configuration(conf);
         testConf.setInt(ReplicationLogProcessor.REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE, batchSize);
 
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(testConf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(testConf, testHAGroupName);
 
         // Validate that the batch size is correctly set
         assertEquals("Batch size should be set correctly", batchSize, replicationLogProcessor.getBatchSize());
@@ -688,7 +688,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         // Test with empty map - should not throw any exception
         Map<TableName, List<Mutation>> emptyMap = new HashMap<>();
 
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         try {
             ReplicationLogProcessor.ApplyMutationBatchResult applyMutationBatchResult = replicationLogProcessor.applyMutations(emptyMap);
             assertNotNull("Apply mutations result must not be null", applyMutationBatchResult);
@@ -718,7 +718,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         final TableName tableName2 = TableName.valueOf(table2);
         final TableName tableName3 = TableName.valueOf(table3);
         Map<TableName, List<Mutation>> tableMutationsMap = new HashMap<>();
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         try (Connection conn = DriverManager.getConnection(getUrl())) {
             // Create first table (will succeed)
             conn.createStatement().execute(String.format(CREATE_TABLE_SQL_STATEMENT, table1));
@@ -795,7 +795,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         final String table2 = "T_" + generateUniqueName();
         Map<TableName, List<Mutation>> tableMutationsMap = new HashMap<>();
         // Create processor and apply mutations
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
 
         try (Connection conn = DriverManager.getConnection(getUrl())) {
             // Create first table
@@ -847,7 +847,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         final String table1 = "T_" + generateUniqueName();
         final String table2 = "T_" + generateUniqueName();
         Map<TableName, List<Mutation>> tableMutationsMap = new HashMap<>();
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         try (Connection conn = DriverManager.getConnection(getUrl())) {
             // Create first table
             conn.createStatement().execute(String.format(CREATE_TABLE_SQL_STATEMENT, table1));
@@ -940,7 +940,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         tableMutationsMap.put(TableName.valueOf(table2), mutations2);
 
         // Create processor and spy on it
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         ReplicationLogProcessor spyProcessor = Mockito.spy(replicationLogProcessor);
 
         // Mock applyMutations to return empty failed mutations map (all succeed)
@@ -992,7 +992,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         Map<TableName, List<Mutation>> tableMutationsMap = new HashMap<>();
 
         // Create processor and spy on it
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         ReplicationLogProcessor spyProcessor = Mockito.spy(replicationLogProcessor);
 
         try (Connection conn = DriverManager.getConnection(getUrl())) {
@@ -1106,7 +1106,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         Map<TableName, List<Mutation>> tableMutationsMap = new HashMap<>();
 
         // Create processor and spy on it
-        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupId);
+        ReplicationLogProcessor replicationLogProcessor = new ReplicationLogProcessor(conf, testHAGroupName);
         ReplicationLogProcessor spyProcessor = Mockito.spy(replicationLogProcessor);
 
         try (Connection conn = DriverManager.getConnection(getUrl())) {
@@ -1252,7 +1252,7 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         testConf.setInt(ReplicationLogProcessor.REPLICATION_STANDBY_LOG_REPLAY_BATCH_SIZE, batchSize);
 
         // Create processor with custom batch size and spy on it
-        ReplicationLogProcessor spyProcessor = Mockito.spy(new ReplicationLogProcessor(testConf, testHAGroupId));
+        ReplicationLogProcessor spyProcessor = Mockito.spy(new ReplicationLogProcessor(testConf, testHAGroupName));
 
         // Validate that the batch size is correctly set
         assertEquals("Batch size incorrectly set", batchSize, spyProcessor.getBatchSize());
@@ -1317,33 +1317,33 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
     }
 
     /**
-     * Tests that ReplicationLogProcessor.get() returns the same instance for the same haGroupId.
+     * Tests that ReplicationLogProcessor.get() returns the same instance for the same haGroup.
      * Verifies that multiple calls with the same parameters return the cached instance.
      */
     @Test
     public void testReplicationLogProcessorInstanceCaching() throws Exception {
-        final String haGroupId1 = "testHAGroup_1";
-        final String haGroupId2 = "testHAGroup_2";
+        final String haGroupName1 = "testHAGroup_1";
+        final String haGroupName2 = "testHAGroup_2";
 
         // Get instances for the first HA group
-        ReplicationLogProcessor group1Instance1 = ReplicationLogProcessor.get(conf, haGroupId1);
-        ReplicationLogProcessor group1Instance2 = ReplicationLogProcessor.get(conf, haGroupId1);
+        ReplicationLogProcessor group1Instance1 = ReplicationLogProcessor.get(conf, haGroupName1);
+        ReplicationLogProcessor group1Instance2 = ReplicationLogProcessor.get(conf, haGroupName1);
 
-        // Verify same instance is returned for same haGroupId
+        // Verify same instance is returned for same haGroupName
         assertNotNull("ReplicationLogProcessor should not be null", group1Instance1);
         assertNotNull("ReplicationLogProcessor should not be null", group1Instance2);
-        assertSame("Same instance should be returned for same haGroupId", group1Instance1, group1Instance2);
-        assertEquals("HA Group ID should match", haGroupId1, group1Instance1.getHaGroupId());
+        assertSame("Same instance should be returned for same haGroup", group1Instance1, group1Instance2);
+        assertEquals("HA Group ID should match", haGroupName1, group1Instance1.getHaGroupName());
 
         // Get instance for a different HA group
-        ReplicationLogProcessor group2Instance1 = ReplicationLogProcessor.get(conf, haGroupId2);
+        ReplicationLogProcessor group2Instance1 = ReplicationLogProcessor.get(conf, haGroupName2);
         assertNotNull("ReplicationLogProcessor should not be null", group2Instance1);
-        assertNotSame("Different instance should be returned for different haGroupId", group2Instance1, group1Instance1);
-        assertEquals("HA Group ID should match", haGroupId2, group2Instance1.getHaGroupId());
+        assertNotSame("Different instance should be returned for different haGroup", group2Instance1, group1Instance1);
+        assertEquals("HA Group ID should match", haGroupName2, group2Instance1.getHaGroupName());
 
         // Verify multiple calls still return cached instances
-        ReplicationLogProcessor group1Instance3 = ReplicationLogProcessor.get(conf, haGroupId1);
-        ReplicationLogProcessor group2Instance2 = ReplicationLogProcessor.get(conf, haGroupId2);
+        ReplicationLogProcessor group1Instance3 = ReplicationLogProcessor.get(conf, haGroupName1);
+        ReplicationLogProcessor group2Instance2 = ReplicationLogProcessor.get(conf, haGroupName2);
         assertSame("Cached instance should be returned", group1Instance3, group1Instance1);
         assertSame("Cached instance should be returned", group2Instance2, group2Instance1);
 
@@ -1358,15 +1358,15 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
      */
     @Test
     public void testReplicationLogProcessorCacheRemovalOnClose() throws Exception {
-        final String haGroupId = "testHAGroup";
+        final String haGroupName = "testHAGroup";
 
         // Get initial instance
-        ReplicationLogProcessor group1Instance1 = ReplicationLogProcessor.get(conf, haGroupId);
+        ReplicationLogProcessor group1Instance1 = ReplicationLogProcessor.get(conf, haGroupName);
         assertNotNull("ReplicationLogProcessor should not be null", group1Instance1);
         assertFalse("Executor service must not be shut down", group1Instance1.getExecutorService().isShutdown());
 
         // Verify cached instance is returned
-        ReplicationLogProcessor group1Instance2 = ReplicationLogProcessor.get(conf, haGroupId);
+        ReplicationLogProcessor group1Instance2 = ReplicationLogProcessor.get(conf, haGroupName);
         assertSame("Same instance should be returned before close", group1Instance2, group1Instance1);
 
         // Close the group
@@ -1374,11 +1374,11 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
         assertTrue("Executor service must be shut down", group1Instance1.getExecutorService().isShutdown());
 
         // Get instance after close - should be a new instance
-        ReplicationLogProcessor group1Instance3 = ReplicationLogProcessor.get(conf, haGroupId);
+        ReplicationLogProcessor group1Instance3 = ReplicationLogProcessor.get(conf, haGroupName);
         assertNotNull("ReplicationLogProcessor should not be null after close", group1Instance3);
         assertFalse("Executor service must not be shut down", group1Instance3.getExecutorService().isShutdown());
         assertNotSame("New instance should be created after close", group1Instance1, group1Instance3);
-        assertEquals("HA Group ID should match", haGroupId, group1Instance3.getHaGroupId());
+        assertEquals("HA Group ID should match", haGroupName, group1Instance3.getHaGroupName());
 
         // Clean up
         group1Instance3.close();

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/reader/ReplicationLogProcessorTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/reader/ReplicationLogProcessorTest.java
@@ -418,11 +418,11 @@ public class ReplicationLogProcessorTest extends ParallelStatsDisabledIT {
     }
 
     /**
-     * Tests processing of log files that were not closed, ensuring it's successful.
+     * Tests processing of log files that were not closed, ensuring it's successf.
      */
     @Test
     public void testProcessLogFileForUnClosedFile() throws Exception {
-        final Path emptyFilePath = new Path(testFolder.newFile("testProcessLogFileEmpty").toURI());
+        final Path emptyFilePath = new Path(testFolder.newFile("testProcessLogFileForUnClosedFile").toURI());
         LogFileWriter writer = initLogFileWriter(emptyFilePath);
 
         // Add one mutation


### PR DESCRIPTION
JIRA - [PHOENIX-7632](https://issues.apache.org/jira/browse/PHOENIX-7632)

Adding the ReplicationLogProcessor component, that accepts a single replication log file, process mutations in configurable batch size and apply them to HBase table via async client.
The Replication Log Discovery (to be added as part of [PHOENIX-7568](https://issues.apache.org/jira/browse/PHOENIX-7568)) would list the log files and use ReplicationLogProcessor to read and apply the mutations to respective HBase table.

The Discovery and Tracking (Marking file in-progrss / deletion after successful processing) will be done as part of [PHOENIX-7568](https://issues.apache.org/jira/browse/PHOENIX-7568).