### PR TITLE
PHOENIX-7626: Add metrics to capture HTable thread pool utilization and contention (addendum: fix incompatibility for HBase 2.4 build)

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/CQSIThreadPoolMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/CQSIThreadPoolMetricsIT.java
@@ -19,6 +19,7 @@ package org.apache.phoenix.monitoring;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.util.VersionInfo;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.jdbc.AbstractRPCConnectionInfo;
 import org.apache.phoenix.jdbc.ConnectionInfo;
@@ -40,6 +41,7 @@ import org.junit.runners.Parameterized;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -104,11 +106,17 @@ public class CQSIThreadPoolMetricsIT extends BaseHTableThreadPoolMetricsIT {
         props.clear();
     }
 
-    @Parameterized.Parameters(name = "ExternalHTableThreadPoolMetricsIT_registryClassName={0}")
+    @Parameterized.Parameters(name = "CQSIThreadPoolMetricsIT_registryClassName={0}")
     public synchronized static Collection<String> data() {
-        return Arrays.asList(ZKConnectionInfo.ZK_REGISTRY_NAME,
-                "org.apache.hadoop.hbase.client.RpcConnectionRegistry",
-                "org.apache.hadoop.hbase.client.MasterRegistry");
+        List<String> list = new ArrayList<>();
+        list.add(ZKConnectionInfo.ZK_REGISTRY_NAME);
+        if (VersionInfo.compareVersion(VersionInfo.getVersion(), "2.3.0") >= 0) {
+            list.add("org.apache.hadoop.hbase.client.MasterRegistry");
+        }
+        if (VersionInfo.compareVersion(VersionInfo.getVersion(), "2.5.0") >= 0) {
+            list.add("org.apache.hadoop.hbase.client.RpcConnectionRegistry");
+        }
+        return list;
     }
 
     @Test

--- a/phoenix-core/src/it/java/org/apache/phoenix/monitoring/ExternalHTableThreadPoolMetricsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/monitoring/ExternalHTableThreadPoolMetricsIT.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Threads;
+import org.apache.hadoop.hbase.util.VersionInfo;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.jdbc.ZKConnectionInfo;
 import org.apache.phoenix.job.HTableThreadPoolWithUtilizationStats;
@@ -43,6 +44,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -210,9 +212,15 @@ public class ExternalHTableThreadPoolMetricsIT extends BaseHTableThreadPoolMetri
 
     @Parameterized.Parameters(name = "ExternalHTableThreadPoolMetricsIT_registryClassName={0}")
     public synchronized static Collection<String> data() {
-        return Arrays.asList(ZKConnectionInfo.ZK_REGISTRY_NAME,
-                "org.apache.hadoop.hbase.client.RpcConnectionRegistry",
-                "org.apache.hadoop.hbase.client.MasterRegistry");
+        List<String> list = new ArrayList<>();
+        list.add(ZKConnectionInfo.ZK_REGISTRY_NAME);
+        if (VersionInfo.compareVersion(VersionInfo.getVersion(), "2.3.0") >= 0) {
+            list.add("org.apache.hadoop.hbase.client.MasterRegistry");
+        }
+        if (VersionInfo.compareVersion(VersionInfo.getVersion(), "2.5.0") >= 0) {
+            list.add("org.apache.hadoop.hbase.client.RpcConnectionRegistry");
+        }
+        return list;
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick of: https://github.com/apache/phoenix/pull/2206