### PR TITLE
PHOENIX-7585 New BSON Condition Function begins_with()

### DIFF
--- a/phoenix-core-client/src/main/antlr3/PhoenixBsonExpression.g
+++ b/phoenix-core-client/src/main/antlr3/PhoenixBsonExpression.g
@@ -32,6 +32,7 @@ tokens
     ATTR_NOT = 'attribute_not_exists';
     FIELD = 'field_exists';
     FIELD_NOT = 'field_not_exists';
+    BEGINS_WITH = 'begins_with';
 }
 
 @parser::header {
@@ -211,8 +212,6 @@ and_expression returns [ParseNode ret]
 not_expression returns [ParseNode ret]
     :   (NOT? boolean_expression ) => n=NOT? e=boolean_expression { $ret = n == null ? e : factory.not(e); }
     |   n=NOT? LPAREN e=expression RPAREN { $ret = n == null ? e : factory.not(e); }
-    |   (ATTR | FIELD) ( LPAREN t=literal RPAREN {$ret = factory.documentFieldExists(t, true); } )
-    |   (ATTR_NOT | FIELD_NOT) ( LPAREN t=literal RPAREN {$ret = factory.documentFieldExists(t, false); } )
     ;
 
 comparison_op returns [CompareOperator ret]
@@ -232,6 +231,10 @@ boolean_expression returns [ParseNode ret]
                       |        (IN (LPAREN v=one_or_more_expressions RPAREN {List<ParseNode> il = new ArrayList<ParseNode>(v.size() + 1); il.add(l); il.addAll(v); $ret = factory.inList(il,n!=null);}))
                       ))
                   |  { $ret = l; } )
+        |   (ATTR | FIELD) ( LPAREN t=literal RPAREN {$ret = factory.documentFieldExists(t, true); } )
+        |   (ATTR_NOT | FIELD_NOT) ( LPAREN t=literal RPAREN {$ret = factory.documentFieldExists(t, false); } )
+        |   BEGINS_WITH ( LPAREN l=value_expression COMMA r=value_expression RPAREN
+                {$ret = factory.documentFieldBeginsWith(l, r); } )
     ;
 
 value_expression returns [ParseNode ret]
@@ -511,4 +514,13 @@ CHAR_ESC
         |       { setText("\\"); }
         )
     |   '\'\''  { setText("\'"); }
+    ;
+
+WS
+    :   ( ' ' | '\t' | '\u2002' ) { $channel=HIDDEN; }
+    ;
+
+EOL
+    :  ('\r' | '\n')
+    { skip(); }
     ;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/expression/util/bson/BsonConditionInvalidArgumentException.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/expression/util/bson/BsonConditionInvalidArgumentException.java
@@ -30,4 +30,4 @@ public class BsonConditionInvalidArgumentException extends IllegalArgumentExcept
     public BsonConditionInvalidArgumentException(String message, Throwable cause) {
         super(message, cause);
     }
