### PR TITLE
PHOENIX-7646 New PhoenixStatement API to return old row state in Atomic Updates

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -622,8 +622,8 @@ public class DeleteCompiler {
             Scan scan = context.getScan();
             scan.setAttribute(BaseScannerRegionObserverConstants.DELETE_AGG, QueryConstants.TRUE);
             if (context.getScanRanges().getPointLookupCount() == 1
-                    && (returnResult == MutationState.ReturnResult.ROW
-                    || returnResult == MutationState.ReturnResult.OLD_ROW)) {
+                    && (returnResult == MutationState.ReturnResult.NEW_ROW_ON_SUCCESS
+                    || returnResult == MutationState.ReturnResult.OLD_ROW_ALWAYS)) {
                 scan.setAttribute(BaseScannerRegionObserverConstants.SINGLE_ROW_DELETE,
                         QueryConstants.TRUE);
             }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -622,7 +622,8 @@ public class DeleteCompiler {
             Scan scan = context.getScan();
             scan.setAttribute(BaseScannerRegionObserverConstants.DELETE_AGG, QueryConstants.TRUE);
             if (context.getScanRanges().getPointLookupCount() == 1 &&
-                    returnResult == MutationState.ReturnResult.ROW) {
+                    (returnResult == MutationState.ReturnResult.ROW || 
+                     returnResult == MutationState.ReturnResult.OLD_ROW)) {
                 scan.setAttribute(BaseScannerRegionObserverConstants.SINGLE_ROW_DELETE,
                         QueryConstants.TRUE);
             }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -621,9 +621,9 @@ public class DeleteCompiler {
             final StatementContext context = dataPlan.getContext();
             Scan scan = context.getScan();
             scan.setAttribute(BaseScannerRegionObserverConstants.DELETE_AGG, QueryConstants.TRUE);
-            if (context.getScanRanges().getPointLookupCount() == 1 &&
-                    (returnResult == MutationState.ReturnResult.ROW || 
-                     returnResult == MutationState.ReturnResult.OLD_ROW)) {
+            if (context.getScanRanges().getPointLookupCount() == 1
+                    && (returnResult == MutationState.ReturnResult.ROW
+                    || returnResult == MutationState.ReturnResult.OLD_ROW)) {
                 scan.setAttribute(BaseScannerRegionObserverConstants.SINGLE_ROW_DELETE,
                         QueryConstants.TRUE);
             }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -775,12 +775,12 @@ public class MutationState implements SQLCloseable {
                     }
                 }
                 if (this.returnResult != null) {
-                    if (this.returnResult == ReturnResult.ROW) {
+                    if (this.returnResult == ReturnResult.NEW_ROW_ON_SUCCESS) {
                         for (Mutation mutation : rowMutations) {
                             mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
                                     PhoenixIndexBuilderHelper.RETURN_RESULT_ROW);
                         }
-                    } else if (this.returnResult == ReturnResult.OLD_ROW) {
+                    } else if (this.returnResult == ReturnResult.OLD_ROW_ALWAYS) {
                         for (Mutation mutation : rowMutations) {
                             mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
                                     PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW);
@@ -807,10 +807,10 @@ public class MutationState implements SQLCloseable {
                         mutation.setAttribute(PhoenixIndexBuilderHelper.ATOMIC_OP_ATTRIB, onDupKeyBytes);
                     }
                     if (this.returnResult != null) {
-                        if (this.returnResult == ReturnResult.ROW) {
+                        if (this.returnResult == ReturnResult.NEW_ROW_ON_SUCCESS) {
                             mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
                                     PhoenixIndexBuilderHelper.RETURN_RESULT_ROW);
-                        } else if (this.returnResult == ReturnResult.OLD_ROW) {
+                        } else if (this.returnResult == ReturnResult.OLD_ROW_ALWAYS) {
                             mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
                                     PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW);
                         }
@@ -1527,8 +1527,8 @@ public class MutationState implements SQLCloseable {
                                         .decodeInt(cell.getValueArray(), cell.getValueOffset(),
                                                 SortOrder.getDefault());
                                 if (this.returnResult != null) {
-                                    if (this.returnResult == ReturnResult.ROW ||
-                                            this.returnResult == ReturnResult.OLD_ROW) {
+                                    if (this.returnResult == ReturnResult.NEW_ROW_ON_SUCCESS ||
+                                            this.returnResult == ReturnResult.OLD_ROW_ALWAYS) {
                                         this.result = result;
                                     }
                                 }
@@ -2402,8 +2402,8 @@ public class MutationState implements SQLCloseable {
     }
 
     public enum ReturnResult {
-        ROW,
-        OLD_ROW
+        NEW_ROW_ON_SUCCESS,
+        OLD_ROW_ALWAYS
     }
 
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/MutationState.java
@@ -780,6 +780,11 @@ public class MutationState implements SQLCloseable {
                             mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
                                     PhoenixIndexBuilderHelper.RETURN_RESULT_ROW);
                         }
+                    } else if (this.returnResult == ReturnResult.OLD_ROW) {
+                        for (Mutation mutation : rowMutations) {
+                            mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
+                                    PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW);
+                        }
                     }
                 }
                 // The DeleteCompiler already generates the deletes for indexes, so no need to do it again
@@ -805,6 +810,9 @@ public class MutationState implements SQLCloseable {
                         if (this.returnResult == ReturnResult.ROW) {
                             mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
                                     PhoenixIndexBuilderHelper.RETURN_RESULT_ROW);
+                        } else if (this.returnResult == ReturnResult.OLD_ROW) {
+                            mutation.setAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT,
+                                    PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW);
                         }
                     }
                 }
