### PR TITLE
PHOENIX-7664 Remove EmptyColumnOnlyFilter and FirstKeyOnlyFilter for CDC scanners

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
@@ -160,7 +160,7 @@ abstract public class BaseScannerRegionObserver implements RegionObserver {
             byte[] cdcScan = scan.getAttribute(CDC_DATA_TABLE_DEF);
             if (cdcScan != null) {
                 CDCUtil.setupScanForCDC(scan);
-                ScanUtil.adjustScanFilterForGlobalIndexRegionScanner(scan);
+                ScanUtil.adjustScanFilterForCDC(scan);
             }
         }
         if (isRegionObserverFor(scan)) {


### PR DESCRIPTION
Jira: PHOENIX-7664

CDC Scanners like other Global index scanners attempt to remove EmptyColumnOnlyFilter and FirstKeyOnlyFilter from the scan, however it is not enough when EmptyColumnOnlyFilter or FirstKeyOnlyFilter is used with other filters e.g. PageFilter with LIMIT.

For CDC queries, the user initiated upsert and delete statements do not face any issues as the scan on the uncovered index is only expected to retrieve empty column cell. However, it does not work when we need to retrieve more cells than just empty column e.g. `_CDC_IMG_` column cell should be returned by the delegate scanner for TTL expired CDC events.

The purpose of this PR is to remove the filters even when they are used in combination with others.