### PR TITLE
PHOENIX-7645 HighAvailabilityGroup can leak zookeeper connections

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
@@ -445,8 +445,8 @@ public class HighAvailabilityGroup {
                                 + "timeout " + PHOENIX_HA_ZK_CONNECTION_TIMEOUT_MS_DEFAULT + " ms");
                     }
                 } catch (Exception e) {
-                    LOG.warn("HA cluster role manager getCurator thread for '{}' is interrupted/exception, closing CuratorFramework",
-                            jdbcUrl, e);
+                    LOG.warn("HA cluster role manager getCurator thread for '{}' is interrupted"
+                        + ", closing CuratorFramework", jdbcUrl, e);
                     curator.close();
                     if (e instanceof InterruptedException) {
                         Thread.currentThread().interrupt();


### PR DESCRIPTION
In `HighAvailabilityGroup#getCurator`, the `CuratorFramework` instance may have some issue trying to connect to ZooKeeper. If the connection fails the `CuratorFramework` instance is not closed and leaks. There is a `ZooKeeper` object associated with each `CuratorFramework` instance that also leaks, accumulating ZK connections that continue to try to connect for a while, and leak the associated ZK client send and event threads.