@@ -1519,7 +1527,8 @@ public class MutationState implements SQLCloseable {
                                         .decodeInt(cell.getValueArray(), cell.getValueOffset(),
                                                 SortOrder.getDefault());
                                 if (this.returnResult != null) {
-                                    if (this.returnResult == ReturnResult.ROW) {
+                                    if (this.returnResult == ReturnResult.ROW ||
+                                            this.returnResult == ReturnResult.OLD_ROW) {
                                         this.result = result;
                                     }
                                 }
@@ -2393,7 +2402,8 @@ public class MutationState implements SQLCloseable {
     }
 
     public enum ReturnResult {
-        ROW
+        ROW,
+        OLD_ROW
     }
 
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilderHelper.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilderHelper.java
@@ -41,6 +41,7 @@ public final class PhoenixIndexBuilderHelper {
 
     public static final String RETURN_RESULT = "_RETURN_RESULT";
     public static final byte[] RETURN_RESULT_ROW = new byte[]{0};
+    public static final byte[] RETURN_RESULT_OLD_ROW = new byte[]{1};
 
     public static byte[] serializeOnDupKeyIgnore() {
         return ON_DUP_KEY_IGNORE_BYTES;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -219,8 +219,8 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
      * Executes the given SQL statement similar to JDBC API executeUpdate() but also returns the
      * old row (before update) as Result object back to the client. This must be used with
      * auto-commit Connection. This makes the operation atomic.
-     * If the row is successfully updated, return the old row (state before update), otherwise if
-     * the row cannot be updated, return non-updated (old) row.
+     * Return the old row (state before update) regardless of whether the update is
+     * successful or not.
      *
      * @return The pair of int and ResultSet, where int represents value 1 for successful row update
      * and 0 for non-successful row update, and ResultSet represents the old state of the row.

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -226,6 +226,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
      * and 0 for non-successful row update, and ResultSet represents the old state of the row.
      * @throws SQLException If the statement cannot be executed.
      */
+    // Note: Do Not remove this, it is expected to be used by downstream applications
     public Pair<Integer, ResultSet> executeAtomicUpdateReturnOldRow() throws SQLException {
         if (!connection.getAutoCommit()) {
             throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()
@@ -247,6 +248,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
      * and 0 for non-successful row update, and ResultSet represents the state of the row.
      * @throws SQLException If the statement cannot be executed.
      */
+    // Note: Do Not remove this, it is expected to be used by downstream applications
     public Pair<Integer, ResultSet> executeAtomicUpdateReturnRow() throws SQLException {
         if (!connection.getAutoCommit()) {
             throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -36,7 +36,6 @@ import java.sql.RowId;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLXML;
-import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.ZoneOffset;
@@ -234,7 +233,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
         }
         preExecuteUpdate();
         return executeMutation(statement, createAuditQueryLogger(statement, query),
-                MutationState.ReturnResult.OLD_ROW);
+                MutationState.ReturnResult.OLD_ROW_ALWAYS);
     }
 
     /**
@@ -256,7 +255,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Phoeni
         }
         preExecuteUpdate();
         return executeMutation(statement, createAuditQueryLogger(statement, query),
-                MutationState.ReturnResult.ROW);
+                MutationState.ReturnResult.NEW_ROW_ON_SUCCESS);
     }
 
     public QueryPlan optimizeQuery() throws SQLException {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -583,7 +583,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
     protected int executeMutation(final CompilableStatement stmt,
                                   final AuditQueryLogger queryLogger) throws SQLException {
         return executeMutation(stmt, true, queryLogger,
-                isResultSetExpected(stmt) ? ReturnResult.ROW : null).getFirst();
+                isResultSetExpected(stmt) ? ReturnResult.NEW_ROW_ON_SUCCESS : null).getFirst();
     }
 
     Pair<Integer, ResultSet> executeMutation(final CompilableStatement stmt,
@@ -626,8 +626,8 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
                                 isUpsert = stmt instanceof ExecutableUpsertStatement;
                                 isDelete = stmt instanceof ExecutableDeleteStatement;
                                 if (isDelete && connection.getAutoCommit() &&
-                                        (returnResult == ReturnResult.ROW ||
-                                                returnResult == ReturnResult.OLD_ROW)) {
+                                        (returnResult == ReturnResult.NEW_ROW_ON_SUCCESS ||
+                                                returnResult == ReturnResult.OLD_ROW_ALWAYS)) {
                                     // used only if single row deletion needs to atomically
                                     // return row that is deleted.
                                     plan = ((ExecutableDeleteStatement) stmt).compilePlan(
@@ -2498,7 +2498,8 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         }
         CompilableStatement stmt = preExecuteUpdate(sql);
         Pair<Integer, ResultSet> result =
-                executeMutation(stmt, createAuditQueryLogger(stmt, sql), ReturnResult.ROW);
+                executeMutation(stmt, createAuditQueryLogger(stmt, sql),
+                        ReturnResult.NEW_ROW_ON_SUCCESS);
         flushIfNecessary();
         return result;
     }
@@ -2525,7 +2526,8 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
         }
         CompilableStatement stmt = preExecuteUpdate(sql);
         Pair<Integer, ResultSet> result =
-                executeMutation(stmt, createAuditQueryLogger(stmt, sql), ReturnResult.OLD_ROW);
+                executeMutation(stmt, createAuditQueryLogger(stmt, sql),
+                        ReturnResult.OLD_ROW_ALWAYS);
         flushIfNecessary();
         return result;
     }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -2507,8 +2507,8 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
      * Executes the given SQL statement similar to JDBC API executeUpdate() but also returns the
      * old row (before update) as Result object back to the client. This must be used with
      * auto-commit Connection. This makes the operation atomic.
-     * If the row is successfully updated, return the old row (state before update), otherwise
-     * if the row cannot be updated, return non-updated (old) row.
+     * Return the old row (state before update) regardless of whether the update is
+     * successful or not.
      *
      * @param sql The SQL DML statement, UPSERT or DELETE for Phoenix.
      * @return The pair of int and ResultSet, where int represents value 1 for successful row

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -2490,6 +2490,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
      * update and 0 for non-successful row update, and ResultSet represents the state of the row.
      * @throws SQLException If the statement cannot be executed.
      */
+    // Note: Do Not remove this, it is expected to be used by downstream applications
     public Pair<Integer, ResultSet> executeAtomicUpdateReturnRow(String sql) throws SQLException {
         if (!connection.getAutoCommit()) {
             throw new SQLExceptionInfo.Builder(SQLExceptionCode.AUTO_COMMIT_NOT_ENABLED).build()
@@ -2515,6 +2516,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
      * row.
      * @throws SQLException If the statement cannot be executed.
      */
+    // Note: Do Not remove this, it is expected to be used by downstream applications
     public Pair<Integer, ResultSet> executeAtomicUpdateReturnOldRow(String sql)
             throws SQLException {
         if (!connection.getAutoCommit()) {

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -278,6 +278,9 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
         // true, will be null if there is no expression on this column, otherwise false
         // This is only initialized for single row atomic mutation.
         private Map<ColumnReference, Pair<Cell, Boolean>> currColumnCellExprMap;
+        // store old row cells into a map for OLD_ROW return result. This preserves the original
+        // state of the row before any conditional updates are applied.
+        private Map<ColumnReference, Pair<Cell, Boolean>> oldRowColumnCellExprMap;
         // list containing the original mutations from the MiniBatchOperationInProgress. Contains
         // any annotations we were sent by the client, and can be used in hooks that don't get
         // passed MiniBatchOperationInProgress, like preWALAppend()
@@ -290,6 +293,7 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
         private boolean hasLocalIndex;
         private boolean hasTransform;
         private boolean returnResult;
+        private boolean returnOldRow;
         private boolean hasConditionalTTL; // table has Conditional TTL
 
         public BatchMutateContext() {
@@ -1316,6 +1320,11 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
             Mutation m = miniBatchOp.getOperation(i);
             if (this.builder.returnResult(m) && miniBatchOp.size() == 1) {
                 context.returnResult = true;
+                byte[] returnResult = m.getAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT);
+                if (returnResult != null && 
+                    Arrays.equals(returnResult, PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW)) {
+                    context.returnOldRow = true;
+                }
             }
             if (this.builder.hasConditionalTTL(m)) {
                 context.hasConditionalTTL = true;
@@ -1656,7 +1665,13 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
                       List<Cell> cells = new ArrayList<>();
                       cells.add(cell);
 
-                      addCellsIfResultReturned(miniBatchOp, context, cells);
+                      if (!context.returnOldRow) {
+                          addCellsIfResultReturned(miniBatchOp, context.returnResult, cells,
+                                  context.currColumnCellExprMap, false);
+                      } else {
+                          addCellsIfResultReturned(miniBatchOp, context.returnResult, cells,
+                                  context.oldRowColumnCellExprMap, true);
+                      }
 
                       Result result = Result.create(cells);
                       miniBatchOp.setOperationStatus(0,
@@ -1682,28 +1697,32 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
   }
 
     /**
-     * If the result needs to be returned for the given update operation, identify the updated row
-     * cells and add the input list of cells.
+     * If the result needs to be returned for the given update operation, identify the appropriate
+     * row cells and add them to the input list of cells. The method can return either the updated
+     * row cells (for ROW return type) or the original row cells (for OLD_ROW return type).
      *
      * @param miniBatchOp Batch of mutations getting applied to region.
-     * @param context The BatchMutateContext object shared during coproc hooks execution as part of
-     * the batch mutate life cycle.
+     * @param returnResult Whether the result should be returned to the client.
      * @param cells The list of cells to be returned back to the client.
+     * @param currColumnCellExprMap The map containing column reference to cell mappings. This
+     * can be either the current/updated state (for ROW) or the original state (for OLD_ROW)
+     * depending on the return type requested.
      */
     private static void addCellsIfResultReturned(MiniBatchOperationInProgress<Mutation> miniBatchOp,
-                                                 BatchMutateContext context, List<Cell> cells) {
-        if (context.returnResult) {
-            Map<ColumnReference, Pair<Cell, Boolean>> currColumnCellExprMap =
-                    context.currColumnCellExprMap;
+                                                 boolean returnResult, List<Cell> cells,
+                                                 Map<ColumnReference, Pair<Cell, Boolean>>
+                                                         currColumnCellExprMap,
+                                                 boolean retainOldRow) {
+        if (returnResult) {
             if (currColumnCellExprMap == null) {
                 return;
             }
             Mutation mutation = miniBatchOp.getOperation(0);
-            if (mutation instanceof Put) {
+            if (mutation instanceof Put && !retainOldRow) {
                 updateColumnCellExprMap(mutation, currColumnCellExprMap);
             }
             Mutation[] mutations = miniBatchOp.getOperationsFromCoprocessors(0);
-            if (mutations != null) {
+            if (mutations != null && !retainOldRow) {
                 for (Mutation m : mutations) {
                     updateColumnCellExprMap(m, currColumnCellExprMap);
                 }
@@ -1892,6 +1911,13 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
       Pair<Put, Put> dataRowState = context.dataRowStates.get(rowKeyPtr);
       Put currentDataRowState = dataRowState != null ? dataRowState.getFirst() : null;
 
+        // Create separate map for old row data when OLD_ROW is requested
+        // This must be done before any conditional update logic to preserve original state
+        if (context.returnResult && context.returnOldRow && currentDataRowState != null) {
+            context.oldRowColumnCellExprMap = new HashMap<>();
+            updateCurrColumnCellExpr(currentDataRowState, context.oldRowColumnCellExprMap);
+        }
+
         // if result needs to be returned but the DML does not have ON DUPLICATE KEY present,
         // perform the mutation and return the result.
         if (opBytes == null) {
@@ -2074,6 +2100,9 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
     private static void updateCurrColumnCellExpr(Put put,
                                                  Map<ColumnReference, Pair<Cell, Boolean>>
                                                          currColumnCellExprMap) {
+        if (put == null) {
+            return;
+        }
         for (Map.Entry<byte[], List<Cell>> entry :
                 put.getFamilyCellMap().entrySet()) {
             for (Cell cell : entry.getValue()) {

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -1321,8 +1321,8 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
             if (this.builder.returnResult(m) && miniBatchOp.size() == 1) {
                 context.returnResult = true;
                 byte[] returnResult = m.getAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT);
-                if (returnResult != null && 
-                    Arrays.equals(returnResult, PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW)) {
+                if (returnResult != null && Arrays.equals(returnResult,
+                        PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW)) {
                     context.returnOldRow = true;
                 }
             }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilder.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilder.java
@@ -22,6 +22,7 @@ import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -278,7 +279,10 @@ public class PhoenixIndexBuilder extends NonTxIndexBuilder {
 
     @Override
     public boolean returnResult(Mutation m) {
-        return m.getAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT) != null;
+        byte[] returnResult = m.getAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT);
+        return returnResult != null && 
+               (Arrays.equals(returnResult, PhoenixIndexBuilderHelper.RETURN_RESULT_ROW) ||
+                Arrays.equals(returnResult, PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW));
     }
 
     @Override

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilder.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/index/PhoenixIndexBuilder.java
@@ -280,9 +280,9 @@ public class PhoenixIndexBuilder extends NonTxIndexBuilder {
     @Override
     public boolean returnResult(Mutation m) {
         byte[] returnResult = m.getAttribute(PhoenixIndexBuilderHelper.RETURN_RESULT);
-        return returnResult != null && 
-               (Arrays.equals(returnResult, PhoenixIndexBuilderHelper.RETURN_RESULT_ROW) ||
-                Arrays.equals(returnResult, PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW));
+        return returnResult != null && (Arrays.equals(returnResult,
+                PhoenixIndexBuilderHelper.RETURN_RESULT_ROW) || Arrays.equals(returnResult,
+                PhoenixIndexBuilderHelper.RETURN_RESULT_OLD_ROW));
     }
 
     @Override

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OnDuplicateKey2IT.java
@@ -52,6 +52,7 @@ import org.apache.phoenix.compile.ExplainPlan;
 import org.apache.phoenix.compile.ExplainPlanAttributes;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
+import org.apache.phoenix.jdbc.PhoenixStatement;
 import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PTable;
@@ -504,6 +505,164 @@ public class OnDuplicateKey2IT extends ParallelStatsDisabledIT {
         else {
             assertNull(resultSet);
             assertEquals(1, updateCount);
+        }
+    }
+
+    /**
+     * Validates that the returned row contains the original state before the upsert operation.
+     * This method uses executeAtomicUpdateReturnOldRow() to test the OLD_ROW functionality.
+     */
+    private static void validateReturnedRowBeforeUpsert(Connection conn,
+                                                       String upsertSql,
+                                                       String tableName,
+                                                       Double col1,
+                                                       String col2,
+                                                       boolean success,
+                                                       BsonDocument inputDoc,
+                                                       BsonDocument expectedDoc,
+                                                       Integer col4)
+            throws SQLException {
+        int updateCount;
+        ResultSet resultSet;
+        if (inputDoc != null) {
+            PreparedStatement ps = conn.prepareStatement(upsertSql);
+            ps.setObject(1, inputDoc);
+            Pair<Integer, ResultSet> resultPair =
+                    ps.unwrap(PhoenixPreparedStatement.class).executeAtomicUpdateReturnOldRow();
+            updateCount = resultPair.getFirst();
+            resultSet = resultPair.getSecond();
+        } else {
+            Statement stmt = conn.createStatement();
+            Pair<Integer, ResultSet> resultPair =
+                    stmt.unwrap(PhoenixStatement.class).executeAtomicUpdateReturnOldRow(upsertSql);
+            updateCount = resultPair.getFirst();
+            resultSet = resultPair.getSecond();
+        }
+        boolean isOnDuplicateKey = upsertSql.toUpperCase().contains("ON DUPLICATE KEY");
+        if (conn.getAutoCommit() && isOnDuplicateKey) {
+            assertEquals(success ? 1 : 0, updateCount);
+            if (resultSet != null) {
+                assertEquals("pk000", resultSet.getString(1));
+                assertEquals(-123.98, resultSet.getDouble(2), 0.0);
+                assertEquals("pk003", resultSet.getString(3));
+                assertEquals(col1, resultSet.getDouble(4), 0.0);
+                validateReturnedRowResult(col2, expectedDoc, col4, resultSet);
+                assertFalse(resultSet.next());
+            }
+        }
+    }
+
+    @Test
+    public void testReturnOldRowResult1() throws Exception {
+        Assume.assumeTrue("Set correct result to RegionActionResult on hbase versions " +
+                "2.4.18+, 2.5.9+, and 2.6.0+", isSetCorrectResultEnabledOnHBase());
+        // NOTE - Tuple result projection does not work well with local index because
+        // this assertion can be false: CellUtil.matchingRows(kvs[0], kvs[kvs.length-1])
+        // as the Tuple contains different rowkeys.
+        Assume.assumeTrue("ResultSet return does not work with local index",
+            !indexDDL.startsWith("create local index"));
+
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        String sample1 = getJsonString("json/sample_01.json");
+        String sample2 = getJsonString("json/sample_02.json");
+        BsonDocument bsonDocument1 = RawBsonDocument.parse(sample1);
+        BsonDocument bsonDocument2 = RawBsonDocument.parse(sample2);
+        try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+            conn.setAutoCommit(true);
+            String tableName = generateUniqueName();
+            String ddl = "CREATE TABLE " + tableName
+                    + "(PK1 VARCHAR, PK2 DOUBLE NOT NULL, PK3 VARCHAR, COUNTER1 DOUBLE,"
+                    + " COUNTER2 VARCHAR,"
+                    + " COL3 BSON, COL4 INTEGER, CONSTRAINT pk PRIMARY KEY(PK1, PK2, PK3))";
+            conn.createStatement().execute(ddl);
+            createIndex(conn, tableName);
+
+            validateAtomicUpsertReturnOldRow(tableName, conn, bsonDocument1, bsonDocument2);
+
+            verifyIndexRow(conn, tableName, false);
+        }
+    }
+
+    private static void validateAtomicUpsertReturnOldRow(String tableName, Connection conn,
+                                                         BsonDocument bsonDocument1,
+                                                         BsonDocument bsonDocument2)
+            throws SQLException {
+        String upsertSql = "UPSERT INTO " + tableName + " (PK1, PK2, PK3, COUNTER1, COL3, COL4)"
+                + " VALUES('pk000', -123.98, 'pk003', 1011.202, ?, 123) ON DUPLICATE KEY " +
+                "IGNORE";
+        validateReturnedRowBeforeUpsert(conn, upsertSql, tableName, 0.0, null, true,
+                bsonDocument1, null, null);
+
+        upsertSql =
+                "UPSERT INTO " + tableName + " (PK1, PK2, PK3, COUNTER1) "
+                        + "VALUES('pk000', -123.98, 'pk003', 0) ON DUPLICATE KEY IGNORE";
+        validateReturnedRowBeforeUpsert(conn, upsertSql, tableName, 1011.202, null, false,
+                null, bsonDocument1, 123);
+
+        upsertSql =
+                "UPSERT INTO " + tableName
+                        + " (PK1, PK2, PK3, COUNTER1, COUNTER2) VALUES('pk000', -123.98, "
+                        + "'pk003', 234, 'col2_000')";
+        validateReturnedRowBeforeUpsert(conn, upsertSql, tableName, 1011.202, null, true,
+                null, bsonDocument1, 123);
+
+        upsertSql = "UPSERT INTO " + tableName
+                + " (PK1, PK2, PK3) VALUES('pk000', -123.98, 'pk003') ON DUPLICATE KEY UPDATE "
+                + "COUNTER1 = CASE WHEN COUNTER1 < 2000 THEN COUNTER1 + 1999.99 ELSE COUNTER1"
+                + " END, "
+                + "COUNTER2 = CASE WHEN COUNTER2 = 'col2_000' THEN 'col2_001' ELSE COUNTER2 "
+                + "END, "
+                + "COL3 = ?, "
+                + "COL4 = 234";
+        validateReturnedRowBeforeUpsert(conn, upsertSql, tableName, 234d, "col2_000", true,
+                bsonDocument2, bsonDocument1, 123);
+
+        upsertSql = "UPSERT INTO " + tableName
+                + " (PK1, PK2, PK3) VALUES('pk000', -123.98, 'pk003') ON DUPLICATE KEY UPDATE "
+                + "COUNTER1 = CASE WHEN COUNTER1 < 2000 THEN COUNTER1 + 1999.99 ELSE COUNTER1"
+                + " END,"
+                + "COUNTER2 = CASE WHEN COUNTER2 = 'col2_000' THEN 'col2_001' ELSE COUNTER2 "
+                + "END";
+        validateReturnedRowBeforeUpsert(conn, upsertSql, tableName, 2233.99, "col2_001", false
+                , null, bsonDocument2, 234);
+    }
+
+    @Test
+    public void testReturnOldRowResult2() throws Exception {
+        Assume.assumeTrue("Set correct result to RegionActionResult on hbase versions " +
+                "2.4.18+, 2.5.9+, and 2.6.0+", isSetCorrectResultEnabledOnHBase());
+        // NOTE - Tuple result projection does not work well with local index because
+        // this assertion can be false: CellUtil.matchingRows(kvs[0], kvs[kvs.length-1])
+        // as the Tuple contains different rowkeys.
+        Assume.assumeTrue("ResultSet return does not work with local index",
+            !indexDDL.startsWith("create local index"));
+
+        Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        String sample1 = getJsonString("json/sample_01.json");
+        String sample2 = getJsonString("json/sample_02.json");
+        BsonDocument bsonDocument1 = RawBsonDocument.parse(sample1);
+        BsonDocument bsonDocument2 = RawBsonDocument.parse(sample2);
+        try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+            conn.setAutoCommit(true);
+            String tableName = generateUniqueName();
+            String ddl = "CREATE TABLE " + tableName
+                    + "(PK1 VARCHAR, PK2 DOUBLE NOT NULL, PK3 VARCHAR, COUNTER1 DOUBLE,"
+                    + " COUNTER2 VARCHAR,"
+                    + " COL3 BSON, COL4 INTEGER, CONSTRAINT pk PRIMARY KEY(PK1, PK2, PK3))";
+            conn.createStatement().execute(ddl);
+            createIndex(conn, tableName);
+
+            String upsertSql = "UPSERT INTO " + tableName + " (PK1, PK2, PK3, COUNTER1, COL3, COL4)"
+                    + " VALUES('pk000', -123.98, 'pk003', 999.999, ?, 999) ON DUPLICATE KEY " +
+                    "IGNORE";
+            validateReturnedRowBeforeUpsert(conn, upsertSql, tableName, 0.0, null, true,
+                    bsonDocument1, null, null);
+
+            upsertSql = "UPSERT INTO " + tableName + " (PK1, PK2, PK3, COUNTER1, COL3, COL4)"
+                    + " VALUES('pk000', -123.98, 'pk003', 888.888, ?, 888) ON DUPLICATE KEY " +
+                    "IGNORE";
+            validateReturnedRowBeforeUpsert(conn, upsertSql, tableName, 999.999, null, false,
+                    bsonDocument2, bsonDocument1, 999);
         }
     }
 


### PR DESCRIPTION
Jira: PHOENIX-7646

PHOENIX-7462, PHOENIX-7398, PHOENIX-7434, PHOENIX-7411 and PHOENIX-7630 Jiras have introduced support for PhoenixStatement to return ResultSet for updated new row version.

The purpose of this PR is to add support for returning the old row state (before update) in atomic update operations. This enhancement allows applications to retrieve the previous state of a row when performing conditional updates, enabling better audit trails.

New API signature:
```
/**
 * Executes the given SQL statement similar to JDBC API executeUpdate() but also returns the
 * old row (before update) as Result object back to the client. This must be used with
 * auto-commit Connection. This makes the operation atomic.
 * If the row is successfully updated, return the old row (state before update), otherwise
 * if the row cannot be updated, return non-updated (old) row.
 *
 * @param sql The SQL DML statement, UPSERT or DELETE for Phoenix.
 * @return The pair of int and ResultSet, where int represents value 1 for successful row
 * update and 0 for non-successful row update, and ResultSet represents the old state of the
 * row.
 * @throws SQLException If the statement cannot be executed.
 */
public Pair<Integer, ResultSet> executeAtomicUpdateReturnOldRow(String sql)
        throws SQLException {
```