### PR TITLE
PHOENIX-7658 CDC event for TTL_DELETE to exclude pre-image if PRE scope is not selected

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/CDCChangeBuilder.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/CDCChangeBuilder.java
@@ -149,4 +149,8 @@ public class CDCChangeBuilder {
         return (cell.getTimestamp() < changeTimestamp &&
                 cell.getTimestamp() > lastDeletedTimestamp) ? true : false;
     }
+
+    public boolean isPreImageInScope() {
+        return isPreImageInScope;
+    }
 }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/CDCCompactionUtil.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/CDCCompactionUtil.java
@@ -47,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,7 +129,6 @@ public final class CDCCompactionUtil {
             }
         }
         cdcEvent.put(QueryConstants.CDC_PRE_IMAGE, preImage);
-        cdcEvent.put(QueryConstants.CDC_POST_IMAGE, Collections.emptyMap());
         return cdcEvent;
     }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/schema/ConditionalTTLExpressionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/schema/ConditionalTTLExpressionIT.java
@@ -501,9 +501,8 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
                 assertFalse("TTL_DELETE events should have non-empty pre-image",
                         preImage.isEmpty());
 
-                Map<String, Object> postImage =
-                        (Map<String, Object>) map.get(QueryConstants.CDC_POST_IMAGE);
-                assertTrue("TTL_DELETE events should have empty post-image", postImage.isEmpty());
+                assertNull("TTL_DELETE events should have empty post-image",
+                        map.get(QueryConstants.CDC_POST_IMAGE));
 
                 // TTL delete pre-image should match previous upsert post-image
                 assertEquals("TTL_DELETE pre-image should match original insert post-image",
@@ -600,9 +599,8 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
                 assertFalse("Second TTL_DELETE should have non-empty pre-image",
                         preImage.isEmpty());
 
-                Map<String, Object> postImage =
-                        (Map<String, Object>) map.get(QueryConstants.CDC_POST_IMAGE);
-                assertTrue("Second TTL_DELETE should have empty post-image", postImage.isEmpty());
+                assertNull("TTL_DELETE events should have empty post-image",
+                        map.get(QueryConstants.CDC_POST_IMAGE));
 
                 assertEquals("Second TTL_DELETE pre-image should match resurrection post-image",
                         postImageList.get(i), preImage);


### PR DESCRIPTION
Jira: PHOENIX-7658

As a follow-up to PHOENIX-7653 which introduced TTL_DELETE as new CDC event type, we should not return pre-built pre-image with CDC JSON if the SELECT query does not have PRE scope.