### PR TITLE
PHOENIX-7653 New CDC Event for TTL expired rows

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryConstants.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryConstants.java
@@ -363,6 +363,9 @@ public interface QueryConstants {
     String CDC_UPSERT_EVENT_TYPE = "upsert";
     String CDC_DELETE_EVENT_TYPE = "delete";
     String SPLITS_FILE = "SPLITS_FILE";
+    String CDC_TTL_DELETE_EVENT_TYPE = "ttl_delete";
+    String CDC_IMAGE_CQ = "__CDC_IMAGE__";
+    byte[] CDC_IMAGE_CQ_BYTES = Bytes.toBytes(CDC_IMAGE_CQ);
 
     /**
      * We mark counter values 0 to 10 as reserved. Value 0 is used by

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -440,6 +440,9 @@ public interface QueryServices extends SQLCloseable {
     String CONNECTION_QUERY_SERVICE_HISTOGRAM_SIZE_RANGES =
             "phoenix.conn.query.service.histogram.size.ranges";
 
+    // CDC TTL mutation retry configuration
+    String CDC_TTL_MUTATION_MAX_RETRIES = "phoenix.cdc.ttl.mutation.max.retries";
+
     // This config is used to move (copy and delete) the child links from the SYSTEM.CATALOG to SYSTEM.CHILD_LINK table.
     // As opposed to a copy and async (out of band) delete.
     public static final String MOVE_CHILD_LINKS_DURING_UPGRADE_ENABLED = "phoenix.move.child_link.during.upgrade";

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -24,6 +24,7 @@ import static org.apache.phoenix.query.QueryServices.ALLOW_VIEWS_ADD_NEW_CF_BASE
 import static org.apache.phoenix.query.QueryServices.AUTO_UPGRADE_ENABLED;
 import static org.apache.phoenix.query.QueryServices.CALL_QUEUE_PRODUCER_ATTRIB_NAME;
 import static org.apache.phoenix.query.QueryServices.CALL_QUEUE_ROUND_ROBIN_ATTRIB;
+import static org.apache.phoenix.query.QueryServices.CDC_TTL_MUTATION_MAX_RETRIES;
 import static org.apache.phoenix.query.QueryServices.CLIENT_METRICS_TAG;
 import static org.apache.phoenix.query.QueryServices.CLIENT_SPOOL_THRESHOLD_BYTES_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
@@ -469,7 +470,7 @@ public class QueryServicesOptions {
     public static final int DEFAULT_CQSI_THREAD_POOL_MAX_QUEUE = 512;
     public static final Boolean DEFAULT_CQSI_THREAD_POOL_ALLOW_CORE_THREAD_TIMEOUT = true;
     public static final Boolean DEFAULT_CQSI_THREAD_POOL_METRICS_ENABLED = false;
-
+    public static final int DEFAULT_CDC_TTL_MUTATION_MAX_RETRIES = 5;
 
     private final Configuration config;
 
@@ -585,7 +586,8 @@ public class QueryServicesOptions {
             .setIfUnset(CQSI_THREAD_POOL_MAX_QUEUE, DEFAULT_CQSI_THREAD_POOL_MAX_QUEUE)
             .setIfUnset(CQSI_THREAD_POOL_ALLOW_CORE_THREAD_TIMEOUT,
                     DEFAULT_CQSI_THREAD_POOL_ALLOW_CORE_THREAD_TIMEOUT)
-            .setIfUnset(CQSI_THREAD_POOL_METRICS_ENABLED, DEFAULT_CQSI_THREAD_POOL_METRICS_ENABLED);
+            .setIfUnset(CQSI_THREAD_POOL_METRICS_ENABLED, DEFAULT_CQSI_THREAD_POOL_METRICS_ENABLED)
+            .setIfUnset(CDC_TTL_MUTATION_MAX_RETRIES, DEFAULT_CDC_TTL_MUTATION_MAX_RETRIES);
 
         // HBase sets this to 1, so we reset it to something more appropriate.
         // Hopefully HBase will change this, because we can't know if a user set

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/CDCChangeBuilder.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/CDCChangeBuilder.java
@@ -31,6 +31,7 @@ import static org.apache.phoenix.query.QueryConstants.CDC_DELETE_EVENT_TYPE;
 import static org.apache.phoenix.query.QueryConstants.CDC_EVENT_TYPE;
 import static org.apache.phoenix.query.QueryConstants.CDC_POST_IMAGE;
 import static org.apache.phoenix.query.QueryConstants.CDC_PRE_IMAGE;
+import static org.apache.phoenix.query.QueryConstants.CDC_TTL_DELETE_EVENT_TYPE;
 import static org.apache.phoenix.query.QueryConstants.CDC_UPSERT_EVENT_TYPE;
 
 public class CDCChangeBuilder {
@@ -69,7 +70,7 @@ public class CDCChangeBuilder {
     }
 
     public boolean isDeletionEvent() {
-        return changeType == CDC_DELETE_EVENT_TYPE;
+        return changeType == CDC_DELETE_EVENT_TYPE || changeType == CDC_TTL_DELETE_EVENT_TYPE;
     }
 
     public boolean isNonEmptyEvent() {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/CDCUtil.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/CDCUtil.java
@@ -112,6 +112,19 @@ public class CDCUtil {
         return isCDCIndex(indexTable.getTableName().getString());
     }
 
+    /**
+     * Check if the given table has any CDC indexes.
+     * 
+     * @param table The PTable object.
+     * @return true if the table has an CDC index, false otherwise.
+     */
+    public static boolean hasCDCIndex(PTable table) {
+        if (table == null || table.getIndexes() == null) {
+            return false;
+        }
+        return table.getIndexes().stream().anyMatch(CDCUtil::isCDCIndex);
+    }
+
     public static Scan setupScanForCDC(Scan scan) {
         scan.setRaw(true);
         scan.readAllVersions();
@@ -139,7 +152,7 @@ public class CDCUtil {
     public static Object getColumnEncodedValue(Object value, PDataType dataType) {
         if (value != null) {
             if (dataType.getSqlType() == PDataType.BSON_TYPE) {
-                value = Bytes.toBytes(((RawBsonDocument) value).getByteBuffer().asNIO());
+                value = ByteUtil.toBytes(((RawBsonDocument) value).getByteBuffer().asNIO());
             } else if (isBinaryType(dataType)) {
                 // Unfortunately, Base64.Encoder has no option to specify offset and length so can't
                 // avoid copying bytes.

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/CDCCompactionUtil.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/CDCCompactionUtil.java
@@ -1,0 +1,400 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.coprocessor;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.CheckAndMutate;
+import org.apache.hadoop.hbase.client.CheckAndMutateResult;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.Region;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.expression.function.PartitionIdFunction;
+import org.apache.phoenix.hbase.index.ValueGetter;
+import org.apache.phoenix.hbase.index.util.GenericKeyValueBuilder;
+import org.apache.phoenix.hbase.index.util.ImmutableBytesPtr;
+import org.apache.phoenix.index.IndexMaintainer;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.query.QueryConstants;
+import org.apache.phoenix.schema.PColumn;
+import org.apache.phoenix.schema.PTable;
+import org.apache.phoenix.schema.types.PDate;
+import org.apache.phoenix.util.CDCUtil;
+import org.apache.phoenix.util.IndexUtil;
+import org.apache.phoenix.util.JacksonUtil;
+import org.apache.phoenix.util.QueryUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.phoenix.query.QueryConstants.NAME_SEPARATOR;
+
+/**
+ * Utility class for CDC (Change Data Capture) operations during compaction.
+ * This class contains utilities for handling TTL row expiration events and generating
+ * CDC events with pre-image data that are written directly to CDC index tables.
+ */
+public class CDCCompactionUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CDCCompactionUtil.class);
+
+    /**
+     * Finds the column name for a given cell in the data table.
+     *
+     * @param dataTable The data table
+     * @param cell      The cell
+     * @return The column name or null if not found
+     */
+    static String findColumnName(PTable dataTable, Cell cell) {
+        try {
+            byte[] family = CellUtil.cloneFamily(cell);
+            byte[] qualifier = CellUtil.cloneQualifier(cell);
+            byte[] defaultCf = dataTable.getDefaultFamilyName() != null ?
+                    dataTable.getDefaultFamilyName().getBytes() :
+                    QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES;
+            for (PColumn column : dataTable.getColumns()) {
+                if (column.getFamilyName() != null &&
+                        Bytes.equals(family, column.getFamilyName().getBytes()) &&
+                        Bytes.equals(qualifier, column.getColumnQualifierBytes())) {
+                    if (Bytes.equals(defaultCf, column.getFamilyName().getBytes())) {
+                        return column.getName().getString();
+                    } else {
+                        return column.getFamilyName().getString() + NAME_SEPARATOR
+                                + column.getName().getString();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error finding column name for cell: {}", CellUtil.toString(cell, true),
+                    e);
+        }
+        return null;
+    }
+
+    /**
+     * Creates a CDC event map for TTL delete with pre-image data.
+     *
+     * @param expiredRowPut The expired row data
+     * @param dataTable     The data table
+     * @param preImage      Pre-image map
+     * @return CDC event map
+     */
+    static Map<String, Object> createTTLDeleteCDCEvent(Put expiredRowPut, PTable dataTable,
+                                                       Map<String, Object> preImage)
+            throws Exception {
+        Map<String, Object> cdcEvent = new HashMap<>();
+        cdcEvent.put(QueryConstants.CDC_EVENT_TYPE, QueryConstants.CDC_TTL_DELETE_EVENT_TYPE);
+        for (List<Cell> familyCells : expiredRowPut.getFamilyCellMap().values()) {
+            for (Cell cell : familyCells) {
+                String columnName = findColumnName(dataTable, cell);
+                if (columnName != null) {
+                    PColumn column = dataTable.getColumnForColumnQualifier(
+                            CellUtil.cloneFamily(cell), CellUtil.cloneQualifier(cell));
+                    Object value = column.getDataType().toObject(cell.getValueArray(),
+                            cell.getValueOffset(),
+                            cell.getValueLength());
+                    Object encodedValue =
+                            CDCUtil.getColumnEncodedValue(value, column.getDataType());
+                    preImage.put(columnName, encodedValue);
+                }
+            }
+        }
+        cdcEvent.put(QueryConstants.CDC_PRE_IMAGE, preImage);
+        cdcEvent.put(QueryConstants.CDC_POST_IMAGE, Collections.emptyMap());
+        return cdcEvent;
+    }
+
+    /**
+     * Builds CDC index Put mutation.
+     *
+     * @param cdcIndex            The CDC index table
+     * @param expiredRowPut       The expired row data as a Put
+     * @param eventTimestamp      The timestamp for the CDC event
+     * @param cdcEventBytes       The CDC event data to store
+     * @param dataTable           The data table
+     * @param env                 The region coprocessor environment
+     * @param region              The HBase region
+     * @param compactionTimeBytes The compaction time as bytes
+     * @return The CDC index Put mutation
+     */
+    static Put buildCDCIndexPut(PTable cdcIndex, Put expiredRowPut, long eventTimestamp,
+                                byte[] cdcEventBytes, PTable dataTable,
+                                RegionCoprocessorEnvironment env, Region region,
+                                byte[] compactionTimeBytes) throws Exception {
+
+        try (PhoenixConnection serverConnection = QueryUtil.getConnectionOnServer(new Properties(),
+                env.getConfiguration()).unwrap(PhoenixConnection.class)) {
+
+            IndexMaintainer cdcIndexMaintainer =
+                    cdcIndex.getIndexMaintainer(dataTable, serverConnection);
+
+            ValueGetter dataRowVG = new IndexUtil.SimpleValueGetter(expiredRowPut);
+            ImmutableBytesPtr rowKeyPtr = new ImmutableBytesPtr(expiredRowPut.getRow());
+
+            Put cdcIndexPut = cdcIndexMaintainer.buildUpdateMutation(
+                    GenericKeyValueBuilder.INSTANCE,
+                    dataRowVG,
+                    rowKeyPtr,
+                    eventTimestamp,
+                    null,
+                    null,
+                    false,
+                    region.getRegionInfo().getEncodedNameAsBytes());
+
+            byte[] rowKey = cdcIndexPut.getRow().clone();
+            System.arraycopy(compactionTimeBytes, 0, rowKey,
+                    PartitionIdFunction.PARTITION_ID_LENGTH, PDate.INSTANCE.getByteSize());
+            Put newCdcIndexPut = new Put(rowKey, eventTimestamp);
+
+            newCdcIndexPut.addColumn(
+                    cdcIndexMaintainer.getEmptyKeyValueFamily().copyBytesIfNecessary(),
+                    cdcIndexMaintainer.getEmptyKeyValueQualifier(), eventTimestamp,
+                    QueryConstants.UNVERIFIED_BYTES);
+
+            // Add CDC event data
+            newCdcIndexPut.addColumn(
+                    QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+                    QueryConstants.CDC_IMAGE_CQ_BYTES,
+                    eventTimestamp,
+                    cdcEventBytes);
+
+            return newCdcIndexPut;
+        }
+    }
+
+    /**
+     * Generates and applies a CDC index mutation for TTL expired row with retries if required.
+     *
+     * @param cdcIndex                 The CDC index table
+     * @param dataTable                The data table
+     * @param expiredRowPut            The expired row data as a Put
+     * @param eventTimestamp           The timestamp for the CDC event
+     * @param tableName                The table name for logging
+     * @param env                      The region coprocessor environment
+     * @param region                   The HBase region
+     * @param compactionTimeBytes      The compaction time as bytes
+     * @param cdcTtlMutationMaxRetries Maximum retry attempts for CDC mutations
+     */
+    static void generateCDCIndexMutation(PTable cdcIndex, PTable dataTable,
+                                         Put expiredRowPut,
+                                         long eventTimestamp, String tableName,
+                                         RegionCoprocessorEnvironment env, Region region,
+                                         byte[] compactionTimeBytes,
+                                         int cdcTtlMutationMaxRetries)
+            throws Exception {
+        Map<String, Object> cdcEvent =
+                createTTLDeleteCDCEvent(expiredRowPut, dataTable, new HashMap<>());
+        byte[] cdcEventBytes =
+                JacksonUtil.getObjectWriter(HashMap.class).writeValueAsBytes(cdcEvent);
+        Put cdcIndexPut =
+                buildCDCIndexPut(cdcIndex, expiredRowPut, eventTimestamp, cdcEventBytes,
+                        dataTable, env, region, compactionTimeBytes);
+
+        Exception lastException = null;
+        for (int retryCount = 0; retryCount <= cdcTtlMutationMaxRetries; retryCount++) {
+            try (Table cdcIndexTable = env.getConnection().getTable(TableName.valueOf(
+                    cdcIndex.getPhysicalName().getBytes()))) {
+                CheckAndMutate checkAndMutate =
+                        CheckAndMutate.newBuilder(cdcIndexPut.getRow())
+                                .ifNotExists(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+                                        QueryConstants.CDC_IMAGE_CQ_BYTES)
+                                .build(cdcIndexPut);
+                CheckAndMutateResult result = cdcIndexTable.checkAndMutate(checkAndMutate);
+
+                if (result.isSuccess()) {
+                    // Successfully inserted new CDC event - Single CF case
+                    lastException = null;
+                    break;
+                } else {
+                    // Row already exists, need to retrieve existing pre-image and merge
+                    // Likely to happen for multi CF case
+                    Get get = new Get(cdcIndexPut.getRow());
+                    get.addColumn(QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+                            QueryConstants.CDC_IMAGE_CQ_BYTES);
+                    Result existingResult = cdcIndexTable.get(get);
+
+                    if (!existingResult.isEmpty()) {
+                        Cell existingCell = existingResult.getColumnLatestCell(
+                                QueryConstants.DEFAULT_COLUMN_FAMILY_BYTES,
+                                QueryConstants.CDC_IMAGE_CQ_BYTES);
+
+                        if (existingCell != null) {
+                            byte[] existingCdcBytes = CellUtil.cloneValue(existingCell);
+                            Map<String, Object> existingCdcEvent =
+                                    JacksonUtil.getObjectReader(HashMap.class)
+                                            .readValue(existingCdcBytes);
+                            Map<String, Object> existingPreImage =
+                                    (Map<String, Object>) existingCdcEvent.getOrDefault(
+                                            QueryConstants.CDC_PRE_IMAGE, new HashMap<>());
+
+                            // Create new TTL delete event with merged pre-image
+                            Map<String, Object> mergedCdcEvent =
+                                    createTTLDeleteCDCEvent(expiredRowPut, dataTable,
+                                            existingPreImage);
+                            byte[] mergedCdcEventBytes =
+                                    JacksonUtil.getObjectWriter(HashMap.class)
+                                            .writeValueAsBytes(mergedCdcEvent);
+
+                            Put mergedCdcIndexPut = buildCDCIndexPut(cdcIndex, expiredRowPut,
+                                    eventTimestamp, mergedCdcEventBytes, dataTable, env, region,
+                                    compactionTimeBytes);
+
+                            cdcIndexTable.put(mergedCdcIndexPut);
+                            lastException = null;
+                            break;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                lastException = e;
+                if (retryCount < cdcTtlMutationMaxRetries) {
+                    long backoffMs = 100;
+                    LOGGER.warn("CDC mutation attempt {}/{} failed, retrying in {}ms",
+                            retryCount + 1, cdcTtlMutationMaxRetries + 1, backoffMs, e);
+                    try {
+                        Thread.sleep(backoffMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Interrupted during CDC mutation retry", ie);
+                    }
+                }
+            }
+        }
+        if (lastException != null) {
+            LOGGER.error("Failed to generate CDC mutation after {} attempts for table {}, index " +
+                            "{}. The event update is missed.",
+                    cdcTtlMutationMaxRetries + 1,
+                    tableName,
+                    cdcIndex.getPhysicalName().getString(),
+                    lastException);
+        }
+    }
+
+    /**
+     * Generates CDC TTL delete event and writes it directly to CDC index tables.
+     * This bypasses the normal CDC update path since the row is being expired.
+     *
+     * @param expiredRow               The cells of the expired row
+     * @param tableName                The table name for logging
+     * @param compactionTime           The compaction timestamp
+     * @param dataTable                The data table
+     * @param env                      The region coprocessor environment
+     * @param region                   The HBase region
+     * @param compactionTimeBytes      The compaction time as bytes
+     * @param cdcTtlMutationMaxRetries Maximum retry attempts for CDC mutations
+     */
+    static void generateCDCTTLDeleteEvent(List<Cell> expiredRow, String tableName,
+                                          long compactionTime, PTable dataTable,
+                                          RegionCoprocessorEnvironment env, Region region,
+                                          byte[] compactionTimeBytes,
+                                          int cdcTtlMutationMaxRetries) {
+        if (expiredRow.isEmpty()) {
+            return;
+        }
+        try {
+            List<PTable> cdcIndexes = new ArrayList<>();
+            for (PTable index : dataTable.getIndexes()) {
+                if (CDCUtil.isCDCIndex(index)) {
+                    cdcIndexes.add(index);
+                }
+            }
+            if (cdcIndexes.isEmpty()) {
+                LOGGER.debug("No CDC indexes found for table {}", tableName);
+                return;
+            }
+            Cell firstCell = expiredRow.get(0);
+            byte[] dataRowKey = CellUtil.cloneRow(firstCell);
+            Put expiredRowPut = new Put(dataRowKey);
+
+            for (Cell cell : expiredRow) {
+                expiredRowPut.add(cell);
+            }
+
+            for (PTable cdcIndex : cdcIndexes) {
+                try {
+                    generateCDCIndexMutation(cdcIndex, dataTable, expiredRowPut, compactionTime,
+                            tableName, env, region, compactionTimeBytes, cdcTtlMutationMaxRetries);
+                } catch (Exception e) {
+                    LOGGER.error("Failed to generate CDC mutation for index {}: {}",
+                            cdcIndex.getName().getString(), e.getMessage(), e);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error generating CDC TTL delete event for table {}",
+                    tableName, e);
+        }
+    }
+
+    /**
+     * Handles TTL row expiration for CDC event generation.
+     * This method is called when a row is detected as expired during major compaction.
+     *
+     * @param expiredRow               The cells of the expired row
+     * @param expirationType           The type of TTL expiration
+     * @param tableName                The table name for logging purposes
+     * @param compactionTime           The timestamp when compaction started
+     * @param table                    The Phoenix data table metadata
+     * @param env                      The region coprocessor environment for accessing HBase
+     *                                 resources
+     * @param region                   The HBase region being compacted
+     * @param compactionTimeBytes      The compaction timestamp as byte array for CDC index row key
+     *                                 construction
+     * @param cdcTtlMutationMaxRetries Maximum number of retry attempts for CDC mutation operations
+     */
+    static void handleTTLRowExpiration(List<Cell> expiredRow, String expirationType,
+                                       String tableName, long compactionTime, PTable table,
+                                       RegionCoprocessorEnvironment env, Region region,
+                                       byte[] compactionTimeBytes,
+                                       int cdcTtlMutationMaxRetries) {
+        if (expiredRow.isEmpty()) {
+            return;
+        }
+
+        try {
+            Cell firstCell = expiredRow.get(0);
+            byte[] rowKey = CellUtil.cloneRow(firstCell);
+
+            LOGGER.info("TTL row expiration detected: table={}, rowKey={}, expirationType={}, "
+                            + "cellCount={}, compactionTime={}",
+                    tableName,
+                    Bytes.toStringBinary(rowKey),
+                    expirationType,
+                    expiredRow.size(),
+                    compactionTime);
+
+            // Generate CDC TTL delete event with pre-image data
+            generateCDCTTLDeleteEvent(expiredRow, tableName, compactionTime, table, env, region,
+                    compactionTimeBytes, cdcTtlMutationMaxRetries);
+
+        } catch (Exception e) {
+            LOGGER.error("Error handling TTL row expiration for CDC: table {}", tableName, e);
+        }
+    }
+}

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/CompactionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/CompactionScanner.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -63,6 +64,7 @@ import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.exception.SQLExceptionInfo;
 import org.apache.phoenix.expression.RowKeyColumnExpression;
 import org.apache.phoenix.filter.RowKeyComparisonFilter.RowKeyTuple;
+import org.apache.phoenix.schema.types.PDate;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
 import org.apache.phoenix.query.QueryServices;
@@ -150,6 +152,7 @@ public class CompactionScanner implements InternalScanner {
     private final int familyCount;
     private KeepDeletedCells keepDeletedCells;
     private long compactionTime;
+    private byte[] compactionTimeBytes;
     private final byte[] emptyCF;
     private final byte[] emptyCQ;
     private final byte[] storeColumnFamily;
@@ -163,6 +166,9 @@ public class CompactionScanner implements InternalScanner {
     private long outputCellCount = 0;
     private boolean phoenixLevelOnly = false;
     private boolean isCDCIndex;
+    private final boolean isCdcTtlEnabled;
+    private final PTable table;
+    private final int cdcTtlMutationMaxRetries;
 
     // Only for forcing minor compaction while testing
     private static boolean forceMinorCompaction = false;
@@ -184,6 +190,7 @@ public class CompactionScanner implements InternalScanner {
         this.emptyCF = SchemaUtil.getEmptyColumnFamily(table);
         this.emptyCQ = SchemaUtil.getEmptyColumnQualifier(table);
         compactionTime = EnvironmentEdgeManager.currentTimeMillis();
+        compactionTimeBytes = PDate.INSTANCE.toBytes(new Date(compactionTime));
         columnFamilyName = store.getColumnFamilyName();
         storeColumnFamily = columnFamilyName.getBytes();
         tableName = region.getRegionInfo().getTable().getNameAsString();
@@ -205,7 +212,15 @@ public class CompactionScanner implements InternalScanner {
         emptyCFStore = familyCount == 1 || columnFamilyName.equals(Bytes.toString(emptyCF))
                         || localIndex;
 
-        isCDCIndex = table != null ? CDCUtil.isCDCIndex(table) : false;
+        this.table = table;
+        isCDCIndex = CDCUtil.isCDCIndex(table);
+        isCdcTtlEnabled =
+                CDCUtil.hasCDCIndex(table) && major && !table.isMultiTenant() &&
+                        table.getType() == PTableType.TABLE;
+        cdcTtlMutationMaxRetries = env.getConfiguration().getInt(
+                QueryServices.CDC_TTL_MUTATION_MAX_RETRIES,
+                QueryServicesOptions.DEFAULT_CDC_TTL_MUTATION_MAX_RETRIES);
+
         // Initialize the tracker that computes the TTL for the compacting table.
         // The TTL tracker can be
         // simple (one single TTL for the table) when the compacting table is not Partitioned
@@ -412,6 +427,11 @@ public class CompactionScanner implements InternalScanner {
         CompiledConditionalTTLExpression ttlExpr =
                 (CompiledConditionalTTLExpression) rowContext.ttlExprForRow;
         if (ttlExpr.isExpired(result, true)) {
+            if (isCdcTtlEnabled && !result.isEmpty()) {
+                CDCCompactionUtil.handleTTLRowExpiration(result, "conditional_ttl", tableName,
+                        compactionTime, table, env, region, compactionTimeBytes,
+                        cdcTtlMutationMaxRetries);
+            }
             // If the row is expired, purge the row
             result.clear();
         }
@@ -2591,6 +2611,12 @@ public class CompactionScanner implements InternalScanner {
             if (major && compactionTime - rowContext.maxTimestamp > maxLookbackInMillis + ttl) {
                 // Only do this check for major compaction as for minor compactions we don't expire cells.
                 // The row version should not be visible via the max lookback window. Nothing to do
+
+                if (isCdcTtlEnabled && !lastRow.isEmpty()) {
+                    CDCCompactionUtil.handleTTLRowExpiration(lastRow, "time_based_ttl", tableName,
+                            compactionTime, table, env, region, compactionTimeBytes,
+                            cdcTtlMutationMaxRetries);
+                }
                 return;
             }
             retainedCells.addAll(lastRow);
@@ -2682,6 +2708,11 @@ public class CompactionScanner implements InternalScanner {
                     // if we should retain it with the store level compaction when the current
                     // store is not the empty column family store.
                     return false;
+                }
+                if (isCdcTtlEnabled && !lastRowVersion.isEmpty()) {
+                    CDCCompactionUtil.handleTTLRowExpiration(lastRowVersion, "max_lookback_ttl",
+                            tableName, compactionTime, table, env, region, compactionTimeBytes,
+                            cdcTtlMutationMaxRetries);
                 }
                 return true;
             }

--- a/phoenix-core/src/it/java/org/apache/phoenix/schema/ConditionalTTLExpressionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/schema/ConditionalTTLExpressionIT.java
@@ -31,7 +31,6 @@ import static org.apache.phoenix.schema.LiteralTTLExpression.TTL_EXPRESSION_FORE
 import static org.apache.phoenix.util.TestUtil.retainSingleQuotes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -43,6 +42,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -55,6 +55,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.mapreduce.CounterGroup;
@@ -66,6 +67,7 @@ import org.apache.phoenix.hbase.index.IndexRegionObserver;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixResultSet;
 import org.apache.phoenix.mapreduce.index.IndexTool;
+import org.apache.phoenix.query.PhoenixTestBuilder;
 import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder;
 import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder.OtherOptions;
 import org.apache.phoenix.query.PhoenixTestBuilder.SchemaBuilder.TableOptions;
@@ -129,6 +131,8 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
     // map of row-pos -> HBase row-key, used for verification
     private Map<Integer, String> dataRowPosToKey = Maps.newHashMap();
     private Map<Integer, String> indexRowPosToKey = Maps.newHashMap();
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public ConditionalTTLExpressionIT(boolean columnEncoded,
                                       Integer tableLevelMaxLooback) {
@@ -418,6 +422,182 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
             CellCount expectedCellCount = new CellCount();
             expectedCellCount.insertRow(dataRowPosToKey.get(1), 2);
             validateTable(conn, tableName, expectedCellCount, dataRowPosToKey.values());
+        }
+    }
+
+    /**
+     * Tests CDC (Change Data Capture) functionality with TTL (Time To Live) expired rows.
+     * This test validates the complete CDC lifecycle including:
+     */
+    @Test
+    public void testPhoenixRowTimestampWithCdc() throws Exception {
+        int ttl = 50 * 1000;
+        String ttlExpression = String.format(
+                "TO_NUMBER(CURRENT_TIME()) - TO_NUMBER(PHOENIX_ROW_TIMESTAMP()) >= %d", ttl);
+        createTable(ttlExpression);
+        String tableName = schemaBuilder.getEntityTableName();
+        String cdcName = "cdc_" + generateUniqueName();
+        injectEdge();
+        int rowCount = 5;
+        long actual;
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            // Initial Setup - Create CDC index on the table
+            conn.createStatement().execute("CREATE CDC " + cdcName + " ON " + tableName);
+            populateTable(conn, rowCount);
+
+            // Verify initial row count
+            actual = TestUtil.getRowCount(conn, tableName, true);
+            assertEquals("Table should contain all inserted rows", 5, actual);
+
+            // Query initial CDC events (inserts)
+            String cdcQuery = "SELECT /*+ CDC_INCLUDE(PRE, POST) */ * FROM " +
+                    PhoenixTestBuilder.DDLDefaults.DEFAULT_SCHEMA_NAME + "." + cdcName;
+
+            ResultSet resultSet = conn.createStatement().executeQuery(cdcQuery);
+            List<Map<String, Object>> postImageList = new ArrayList<>();
+            while (resultSet.next()) {
+                String cdcVal = resultSet.getString(4);
+                Map<String, Object> map = OBJECT_MAPPER.readValue(cdcVal, Map.class);
+
+                // Validate insert events have no pre-image but have post-image
+                Map<String, Object> preImage =
+                        (Map<String, Object>) map.get(QueryConstants.CDC_PRE_IMAGE);
+                assertTrue("Insert events should have empty pre-image", preImage.isEmpty());
+
+                Map<String, Object> postImage =
+                        (Map<String, Object>) map.get(QueryConstants.CDC_POST_IMAGE);
+                assertFalse("Insert events should have non-empty post-image", postImage.isEmpty());
+                postImageList.add(postImage);
+
+                assertEquals("Initial events should be UPSERT type",
+                        QueryConstants.CDC_UPSERT_EVENT_TYPE,
+                        map.get(QueryConstants.CDC_EVENT_TYPE));
+            }
+
+            // TTL Expiration - Advance time to trigger TTL expiration
+            injectEdge.incrementValue(ttl);
+            doMajorCompaction(tableName);
+
+            // Verify all rows are expired from data table
+            actual = TestUtil.getRowCount(conn, tableName, true);
+            assertEquals("All rows should be expired after TTL", 0, actual);
+
+            // TTL CDC Events - Validate TTL_DELETE events are generated
+            resultSet = conn.createStatement().executeQuery(cdcQuery);
+            int i = 0;
+            while (resultSet.next()) {
+                String cdcVal = resultSet.getString(4);
+                Map<String, Object> map = OBJECT_MAPPER.readValue(cdcVal, Map.class);
+
+                // Validate TTL delete events
+                assertEquals("TTL expired rows should generate TTL_DELETE events",
+                        QueryConstants.CDC_TTL_DELETE_EVENT_TYPE,
+                        map.get(QueryConstants.CDC_EVENT_TYPE));
+
+                Map<String, Object> preImage =
+                        (Map<String, Object>) map.get(QueryConstants.CDC_PRE_IMAGE);
+                assertFalse("TTL_DELETE events should have non-empty pre-image",
+                        preImage.isEmpty());
+
+                Map<String, Object> postImage =
+                        (Map<String, Object>) map.get(QueryConstants.CDC_POST_IMAGE);
+                assertTrue("TTL_DELETE events should have empty post-image", postImage.isEmpty());
+
+                // TTL delete pre-image should match previous upsert post-image
+                assertEquals("TTL_DELETE pre-image should match original insert post-image",
+                        postImageList.get(i), preImage);
+                i++;
+            }
+
+            // Update an expired row to bring it back
+            injectEdge.incrementValue(1);
+            long currentTime = injectEdge.currentTime();
+            updateColumn(conn, 1, "VAL4", currentTime);
+
+            // Verify the row
+            actual = TestUtil.getRowCount(conn, tableName, true);
+            assertEquals("Only one row should be resurrected after update", 1, actual);
+
+            // Verify resurrected row has only updated column visible
+            try (ResultSet rs = readRow(conn, 1)) {
+                assertTrue("Resurrected row should exist", rs.next());
+                for (String col : COLUMNS) {
+                    if (!col.equals("VAL4")) {
+                        assertNull("Non-updated columns should be null in resurrected row",
+                                rs.getObject(col));
+                    } else {
+                        assertEquals("Updated column should have new timestamp",
+                                currentTime, rs.getTimestamp("VAL4").getTime());
+                    }
+                }
+            }
+
+            // Advance time beyond max lookback window
+            injectEdge.incrementValue(tableLevelMaxLookback * 1000L + 2);
+            doMajorCompaction(tableName);
+            CellCount expectedCellCount = new CellCount();
+            expectedCellCount.insertRow(dataRowPosToKey.get(1), 2);
+            validateTable(conn, tableName, expectedCellCount, dataRowPosToKey.values());
+
+            // Query CDC events
+            cdcQuery = "SELECT /*+ CDC_INCLUDE(PRE, POST) */ * FROM " +
+                    PhoenixTestBuilder.DDLDefaults.DEFAULT_SCHEMA_NAME + "." + cdcName
+                    + " WHERE PHOENIX_ROW_TIMESTAMP() >= ?";
+            PreparedStatement ps = conn.prepareStatement(cdcQuery);
+            ps.setTimestamp(1, new Timestamp(currentTime));
+            resultSet = ps.executeQuery();
+            postImageList = new ArrayList<>();
+            while (resultSet.next()) {
+                String cdcVal = resultSet.getString(4);
+                Map<String, Object> map = OBJECT_MAPPER.readValue(cdcVal, Map.class);
+
+                assertEquals("Resurrection event should be UPSERT type",
+                        QueryConstants.CDC_UPSERT_EVENT_TYPE,
+                        map.get(QueryConstants.CDC_EVENT_TYPE));
+
+                Map<String, Object> preImage =
+                        (Map<String, Object>) map.get(QueryConstants.CDC_PRE_IMAGE);
+                assertTrue("Resurrection event should have empty pre-image", preImage.isEmpty());
+
+                Map<String, Object> postImage =
+                        (Map<String, Object>) map.get(QueryConstants.CDC_POST_IMAGE);
+                assertFalse("Resurrection event should have non-empty post-image",
+                        postImage.isEmpty());
+                postImageList.add(postImage);
+            }
+
+            // Trigger TTL expiration again
+            injectEdge.incrementValue(ttl);
+            doMajorCompaction(tableName);
+            expectedCellCount = new CellCount();
+            validateTable(conn, tableName, expectedCellCount, dataRowPosToKey.values());
+
+            // Validate second round of TTL_DELETE events
+            ps = conn.prepareStatement(cdcQuery);
+            ps.setTimestamp(1, new Timestamp(currentTime));
+            resultSet = ps.executeQuery();
+            i = 0;
+            while (resultSet.next()) {
+                String cdcVal = resultSet.getString(4);
+                Map<String, Object> map = OBJECT_MAPPER.readValue(cdcVal, Map.class);
+
+                assertEquals("Second TTL expiration should generate TTL_DELETE events",
+                        QueryConstants.CDC_TTL_DELETE_EVENT_TYPE,
+                        map.get(QueryConstants.CDC_EVENT_TYPE));
+
+                Map<String, Object> preImage =
+                        (Map<String, Object>) map.get(QueryConstants.CDC_PRE_IMAGE);
+                assertFalse("Second TTL_DELETE should have non-empty pre-image",
+                        preImage.isEmpty());
+
+                Map<String, Object> postImage =
+                        (Map<String, Object>) map.get(QueryConstants.CDC_POST_IMAGE);
+                assertTrue("Second TTL_DELETE should have empty post-image", postImage.isEmpty());
+
+                assertEquals("Second TTL_DELETE pre-image should match resurrection post-image",
+                        postImageList.get(i), preImage);
+                i++;
+            }
         }
     }
 


### PR DESCRIPTION
Jira: PHOENIX-7653

The purpose of this PR is to extend the Change Data Capture (CDC) capabilities to generate CDC events when rows expire due to Time-To-Live (TTL) settings (literal or conditional) during the major compaction. The implementation ensures that applications consuming CDC streams receive notification when data is automatically removed from tables, providing additional visibility into the system-initiated deletions.

The proposed new event_type: ttl_delete

Example of TTL expired CDC event, assuming the row had two columns c1 and c2 with values "v1" and "v2" respectively:
```
{
  "event_type": "ttl_delete",
  "pre_image": {
    "c1": "v1",
    "c2": "v2"
  },
  "post_image": {}
}
```

High level Design steps:

- Identify the event which causes the row expiration: conditional_ttl, maxlookback/ttl expired rows
- Capture the complete row image for the expiration. The image needs to be directly inserted into the CDC index. If we do not provide the expired row pre-image upfront, CDC index can not scan it after the major compaction because the data table row no longer exists after it is expired by the major compaction. CompactionScanner needs to send the exact CDC Json structure with encoded bytes, which can later be directly sent to the client by the scanner when requested.
- CDCGlobalIndexRegionScanner needs to check for the existence of the special CF:CQ, which if found, can be directly returned as the value of "CDC JSON" column.
- For single CF, CompactionScanner needs to perform mutation to the CDC index directly only once.
- For multi CF, CompactionScanner might perform multiple mutation to the CDC index. Therefore, it should use checkAndMutate to ensure the mutation happens if the row does not exist. If the row is already inserted, and the other CF compaction tries to put recent row values, it can update the existing pre-image.
- In order to distinguish the same PHOENIX_ROW_TIMESTAMP() value for the CDC index while multiple CF compactions are taking place, CompactionScanner needs to provide compactionTime as the timestamp value in the CDC index rowkey by updating the rowkey before performing the mutation.
- Introduce some retries in case of HTable mutation failures.