### PR TITLE
PHOENIX-7660 traceserver.py has a blank line that causes a syntax error

### DIFF
--- a/bin/traceserver.py
+++ b/bin/traceserver.py
@@ -123,7 +123,6 @@ java_cmd = '%(java)s  ' + \
     phoenix_utils.phoenix_traceserver_jar + os.pathsep + phoenix_utils.slf4j_backend_jar + os.pathsep + \
     phoenix_utils.logging_jar + os.pathsep + \
     phoenix_utils.phoenix_client_embedded_jar + os.pathsep + phoenix_utils.phoenix_queryserver_jar + \
-    
     " -Dproc_phoenixtraceserver" + \
     " -Dlog4j2.configurationFile=file:" + os.path.join(phoenix_utils.current_dir, "log4j2.properties") + \
     " -Dpsql.root.logger=%(root_logger)s" + \


### PR DESCRIPTION
This pull request removes a blank line in `traceserver.py` that occurs within the variable declaration of `java_cmd`. This blank line was causing an error when running `python3 -m compileall bin/traceserver.py`:

```
% python3 -m compileall bin/traceserver.py
Compiling 'traceserver.py'...
***   File "traceserver.py", line 126
    
    ^
SyntaxError: invalid syntax
```

This error no longer occurs after removing the blank line:

```
% python -m compileall bin/traceserver.py
Compiling 'bin/traceserver.py'...
```