-} 
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/expression/util/bson/BsonConditionInvalidArgumentException.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/expression/util/bson/BsonConditionInvalidArgumentException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.expression.util.bson;
+
+/**
+ * Exception thrown when invalid arguments are provided to BSON condition expressions.
+ */
+public class BsonConditionInvalidArgumentException extends IllegalArgumentException {
+
+    public BsonConditionInvalidArgumentException(String message) {
+        super(message);
+    }
+
+    public BsonConditionInvalidArgumentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+} 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/parse/DocumentFieldBeginsWithParseNode.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/parse/DocumentFieldBeginsWithParseNode.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.parse;
+
+import org.apache.phoenix.compile.ColumnResolver;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Parse Node to help determine whether the document field starts with a given value.
+ * The first operand is the field key and the second operand is the value to check.
+ */
+public class DocumentFieldBeginsWithParseNode extends CompoundParseNode {
+
+    DocumentFieldBeginsWithParseNode(ParseNode fieldKey, ParseNode value) {
+        super(Arrays.asList(fieldKey, value));
+    }
+
+    @Override
+    public <T> T accept(ParseNodeVisitor<T> visitor) throws SQLException {
+        List<T> l = java.util.Collections.emptyList();
+        if (visitor.visitEnter(this)) {
+            l = acceptChildren(visitor);
+        }
+        return visitor.visitLeave(this, l);
+    }
+
+    @Override
+    public void toSQL(ColumnResolver resolver, StringBuilder buf) {
+        List<ParseNode> children = getChildren();
+        buf.append("begins_with(");
+        children.get(0).toSQL(resolver, buf);
+        buf.append(", ");
+        children.get(1).toSQL(resolver, buf);
+        buf.append(")");
+    }
+
+    public ParseNode getFieldKey() {
+        return getChildren().get(0);
+    }
+
+    public ParseNode getValue() {
+        return getChildren().get(1);
+    }
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/parse/ParseNodeFactory.java
@@ -298,6 +298,11 @@ public class ParseNodeFactory {
         return new DocumentFieldExistsParseNode(fieldName, exists);
     }
 
+    public DocumentFieldBeginsWithParseNode documentFieldBeginsWith(ParseNode fieldKey,
+                                                                    ParseNode value) {
+        return new DocumentFieldBeginsWithParseNode(fieldKey, value);
+    }
+
     public ColumnDef columnDef(ColumnName columnDefName, String sqlTypeName,
                                boolean isArray, Integer arrSize, Boolean isNull,
                                Integer maxLength, Integer scale, boolean isPK,

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson1IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/Bson1IT.java
@@ -186,6 +186,27 @@ public class Bson1IT extends ParallelStatsDisabledIT {
       assertEquals(bsonDocument2, document2);
 
       assertFalse(rs.next());
+
+      conditionExpression =
+              "NestedList1[0] <= :NestedList1_485 AND NestedList1[2][0] >= :NestedList1_xyz0123 "
+                      + "AND NestedList1[2][1].Id < :Id1 AND IdS < :Ids1 AND Id2 > :Id2 "
+                      + "AND begins_with(Title, :TitlePrefix)";
+
+      conditionDoc = new BsonDocument();
+      conditionDoc.put("$EXPR", new BsonString(conditionExpression));
+      conditionDoc.put("$VAL", compareValuesDocument);
+
+      query = "SELECT * FROM " + tableName + " WHERE BSON_CONDITION_EXPRESSION(COL, '"
+          + conditionDoc.toJson() + "')";
+      rs = conn.createStatement().executeQuery(query);
+
+      assertTrue(rs.next());
+      assertEquals("pk0002", rs.getString(1));
+      assertEquals(4596.354, rs.getDouble(2), 0.0);
+      document2 = (BsonDocument) rs.getObject(3);
+      assertEquals(bsonDocument2, document2);
+
+      assertFalse(rs.next());
     }
   }
 
@@ -194,6 +215,7 @@ public class Bson1IT extends ParallelStatsDisabledIT {
             "  \":NestedList1_485\" : -485.33,\n" +
             "  \":ISBN\" : \"111-1111111111\",\n" +
             "  \":Title\" : \"Book 101 Title\",\n" +
+            "  \":TitlePrefix\" : \"Book \",\n" +
             "  \":Id\" : 101.01,\n" +
             "  \":Id2\" : 12,\n" +
             "  \":Id1\" : 120,\n" +


### PR DESCRIPTION
Jira: PHOENIX-7585

PHOENIX-7463 provides us with the ability to generate and evaluate AST (Abstract Syntax Tree) for the BSON condition expression evaluation for it's SQL type expressions.

The purpose of this PR is to provide a new internal function (similar to field_exists(), field_not_exists() etc) within BSON_CONDITION_EXPRESSION() such that it can identify whether the value of the given document field of type BsonString or BsonBinary has prefix value as the constant provided in the second argument.

begins_with(fieldKey, substr) => here, fieldKey represents path in the given BSON document. substr represents value which needs to be compared as the prefix value of path field from the document. The function should only support BsonString and BsonBinary types for prefix search.