### PR TITLE
PHOENIX-7566 [1/n] HAGroupStoreClient/Manager changes for Consistent HA

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/exception/InvalidClusterRoleTransitionException.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/exception/InvalidClusterRoleTransitionException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.exception;
+
+/**
+ * Exception thrown when attempting an invalid cluster role transition.
+ */
+public class InvalidClusterRoleTransitionException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param msg reason for the exception
+     */
+    public InvalidClusterRoleTransitionException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * @param msg reason for the exception
+     * @param cause the underlying cause
+     */
+    public InvalidClusterRoleTransitionException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/exception/MutationBlockedIOException.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/exception/MutationBlockedIOException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.exception;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED is set
+ * and the current cluster role is ACTIVE_TO_STANDBY.
+ */
+public class MutationBlockedIOException extends IOException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param msg reason for the exception
+     */
+    public MutationBlockedIOException(String msg) {
+        super(msg);
+    }
+
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/exception/StaleHAGroupStoreRecordVersionException.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/exception/StaleHAGroupStoreRecordVersionException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.exception;
+
+/**
+ * Exception thrown when attempting to update HAGroupStoreRecord with a stale ZK stat version,
+ * indicating that the record has been modified by another process.
+ */
+public class StaleHAGroupStoreRecordVersionException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param msg reason for the exception
+     */
+    public StaleHAGroupStoreRecordVersionException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * @param msg reason for the exception
+     * @param cause the underlying cause
+     */
+    public StaleHAGroupStoreRecordVersionException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreClient.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreClient.java
@@ -18,190 +18,400 @@
 package org.apache.phoenix.jdbc;
 
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.phoenix.exception.InvalidClusterRoleTransitionException;
+import org.apache.phoenix.exception.StaleHAGroupStoreRecordVersionException;
 import org.apache.phoenix.thirdparty.com.google.common.annotations.VisibleForTesting;
-import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableList;
+import org.apache.phoenix.thirdparty.com.google.common.base.Preconditions;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.getLocalZkUrl;
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
 
 
 /**
- * Write-through cache for HAGroupStore.
+ * Main implementation of HAGroupStoreClient with peer support.
+ * Write-through cache for HAGroupStore based on {@link HAGroupStoreRecord}.
  * Uses {@link PathChildrenCache} from {@link org.apache.curator.framework.CuratorFramework}.
  */
 public class HAGroupStoreClient implements Closeable {
 
+    public static final String ZK_CONSISTENT_HA_NAMESPACE = "phoenix" + ZKPaths.PATH_SEPARATOR + "consistentHA";
     private static final long HA_GROUP_STORE_CLIENT_INITIALIZATION_TIMEOUT_MS = 30000L;
-    private static volatile HAGroupStoreClient haGroupStoreClientInstance;
+    private static final String CACHE_TYPE_LOCAL = "LOCAL";
+    private static final String CACHE_TYPE_PEER = "PEER";
     private PhoenixHAAdmin phoenixHaAdmin;
+    private PhoenixHAAdmin peerPhoenixHaAdmin;
     private static final Logger LOGGER = LoggerFactory.getLogger(HAGroupStoreClient.class);
-    // Map contains <ClusterRole, Map<HAGroupName(String), ClusterRoleRecord>>
-    private final ConcurrentHashMap<ClusterRoleRecord.ClusterRole, ConcurrentHashMap<String, ClusterRoleRecord>> clusterRoleToCRRMap
-            = new ConcurrentHashMap<>();
-    private PathChildrenCache pathChildrenCache;
-    private volatile boolean isHealthy;
+    // Map of <ZKUrl, <HAGroupName, HAGroupStoreClientInstance>>
+    private static final Map<String, ConcurrentHashMap<String, HAGroupStoreClient>> instances = new ConcurrentHashMap<>();
+    // HAGroupName for this instance
+    private final String haGroupName;
+    // PathChildrenCache for current cluster and HAGroupName
+    private PathChildrenCache pathChildrenCache = null;
+    // PathChildrenCache for peer cluster and HAGroupName
+    private PathChildrenCache peerPathChildrenCache = null;
+    // Whether the client is healthy
+    private volatile boolean isHealthy = false;
+    // Configuration
+    private final Configuration conf;
+    // Peer ZK URL for peer cluster and HAGroupName
+    private String peerZKUrl = null;
+    // Peer Custom Event Listener
+    private final PathChildrenCacheListener peerCustomPathChildrenCacheListener;
+
 
     /**
      * Creates/gets an instance of HAGroupStoreClient.
      * Can return null instance if unable to initialize.
      *
      * @param conf configuration
+     * @param haGroupName name of the HA group. Only specified HA group is tracked.
      * @return HAGroupStoreClient instance
      */
-    public static HAGroupStoreClient getInstance(Configuration conf) {
-        if (haGroupStoreClientInstance == null || !haGroupStoreClientInstance.isHealthy) {
+    public static HAGroupStoreClient getInstance(Configuration conf, String haGroupName) {
+        Preconditions.checkNotNull(haGroupName, "haGroupName cannot be null");
+        final String zkUrl = getLocalZkUrl(conf);
+        HAGroupStoreClient result = instances.getOrDefault(zkUrl, new ConcurrentHashMap<>()).getOrDefault(haGroupName, null);
+        if (result == null || !result.isHealthy) {
             synchronized (HAGroupStoreClient.class) {
-                if (haGroupStoreClientInstance == null || !haGroupStoreClientInstance.isHealthy) {
-                    haGroupStoreClientInstance = new HAGroupStoreClient(conf, null);
-                    if (!haGroupStoreClientInstance.isHealthy) {
-                        haGroupStoreClientInstance.close();
-                        haGroupStoreClientInstance = null;
+                result = instances.getOrDefault(zkUrl, new ConcurrentHashMap<>()).getOrDefault(haGroupName, null);
+                if (result == null || !result.isHealthy) {
+                    result = new HAGroupStoreClient(conf, null, null, haGroupName);
+                    if (!result.isHealthy) {
+                        result.close();
+                        result = null;
+                    } else {
+                        instances.putIfAbsent(zkUrl, new ConcurrentHashMap<>());
+                        instances.get(zkUrl).put(haGroupName, result);
                     }
                 }
             }
         }
-        return haGroupStoreClientInstance;
+        return result;
+    }
+
+    /**
+     * Get the list of HAGroupNames from the local quorum.
+     *
+     * @param conf the configuration
+     * @return the list of HAGroupNames
+     * @throws IOException in case of unexpected error
+     */
+    public static List<String> getHAGroupNames(Configuration conf) throws IOException {
+        try (PhoenixHAAdmin phoenixHaAdmin = new PhoenixHAAdmin(conf, ZK_CONSISTENT_HA_NAMESPACE)) {
+            return phoenixHaAdmin.getHAGroupNames();
+        }
     }
 
     @VisibleForTesting
-    HAGroupStoreClient(final Configuration conf, final PathChildrenCacheListener pathChildrenCacheListener) {
+    HAGroupStoreClient(final Configuration conf, final PathChildrenCacheListener pathChildrenCacheListener,
+                       final PathChildrenCacheListener peerPathChildrenCacheListener, final String haGroupName) {
+        this.conf = conf;
+        this.haGroupName = haGroupName;
+        // Custom Event Listener
+        this.peerCustomPathChildrenCacheListener = peerPathChildrenCacheListener;
         try {
-            this.phoenixHaAdmin = new PhoenixHAAdmin(conf);
-            final PathChildrenCache pathChildrenCache;
-                pathChildrenCache = new PathChildrenCache(phoenixHaAdmin.getCurator(), ZKPaths.PATH_SEPARATOR, true);
-            final CountDownLatch latch = new CountDownLatch(1);
-            if (pathChildrenCacheListener != null) {
-                pathChildrenCache.getListenable().addListener(pathChildrenCacheListener);
-            } else {
-                pathChildrenCache.getListenable().addListener((client, event) -> {
-                    LOGGER.info("HAGroupStoreClient PathChildrenCache Received event for type {}", event.getType());
-                    final ChildData childData = event.getData();
-                    ClusterRoleRecord eventCRR = extractCRROrNull(childData);
-                    switch (event.getType()) {
-                        case CHILD_ADDED:
-                        case CHILD_UPDATED:
-                            if (eventCRR != null && eventCRR.getHaGroupName() != null) {
-                                updateClusterRoleRecordMap(eventCRR);
-                            }
-                            break;
-                        case CHILD_REMOVED:
-                            // In case of CHILD_REMOVED, we get the old version of data that was just deleted in event.
-                            if (eventCRR != null && eventCRR.getHaGroupName() != null
-                                    && !eventCRR.getHaGroupName().isEmpty()
-                                    && eventCRR.getRole(phoenixHaAdmin.getZkUrl()) != null) {
-                                LOGGER.info("Received CHILD_REMOVED event, Removing CRR {} from existing CRR Map {}", eventCRR, clusterRoleToCRRMap);
-                                final ClusterRoleRecord.ClusterRole role = eventCRR.getRole(phoenixHaAdmin.getZkUrl());
-                                clusterRoleToCRRMap.putIfAbsent(role, new ConcurrentHashMap<>());
-                                clusterRoleToCRRMap.get(role).remove(eventCRR.getHaGroupName());
-                            }
-                            break;
-                        case INITIALIZED:
-                            latch.countDown();
-                            break;
-                        case CONNECTION_LOST:
-                        case CONNECTION_SUSPENDED:
-                            isHealthy = false;
-                            break;
-                        case CONNECTION_RECONNECTED:
-                            isHealthy = true;
-                            break;
-                        default:
-                            LOGGER.warn("Unexpected event type {}, complete event {}", event.getType(), event);
-                    }
-                });
+            // Initialize local cache
+            this.phoenixHaAdmin = new PhoenixHAAdmin(conf, ZK_CONSISTENT_HA_NAMESPACE);
+            this.pathChildrenCache = initializePathChildrenCache(phoenixHaAdmin, pathChildrenCacheListener, CACHE_TYPE_LOCAL);
+            if (this.pathChildrenCache != null) {
+                this.isHealthy = true;
+                maybeInitializePeerPathChildrenCache(fetchCacheRecord(this.pathChildrenCache, CACHE_TYPE_PEER).getLeft());
             }
-            pathChildrenCache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
-            this.pathChildrenCache = pathChildrenCache;
-            isHealthy = latch.await(HA_GROUP_STORE_CLIENT_INITIALIZATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-            buildClusterRoleToCRRMap();
         } catch (Exception e) {
-            isHealthy = false;
+            this.isHealthy = false;
+            close();
             LOGGER.error("Unexpected error occurred while initializing HAGroupStoreClient, marking cache as unhealthy", e);
         }
     }
 
-    private ClusterRoleRecord extractCRROrNull(final ChildData childData) {
+    private void maybeInitializePeerPathChildrenCache(HAGroupStoreRecord haGroupStoreRecord) {
+        if (haGroupStoreRecord != null
+                && StringUtils.isNotBlank(haGroupStoreRecord.getPeerZKUrl())) {
+            try {
+                String newPeerZKUrl = haGroupStoreRecord.getPeerZKUrl();
+                // Setup peer connection if needed (first time or URL changed)
+                if (peerPathChildrenCache == null || !StringUtils.equals(newPeerZKUrl, peerZKUrl)) {
+                    // Clean up existing peer connection if it exists
+                    closePeerConnection();
+                    // Setup new peer connection
+                    this.peerZKUrl = newPeerZKUrl;
+                    this.peerPhoenixHaAdmin
+                            = new PhoenixHAAdmin(this.peerZKUrl, conf, ZK_CONSISTENT_HA_NAMESPACE);
+                    // Create new PeerPathChildrenCache
+                    this.peerPathChildrenCache = initializePathChildrenCache(peerPhoenixHaAdmin,
+                            this.peerCustomPathChildrenCacheListener, CACHE_TYPE_PEER);
+                }
+            } catch (Exception e) {
+                closePeerConnection();
+                LOGGER.error("Unable to initialize PeerPathChildrenCache for HAGroupStoreClient", e);
+                // Don't think we should mark HAGroupStoreClient as unhealthy if
+                // peerCache is unhealthy, if needed we can introduce a config to control behavior.
+            }
+        } else {
+            // Close Peer Cache for this HAGroupName if currentClusterRecord is null or peerZKUrl is blank
+            closePeerConnection();
+            LOGGER.error("Not initializing PeerPathChildrenCache for HAGroupStoreClient with HAGroupName {}", haGroupName);
+        }
+    }
+
+    private PathChildrenCache initializePathChildrenCache(PhoenixHAAdmin admin, PathChildrenCacheListener customListener, String cacheType) {
+        LOGGER.info("Initializing {} PathChildrenCache", cacheType);
+        PathChildrenCache newPathChildrenCache = null;
+        try {
+            newPathChildrenCache = new PathChildrenCache(admin.getCurator(), ZKPaths.PATH_SEPARATOR, true);
+            final CountDownLatch latch = new CountDownLatch(1);
+            newPathChildrenCache.getListenable().addListener(customListener != null
+                    ? customListener
+                    : createCacheListener(latch, cacheType, haGroupName));
+            newPathChildrenCache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
+            boolean initialized = latch.await(HA_GROUP_STORE_CLIENT_INITIALIZATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            return initialized ? newPathChildrenCache : null;
+        } catch (Exception e) {
+            if (newPathChildrenCache != null) {
+                try {
+                    newPathChildrenCache.close();
+                } catch (IOException ioe) {
+                    LOGGER.error("Failed to close {} PathChildrenCache", cacheType, ioe);
+                }
+            }
+            LOGGER.error("Failed to initialize {} PathChildrenCache", cacheType, e);
+            return null;
+        }
+    }
+
+    private PathChildrenCacheListener createCacheListener(CountDownLatch latch, String cacheType, String haGroupName) {
+        return (client, event) -> {
+            final ChildData childData = event.getData();
+            HAGroupStoreRecord eventRecord = extractHAGroupStoreRecordOrNull(childData);
+            LOGGER.info("HAGroupStoreClient Cache {} received event {} type {} at {}", cacheType, eventRecord, event.getType(), System.currentTimeMillis());
+            switch (event.getType()) {
+                case CHILD_ADDED:
+                case CHILD_UPDATED:
+                    if (eventRecord != null
+                            && eventRecord.getHaGroupName() != null
+                            && eventRecord.getHaGroupName().equals(haGroupName)) {
+                        maybeInitializePeerPathChildrenCache(eventRecord);
+                    }
+                    break;
+                case CHILD_REMOVED:
+                    // In case of CHILD_REMOVED, we get the old version of data that was just deleted in event.
+                    if (eventRecord != null && eventRecord.getHaGroupName() != null
+                            && !eventRecord.getHaGroupName().isEmpty()
+                            && eventRecord.getClusterRole() != null
+                            && eventRecord.getHaGroupName().equals(haGroupName)) {
+                        if (CACHE_TYPE_LOCAL.equals(cacheType)) {
+                            LOGGER.info("Received CHILD_REMOVED event for {}, Closing PeerCache", cacheType);
+                            closePeerConnection();
+                        }
+                    }
+                    break;
+                case INITIALIZED:
+                    latch.countDown();
+                    break;
+                case CONNECTION_LOST:
+                case CONNECTION_SUSPENDED:
+                    if (CACHE_TYPE_LOCAL.equals(cacheType)) {
+                        isHealthy = false;
+                    }
+                    LOGGER.warn("{} HAGroupStoreClient cache connection lost/suspended", cacheType);
+                    break;
+                case CONNECTION_RECONNECTED:
+                    if (CACHE_TYPE_LOCAL.equals(cacheType)) {
+                        isHealthy = true;
+                    }
+                    LOGGER.info("{} HAGroupStoreClient cache connection reconnected", cacheType);
+                    break;
+                default:
+                    LOGGER.warn("Unexpected {} event type {}, complete event {}", cacheType, event.getType(), event);
+            }
+        };
+    }
+
+
+    private Pair<HAGroupStoreRecord, Stat> fetchCacheRecord(PathChildrenCache cache, String cacheType) {
+        String targetPath = toPath(this.haGroupName);
+        ChildData childData = cache.getCurrentData(targetPath);
+
+        if (childData != null) {
+            HAGroupStoreRecord record = extractHAGroupStoreRecordOrNull(childData);
+            Stat currentStat = cache.getCurrentData(targetPath).getStat();
+            LOGGER.info("Built {} cluster record: {}", cacheType, record);
+            return Pair.of(record, currentStat);
+        } else {
+            LOGGER.info("No record found at path {} for {} cluster", targetPath, cacheType);
+            return Pair.of(null, null);
+        }
+    }
+
+    private HAGroupStoreRecord extractHAGroupStoreRecordOrNull(final ChildData childData) {
         if (childData != null) {
             byte[] data = childData.getData();
-            return ClusterRoleRecord.fromJson(data).orElse(null);
+            return HAGroupStoreRecord.fromJson(data).orElse(null);
         }
         return null;
     }
 
-    private void updateClusterRoleRecordMap(final ClusterRoleRecord crr) {
-        if (crr != null && crr.getHaGroupName() != null && crr.getRole(phoenixHaAdmin.getZkUrl()) != null) {
-            ClusterRoleRecord.ClusterRole role = crr.getRole(phoenixHaAdmin.getZkUrl());
-            LOGGER.info("Updating Existing CRR Map {} with new CRR {}", clusterRoleToCRRMap, crr);
-            clusterRoleToCRRMap.putIfAbsent(role, new ConcurrentHashMap<>());
-            clusterRoleToCRRMap.get(role).put(crr.getHaGroupName(), crr);
-            LOGGER.info("Added new CRR {} to CRR Map", crr);
-            // Remove any pre-existing mapping with any other role for this HAGroupName
-            for (ClusterRoleRecord.ClusterRole mapRole : clusterRoleToCRRMap.keySet()) {
-                if (mapRole != role) {
-                    ConcurrentHashMap<String, ClusterRoleRecord> roleWiseMap = clusterRoleToCRRMap.get(mapRole);
-                    if (roleWiseMap.containsKey(crr.getHaGroupName())) {
-                        LOGGER.info("Removing any pre-existing mapping with role {} for HAGroupName {}", mapRole, crr.getHaGroupName());
-                        roleWiseMap.remove(crr.getHaGroupName());
-                    }
-                }
-            }
-            LOGGER.info("Final Updated CRR Map {}", clusterRoleToCRRMap);
-        }
-    }
-
-    private void buildClusterRoleToCRRMap() {
-        List<ClusterRoleRecord> clusterRoleRecords = pathChildrenCache.getCurrentData().stream().map(this::extractCRROrNull)
-                .filter(Objects::nonNull).collect(Collectors.toList());
-        for (ClusterRoleRecord crr : clusterRoleRecords) {
-            updateClusterRoleRecordMap(crr);
-        }
-    }
-
+    /**
+     * Rebuilds the internal cache by querying for all needed data.
+     * This is a blocking operation that does not generate events to listeners.
+     *
+     * @throws Exception if rebuild fails or client is not healthy
+     */
     public void rebuild() throws Exception {
         if (!isHealthy) {
             throw new IOException("HAGroupStoreClient is not healthy");
         }
-        LOGGER.info("Rebuilding HAGroupStoreClient for HA groups");
+        LOGGER.info("Rebuilding HAGroupStoreClient for HA group {}", haGroupName);
         // NOTE: this is a BLOCKING method.
         // Completely rebuild the internal cache by querying for all needed data
         // WITHOUT generating any events to send to listeners.
-        pathChildrenCache.rebuild();
-        buildClusterRoleToCRRMap();
-        LOGGER.info("Rebuild Complete for HAGroupStoreClient");
+        if (pathChildrenCache != null) {
+            pathChildrenCache.rebuild();
+        }
+        if (peerPathChildrenCache != null) {
+            peerPathChildrenCache.rebuild();
+        }
+        LOGGER.info("Rebuild Complete for HAGroupStoreClient for HA group {}", haGroupName);
     }
 
+
+    /**
+     * Closes the peer connection and cleans up peer-related resources.
+     */
+    private void closePeerConnection() {
+        try {
+            if (peerPathChildrenCache != null) {
+                peerPathChildrenCache.close();
+                peerPathChildrenCache = null;
+            }
+            if (peerPhoenixHaAdmin != null) {
+                peerPhoenixHaAdmin.close();
+                peerPhoenixHaAdmin = null;
+            }
+            peerZKUrl = null;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to close peer connection", e);
+        }
+    }
 
     @Override
     public void close() {
         try {
             LOGGER.info("Closing HAGroupStoreClient");
-            clusterRoleToCRRMap.clear();
             if (pathChildrenCache != null) {
                 pathChildrenCache.close();
+                pathChildrenCache = null;
             }
+            closePeerConnection();
             LOGGER.info("Closed HAGroupStoreClient");
         } catch (IOException e) {
             LOGGER.error("Exception closing HAGroupStoreClient", e);
         }
     }
 
-    public List<ClusterRoleRecord> getCRRsByClusterRole(ClusterRoleRecord.ClusterRole clusterRole) throws IOException {
+    /**
+     * Get HAGroupStoreRecord from local quorum.
+     *
+     * @return HAGroupStoreRecord for the specified HA group name, or null if not found
+     * @throws IOException if the client is not healthy
+     */
+    public HAGroupStoreRecord getHAGroupStoreRecord() throws IOException {
         if (!isHealthy) {
             throw new IOException("HAGroupStoreClient is not healthy");
         }
-        return ImmutableList.copyOf(clusterRoleToCRRMap.getOrDefault(clusterRole, new ConcurrentHashMap<>()).values());
+        return fetchCacheRecord(this.pathChildrenCache, CACHE_TYPE_LOCAL).getLeft();
     }
+
+    /**
+     * Set the HA group status for the specified HA group name.
+     * Checks if the status is needed to be upserted based on logic in {@link #isUpsertNeeded(HAGroupStoreRecord, ClusterRoleRecord.ClusterRole)}.
+     *
+     * @param clusterRole the cluster role to set
+     * @throws IOException if the client is not healthy or the operation fails
+     * @throws StaleHAGroupStoreRecordVersionException if the version is stale
+     * @throws InvalidClusterRoleTransitionException
+     */
+    public void setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole clusterRole)
+            throws IOException, StaleHAGroupStoreRecordVersionException, InvalidClusterRoleTransitionException {
+        if (!isHealthy) {
+            throw new IOException("HAGroupStoreClient is not healthy");
+        }
+        Pair<HAGroupStoreRecord, Stat> cacheRecord = fetchCacheRecord(this.pathChildrenCache, CACHE_TYPE_LOCAL);
+        HAGroupStoreRecord currentHAGroupStoreRecord = cacheRecord.getLeft();
+        Stat currentHAGroupStoreRecordStat = cacheRecord.getRight();
+        if (isUpsertNeeded(currentHAGroupStoreRecord, clusterRole)) {
+            if (currentHAGroupStoreRecord == null) {
+                HAGroupStoreRecord recordFromSystemTable = fetchHAGroupStoreRecordFromSystemTable(haGroupName);
+                if (recordFromSystemTable == null) {
+                    throw new IOException("HAGroupStoreRecord not found in system table for HA group " + haGroupName);
+                }
+                HAGroupStoreRecord newHAGroupStoreRecord = new HAGroupStoreRecord(
+                        recordFromSystemTable.getProtocolVersion(),
+                        recordFromSystemTable.getHaGroupName(),
+                        clusterRole,
+                        1,
+                        recordFromSystemTable.getPolicy(),
+                        System.currentTimeMillis(),
+                        recordFromSystemTable.getPeerZKUrl()
+                );
+                phoenixHaAdmin.createHAGroupStoreRecordInZooKeeper(newHAGroupStoreRecord);
+            } else {
+                if (currentHAGroupStoreRecordStat == null) {
+                    throw new IOException("Current HAGroupStoreRecordStat in cache is null, cannot update HAGroupStoreRecord " + haGroupName);
+                }
+                HAGroupStoreRecord newHAGroupStoreRecord = new HAGroupStoreRecord(
+                        currentHAGroupStoreRecord.getProtocolVersion(),
+                        currentHAGroupStoreRecord.getHaGroupName(),
+                        clusterRole,
+                        currentHAGroupStoreRecord.getVersion() + 1,
+                        currentHAGroupStoreRecord.getPolicy(),
+                        System.currentTimeMillis(),
+                        currentHAGroupStoreRecord.getPeerZKUrl()
+                );
+                phoenixHaAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName,
+                        newHAGroupStoreRecord, currentHAGroupStoreRecordStat.getVersion());
+            }
+        }
+    }
+
+    private HAGroupStoreRecord fetchHAGroupStoreRecordFromSystemTable(String haGroupName) {
+        //TODO: Get record from System Table
+        return null;
+    }
+
+    /**
+     * Checks if the HAGroupStoreRecord needs to be updated.
+     * If the current HAGroupStoreRecord is null, it needs to be created.
+     * If the current HAGroupStoreRecord is not null, it needs to be updated if the cluster role is different or the status refresh interval has expired.
+     *
+     * @param currentHAGroupStoreRecord the HAGroupStoreRecord to check
+     * @param newClusterRole the cluster role to check
+     * @return true if the HAGroupStoreRecord needs to be updated, false otherwise
+     * @throws InvalidClusterRoleTransitionException if the cluster role transition is invalid
+     */
+    private boolean isUpsertNeeded(HAGroupStoreRecord currentHAGroupStoreRecord, ClusterRoleRecord.ClusterRole newClusterRole) throws InvalidClusterRoleTransitionException {
+        return currentHAGroupStoreRecord == null
+                || (currentHAGroupStoreRecord.getClusterRole() != null
+                && ((System.currentTimeMillis() - currentHAGroupStoreRecord.getLastUpdatedTimeInMs())
+                > currentHAGroupStoreRecord.getClusterRole().checkTransitionAndGetWaitTime(newClusterRole, conf)));
+    }
+
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreClientV1.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreClientV1.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.phoenix.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.phoenix.thirdparty.com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.getLocalZkUrl;
+
+
+/**
+ * V1 implementation of HAGroupStoreClient without peer support.
+ * This class is kept for backward compatibility and supports {@link ClusterRoleRecord}.
+ * Users should favor {@link HAGroupStoreClient} implementation.
+ * Write-through cache for HAGroupStore.
+ * Uses {@link PathChildrenCache} from {@link org.apache.curator.framework.CuratorFramework}.
+ */
+public class HAGroupStoreClientV1 implements Closeable {
+
+    private static final long HA_GROUP_STORE_CLIENT_INITIALIZATION_TIMEOUT_MS = 30000L;
+    private static volatile HAGroupStoreClientV1 haGroupStoreClientInstance;
+    private PhoenixHAAdmin phoenixHaAdmin;
+    private static final Logger LOGGER = LoggerFactory.getLogger(HAGroupStoreClientV1.class);
+    // Map contains <ClusterRole, Map<HAGroupName(String), ClusterRoleRecord>>
+    private final ConcurrentHashMap<ClusterRoleRecord.ClusterRole, ConcurrentHashMap<String, ClusterRoleRecord>> clusterRoleToCRRMap
+            = new ConcurrentHashMap<>();
+    private PathChildrenCache pathChildrenCache;
+    private volatile boolean isHealthy;
+    private static final Map<String, HAGroupStoreClientV1> instances = new ConcurrentHashMap<>();
+
+    /**
+     * Creates/gets an instance of HAGroupStoreClient.
+     * Can return null instance if unable to initialize.
+     *
+     * @param conf configuration
+     * @return HAGroupStoreClient instance
+     */
+    public static HAGroupStoreClientV1 getInstance(Configuration conf) {
+        final String zkUrl = getLocalZkUrl(conf);
+        HAGroupStoreClientV1 result = instances.get(zkUrl);
+        if (result == null || !result.isHealthy) {
+            synchronized (HAGroupStoreClient.class) {
+                result = instances.get(zkUrl);
+                if (result == null || !result.isHealthy) {
+                    result = new HAGroupStoreClientV1(conf, null);
+                    if (!result.isHealthy) {
+                        result.close();
+                        result = null;
+                    }
+                    instances.put(zkUrl, result);
+                }
+            }
+        }
+        return result;
+    }
+
+    @VisibleForTesting
+    HAGroupStoreClientV1(final Configuration conf, final PathChildrenCacheListener pathChildrenCacheListener) {
+        try {
+            this.phoenixHaAdmin = new PhoenixHAAdmin(conf);
+            final PathChildrenCache pathChildrenCache;
+            pathChildrenCache = new PathChildrenCache(phoenixHaAdmin.getCurator(), ZKPaths.PATH_SEPARATOR, true);
+            final CountDownLatch latch = new CountDownLatch(1);
+            if (pathChildrenCacheListener != null) {
+                pathChildrenCache.getListenable().addListener(pathChildrenCacheListener);
+            } else {
+                pathChildrenCache.getListenable().addListener((client, event) -> {
+                    LOGGER.info("HAGroupStoreClientV1 PathChildrenCache Received event for type {}", event.getType());
+                    final ChildData childData = event.getData();
+                    ClusterRoleRecord eventCRR = extractCRROrNull(childData);
+                    switch (event.getType()) {
+                        case CHILD_ADDED:
+                        case CHILD_UPDATED:
+                            if (eventCRR != null && eventCRR.getHaGroupName() != null) {
+                                updateClusterRoleRecordMap(eventCRR);
+                            }
+                            break;
+                        case CHILD_REMOVED:
+                            // In case of CHILD_REMOVED, we get the old version of data that was just deleted in event.
+                            if (eventCRR != null && eventCRR.getHaGroupName() != null
+                                    && !eventCRR.getHaGroupName().isEmpty()
+                                    && eventCRR.getRole(phoenixHaAdmin.getZkUrl()) != null) {
+                                LOGGER.info("Received CHILD_REMOVED event, Removing CRR {} from existing CRR Map {}", eventCRR, clusterRoleToCRRMap);
+                                final ClusterRoleRecord.ClusterRole role = eventCRR.getRole(phoenixHaAdmin.getZkUrl());
+                                clusterRoleToCRRMap.putIfAbsent(role, new ConcurrentHashMap<>());
+                                clusterRoleToCRRMap.get(role).remove(eventCRR.getHaGroupName());
+                            }
+                            break;
+                        case INITIALIZED:
+                            latch.countDown();
+                            break;
+                        case CONNECTION_LOST:
+                        case CONNECTION_SUSPENDED:
+                            isHealthy = false;
+                            break;
+                        case CONNECTION_RECONNECTED:
+                            isHealthy = true;
+                            break;
+                        default:
+                            LOGGER.warn("Unexpected event type {}, complete event {}", event.getType(), event);
+                    }
+                });
+            }
+            pathChildrenCache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
+            this.pathChildrenCache = pathChildrenCache;
+            isHealthy = latch.await(HA_GROUP_STORE_CLIENT_INITIALIZATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            buildClusterRoleToCRRMap();
+        } catch (Exception e) {
+            isHealthy = false;
+            LOGGER.error("Unexpected error occurred while initializing HAGroupStoreClientV1, marking cache as unhealthy", e);
+        }
+    }
+
+    private ClusterRoleRecord extractCRROrNull(final ChildData childData) {
+        if (childData != null) {
+            byte[] data = childData.getData();
+            return ClusterRoleRecord.fromJson(data).orElse(null);
+        }
+        return null;
+    }
+
+    private void updateClusterRoleRecordMap(final ClusterRoleRecord crr) {
+        if (crr != null && crr.getHaGroupName() != null && crr.getRole(phoenixHaAdmin.getZkUrl()) != null) {
+            ClusterRoleRecord.ClusterRole role = crr.getRole(phoenixHaAdmin.getZkUrl());
+            LOGGER.info("Updating Existing CRR Map {} with new CRR {}", clusterRoleToCRRMap, crr);
+            clusterRoleToCRRMap.putIfAbsent(role, new ConcurrentHashMap<>());
+            clusterRoleToCRRMap.get(role).put(crr.getHaGroupName(), crr);
+            LOGGER.info("Added new CRR {} to CRR Map", crr);
+            // Remove any pre-existing mapping with any other role for this HAGroupName
+            for (ClusterRoleRecord.ClusterRole mapRole : clusterRoleToCRRMap.keySet()) {
+                if (mapRole != role) {
+                    ConcurrentHashMap<String, ClusterRoleRecord> roleWiseMap = clusterRoleToCRRMap.get(mapRole);
+                    if (roleWiseMap.containsKey(crr.getHaGroupName())) {
+                        LOGGER.info("Removing any pre-existing mapping with role {} for HAGroupName {}", mapRole, crr.getHaGroupName());
+                        roleWiseMap.remove(crr.getHaGroupName());
+                    }
+                }
+            }
+            LOGGER.info("Final Updated CRR Map {}", clusterRoleToCRRMap);
+        }
+    }
+
+    private void buildClusterRoleToCRRMap() {
+        List<ClusterRoleRecord> clusterRoleRecords = pathChildrenCache.getCurrentData().stream().map(this::extractCRROrNull)
+                .filter(Objects::nonNull).collect(Collectors.toList());
+        for (ClusterRoleRecord crr : clusterRoleRecords) {
+            updateClusterRoleRecordMap(crr);
+        }
+    }
+
+    /**
+     * Rebuilds the internal cache by querying for all needed data.
+     * This is a blocking operation that does not generate events to listeners.
+     *
+     * @throws Exception if rebuild fails or client is not healthy
+     */
+    public void rebuild() throws Exception {
+        if (!isHealthy) {
+            throw new IOException("HAGroupStoreClientV1 is not healthy");
+        }
+        LOGGER.info("Rebuilding HAGroupStoreClientV1 for HA groups");
+        // NOTE: this is a BLOCKING method.
+        // Completely rebuild the internal cache by querying for all needed data
+        // WITHOUT generating any events to send to listeners.
+        pathChildrenCache.rebuild();
+        buildClusterRoleToCRRMap();
+        LOGGER.info("Rebuild Complete for HAGroupStoreClientV1");
+    }
+
+
+    @Override
+    public void close() {
+        try {
+            LOGGER.info("Closing HAGroupStoreClientV1");
+            clusterRoleToCRRMap.clear();
+            if (pathChildrenCache != null) {
+                pathChildrenCache.close();
+            }
+            LOGGER.info("Closed HAGroupStoreClientV1");
+        } catch (IOException e) {
+            LOGGER.error("Exception closing HAGroupStoreClientV1", e);
+        }
+    }
+
+    /**
+     * Gets cluster role records by cluster role.
+     *
+     * @param clusterRole the cluster role to filter by
+     * @return list of cluster role records for the specified role
+     * @throws IOException if client is not healthy or operation fails
+     */
+    public List<ClusterRoleRecord> getCRRsByClusterRole(ClusterRoleRecord.ClusterRole clusterRole) throws IOException {
+        if (!isHealthy) {
+            throw new IOException("HAGroupStoreClientV1 is not healthy");
+        }
+        return ImmutableList.copyOf(clusterRoleToCRRMap.getOrDefault(clusterRole, new ConcurrentHashMap<>()).values());
+    }
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreManager.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreManager.java
@@ -18,63 +18,78 @@
 package org.apache.phoenix.jdbc;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.phoenix.exception.InvalidClusterRoleTransitionException;
+import org.apache.phoenix.exception.StaleHAGroupStoreRecordVersionException;
+
 import java.io.IOException;
-import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
-import static org.apache.phoenix.query.QueryServicesOptions.DEFAULT_CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
+import java.util.Optional;
 
-public class HAGroupStoreManager {
-    private static volatile HAGroupStoreManager haGroupStoreManagerInstance;
-    private final boolean mutationBlockEnabled;
-    private final Configuration conf;
-
-    /**
-     * Creates/gets an instance of HAGroupStoreManager.
-     *
-     * @param conf configuration
-     * @return HAGroupStoreManager instance
-     */
-    public static HAGroupStoreManager getInstance(Configuration conf) {
-        if (haGroupStoreManagerInstance == null) {
-            synchronized (HAGroupStoreManager.class) {
-                if (haGroupStoreManagerInstance == null) {
-                    haGroupStoreManagerInstance = new HAGroupStoreManager(conf);
-                }
-            }
-        }
-        return haGroupStoreManagerInstance;
-    }
-
-    private HAGroupStoreManager(final Configuration conf) {
-        this.mutationBlockEnabled = conf.getBoolean(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED,
-                DEFAULT_CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED);
-        this.conf = conf;
-    }
+/**
+ * Interface for managing HA group store operations including mutation blocking checks
+ * and client invalidation.
+ */
+public interface HAGroupStoreManager {
 
     /**
-     * Checks whether mutation is blocked or not.
+     * Checks whether mutation is blocked or not across all HA groups.
+     * If any HAGroupStoreClient instance is not created, it will be created.
+     * If any HAGroup mutation is blocked, it will return true.
      * @throws IOException when HAGroupStoreClient is not healthy.
      */
-    public boolean isMutationBlocked() throws IOException {
-        if (mutationBlockEnabled) {
-            HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(conf);
-            if (haGroupStoreClient != null) {
-                return !haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
-            }
-            throw new IOException("HAGroupStoreClient is not initialized");
-        }
-        return false;
-    }
+    boolean isMutationBlocked(Configuration conf) throws IOException;
 
     /**
-     * Force rebuilds the HAGroupStoreClient
+     * Checks whether mutation is blocked or not for a specific HA group.
+     *
+     * @param conf
+     * @param haGroupName name of the HA group, null for default HA group which tracks all HA groups.
+     * @return true if mutation is blocked, false otherwise.
+     * @throws IOException when HAGroupStoreClient is not healthy.
+     */
+    boolean isMutationBlocked(Configuration conf, String haGroupName) throws IOException;
+
+    /**
+     * Force rebuilds the HAGroupStoreClient instance for all HA groups.
+     * If any HAGroupStoreClient instance is not created, it will be created.
      * @throws Exception
      */
-    public void invalidateHAGroupStoreClient() throws Exception {
-        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(conf);
-        if (haGroupStoreClient != null) {
-            haGroupStoreClient.rebuild();
-        } else {
-            throw new IOException("HAGroupStoreClient is not initialized");
-        }
-    }
+    void invalidateHAGroupStoreClient(Configuration conf) throws Exception;
+
+    /**
+     * Force rebuilds the HAGroupStoreClient for a specific HA group.
+     *
+     * @param conf
+     * @param haGroupName name of the HA group, null for default HA group and tracks all HA groups.
+     * @throws Exception
+     */
+    void invalidateHAGroupStoreClient(Configuration conf, String haGroupName) throws Exception;
+
+    /**
+     * Returns the HAGroupStoreRecord for a specific HA group.
+     *
+     * @param conf
+     * @param haGroupName name of the HA group
+     * @return Optional HAGroupStoreRecord for the HA group, can be empty if the HA group is not found.
+     * @throws IOException when HAGroupStoreClient is not healthy.
+     */
+    Optional<HAGroupStoreRecord> getHAGroupStoreRecord(Configuration conf, String haGroupName) throws IOException;
+
+    /**
+     * Sets the HAGroupStoreRecord to StoreAndForward mode in local cluster.
+     *
+     * @param conf
+     * @param haGroupName name of the HA group
+     * @throws IOException when HAGroupStoreClient is not healthy.
+     */
+    void setHAGroupStatusToStoreAndForward(Configuration conf, String haGroupName) throws IOException, StaleHAGroupStoreRecordVersionException, InvalidClusterRoleTransitionException;
+
+    /**
+     * Sets the HAGroupStoreRecord to Sync mode in local cluster.
+     *
+     * @param conf
+     * @param haGroupName name of the HA group
+     * @throws IOException when HAGroupStoreClient is not healthy.
+     */
+    void setHAGroupStatusRecordToSync(Configuration conf, String haGroupName) throws IOException, StaleHAGroupStoreRecordVersionException, InvalidClusterRoleTransitionException;
+
 }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreManagerFactory.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreManagerFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.getLocalZkUrl;
+import static org.apache.phoenix.query.QueryServices.HA_GROUP_STORE_MANAGER_IMPL_CLASS;
+import static org.apache.phoenix.query.QueryServicesOptions.DEFAULT_HA_GROUP_STORE_MANAGER_IMPL_CLASS;
+
+/**
+ * Factory class for creating HAGroupStoreManager instances.
+ */
+public class HAGroupStoreManagerFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HAGroupStoreManagerFactory.class);
+
+    private static final Map<String, HAGroupStoreManager> INSTANCES = new ConcurrentHashMap<>();
+
+    /**
+     * Creates/gets an instance of HAGroupStoreManager.
+     * Returns empty optional if configuration zk url is null/invalid.
+     * Provides unique instance for each ZK URL
+     *
+     * @param conf configuration
+     * @return HAGroupStoreManager instance
+     */
+    public static Optional<HAGroupStoreManager> getInstance(Configuration conf) {
+        String zkUrl;
+        try {
+            zkUrl = getLocalZkUrl(conf);
+        } catch (Exception e) {
+            LOGGER.error("Error getting local ZK URL", e);
+            return Optional.empty();
+        }
+        if (StringUtils.isBlank(zkUrl)) {
+            return Optional.empty();
+        }
+        HAGroupStoreManager result = INSTANCES.get(zkUrl);
+        if (result == null) {
+            synchronized (HAGroupStoreManagerFactory.class) {
+                result = INSTANCES.get(zkUrl);
+                if (result == null) {
+                    result = createInstance(conf);
+                    if (result != null) {
+                        INSTANCES.put(zkUrl, result);
+                    }
+                }
+            }
+        }
+        return Optional.ofNullable(result);
+    }
+
+    private static HAGroupStoreManager createInstance(Configuration conf) {
+        String implClassName = conf.get(HA_GROUP_STORE_MANAGER_IMPL_CLASS, DEFAULT_HA_GROUP_STORE_MANAGER_IMPL_CLASS);
+
+        try {
+            Class<?> implClass = Class.forName(implClassName);
+
+            // Validate that the class implements HAGroupStoreManager
+            if (!HAGroupStoreManager.class.isAssignableFrom(implClass)) {
+                throw new IllegalArgumentException("Class " + implClassName + " does not implement HAGroupStoreManager interface");
+            }
+
+            // Create instance using constructor that takes Configuration
+            return (HAGroupStoreManager) implClass.getConstructor(Configuration.class).newInstance(conf);
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to create HAGroupStoreManager implementation: " + implClassName, e);
+            return null;
+        }
+    }
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreManagerImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreManagerImpl.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.phoenix.exception.InvalidClusterRoleTransitionException;
+import org.apache.phoenix.exception.StaleHAGroupStoreRecordVersionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
+import static org.apache.phoenix.query.QueryServicesOptions.DEFAULT_CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
+
+/**
+ * Main implementation of HAGroupStoreManager that uses HAGroupStoreClient.
+ */
+public class HAGroupStoreManagerImpl implements HAGroupStoreManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HAGroupStoreManager.class);
+    private final boolean mutationBlockEnabled;
+
+    public HAGroupStoreManagerImpl(final Configuration conf) {
+        this.mutationBlockEnabled = conf.getBoolean(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED,
+                DEFAULT_CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED);
+    }
+
+    @Override
+    public boolean isMutationBlocked(Configuration conf) throws IOException {
+        List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(conf);
+        for (String haGroupName : haGroupNames) {
+            if (isMutationBlocked(conf, haGroupName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isMutationBlocked(Configuration conf, String haGroupName) throws IOException {
+        if (mutationBlockEnabled) {
+            HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(conf, haGroupName);
+            if (haGroupStoreClient != null) {
+                return haGroupStoreClient.getHAGroupStoreRecord() != null
+                        && haGroupStoreClient.getHAGroupStoreRecord().getClusterRole() != null
+                        && haGroupStoreClient.getHAGroupStoreRecord().getClusterRole()
+                        .isMutationBlocked();
+            }
+            throw new IOException("HAGroupStoreClient is not initialized");
+        }
+        return false;
+    }
+
+    @Override
+    public void invalidateHAGroupStoreClient(Configuration conf) throws Exception {
+        List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(conf);
+        List<String> failedHAGroupNames = new ArrayList<>();
+        for (String haGroupName : haGroupNames) {
+            try {
+                invalidateHAGroupStoreClient(conf, haGroupName);
+            } catch (Exception e) {
+                failedHAGroupNames.add(haGroupName);
+                LOGGER.error("Failed to invalidate HAGroupStoreClient for " + haGroupName, e);
+            }
+        }
+        if (!failedHAGroupNames.isEmpty()) {
+            throw new IOException("Failed to invalidate HAGroupStoreClient for " + failedHAGroupNames
+                    + "successfully invalidated HAGroupStoreClient instance for " + haGroupNames.removeAll(failedHAGroupNames) + " HA groups");
+        }
+    }
+
+    @Override
+    public void invalidateHAGroupStoreClient(Configuration conf, final String haGroupName) throws Exception {
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(conf, haGroupName);
+        if (haGroupStoreClient != null) {
+            haGroupStoreClient.rebuild();
+        } else {
+            throw new IOException("HAGroupStoreClient is not initialized");
+        }
+    }
+
+    @Override
+    public Optional<HAGroupStoreRecord> getHAGroupStoreRecord(Configuration conf, final String haGroupName) throws IOException {
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(conf, haGroupName);
+        if (haGroupStoreClient != null) {
+            return Optional.ofNullable(haGroupStoreClient.getHAGroupStoreRecord());
+        }
+        throw new IOException("HAGroupStoreClient is not initialized");
+    }
+
+    @Override
+    public void setHAGroupStatusToStoreAndForward(Configuration conf, final String haGroupName)
+            throws IOException, StaleHAGroupStoreRecordVersionException, InvalidClusterRoleTransitionException {
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(conf, haGroupName);
+        if (haGroupStoreClient != null) {
+            haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.ACTIVE_NOT_IN_SYNC);
+        } else {
+            throw new IOException("HAGroupStoreClient is not initialized");
+        }
+    }
+
+    @Override
+    public void setHAGroupStatusRecordToSync(Configuration conf, final String haGroupName)
+            throws IOException, StaleHAGroupStoreRecordVersionException, InvalidClusterRoleTransitionException {
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(conf, haGroupName);
+        if (haGroupStoreClient != null) {
+            haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.ACTIVE);
+        } else {
+            throw new IOException("HAGroupStoreClient is not initialized");
+        }
+    }
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreManagerV1Impl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreManagerV1Impl.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
+import static org.apache.phoenix.query.QueryServicesOptions.DEFAULT_CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
+
+/**
+ * V1 implementation of HAGroupStoreManager that uses HAGroupStoreClientV1.
+ */
+public class HAGroupStoreManagerV1Impl implements HAGroupStoreManager {
+    private final boolean mutationBlockEnabled;
+
+    public HAGroupStoreManagerV1Impl(final Configuration conf) {
+        this.mutationBlockEnabled = conf.getBoolean(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED,
+                DEFAULT_CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED);
+    }
+
+    /**
+     * Checks whether mutation is blocked or not across all HA groups.
+     * @throws IOException when HAGroupStoreClient is not healthy.
+     */
+    @Override
+    public boolean isMutationBlocked(Configuration conf) throws IOException {
+        return isMutationBlocked(conf, null);
+    }
+
+    /**
+     * Checks whether mutation is blocked or not for a specific HA group.
+     *
+     * @param conf
+     * @param haGroupName name of the HA group, null for default HA group which tracks all HA groups.
+     * @return true if mutation is blocked, false otherwise.
+     * @throws IOException when HAGroupStoreClient is not healthy.
+     */
+    @Override
+    public boolean isMutationBlocked(Configuration conf, String haGroupName) throws IOException {
+        if (mutationBlockEnabled) {
+            HAGroupStoreClientV1 haGroupStoreClient = HAGroupStoreClientV1.getInstance(conf);
+            if (haGroupStoreClient != null) {
+                return !haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+            }
+            throw new IOException("HAGroupStoreClient is not initialized");
+        }
+        return false;
+    }
+
+    /**
+     * Force rebuilds the HAGroupStoreClient instance for all HA group.
+     * @throws Exception
+     */
+    @Override
+    public void invalidateHAGroupStoreClient(Configuration conf) throws Exception {
+        invalidateHAGroupStoreClient(conf, null);
+    }
+
+    /**
+     * Force rebuilds the HAGroupStoreClient for a specific HA group.
+     *
+     * @param conf
+     * @param haGroupName name of the HA group, null for default HA group and tracks all HA groups.
+     * @throws Exception
+     */
+    @Override
+    public void invalidateHAGroupStoreClient(Configuration conf, String haGroupName) throws Exception {
+        HAGroupStoreClientV1 haGroupStoreClient = HAGroupStoreClientV1.getInstance(conf);
+        if (haGroupStoreClient != null) {
+            haGroupStoreClient.rebuild();
+        } else {
+            throw new IOException("HAGroupStoreClient is not initialized");
+        }
+    }
+
+    @Override
+    public Optional<HAGroupStoreRecord> getHAGroupStoreRecord(Configuration conf, String haGroupName) throws IOException {
+        throw new UnsupportedOperationException("HAGroupStoreRecord not supported in HAGroupStoreManagerV1Impl");
+    }
+
+    @Override
+    public void setHAGroupStatusToStoreAndForward(Configuration conf, String haGroupName) throws IOException {
+        throw new UnsupportedOperationException("Setting HAGroupStatus to StoreAndForward is not supported in HAGroupStoreManagerV1Impl");
+    }
+
+    @Override
+    public void setHAGroupStatusRecordToSync(Configuration conf, String haGroupName) throws IOException {
+        throw new UnsupportedOperationException("Setting HAGroupStatusRecord to Sync is not supported in HAGroupStoreManagerV1Impl");
+    }
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreRecord.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreRecord.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.phoenix.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.phoenix.thirdparty.com.google.common.base.Preconditions;
+import org.apache.phoenix.util.JacksonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable class representing an HA group store record with simplified fields.
+ *
+ * This is a simplified version of ClusterRoleRecord that contains essential
+ * information about an HA group only for a single cluster.
+ *
+ * This class is immutable.
+ */
+public class HAGroupStoreRecord {
+    private static final Logger LOG = LoggerFactory.getLogger(HAGroupStoreRecord.class);
+    public static final String DEFAULT_PROTOCOL_VERSION = "1.0";
+
+    private final String protocolVersion;
+    private final String haGroupName;
+    private final ClusterRoleRecord.ClusterRole clusterRole;
+    private final long version;
+    private final String policy;
+    private final long lastUpdatedTimeInMs;
+    private final String peerZKUrl;
+
+    @JsonCreator
+    public HAGroupStoreRecord(@JsonProperty("protocolVersion") String protocolVersion,
+                              @JsonProperty("haGroupName") String haGroupName,
+                              @JsonProperty("clusterRole") ClusterRoleRecord.ClusterRole clusterRole,
+                              @JsonProperty("version") long version,
+                              @JsonProperty("policy") String policy,
+                              @JsonProperty("lastUpdatedTimeInMs") long lastUpdatedTimeInMs,
+                              @JsonProperty("peerZKUrl") String peerZKUrl) {
+        Preconditions.checkNotNull(haGroupName, "HA group name cannot be null!");
+        Preconditions.checkNotNull(clusterRole, "Cluster role cannot be null!");
+        Preconditions.checkNotNull(policy, "Policy cannot be null!");
+
+        this.protocolVersion = Objects.toString(protocolVersion, DEFAULT_PROTOCOL_VERSION);
+        this.haGroupName = haGroupName;
+        this.clusterRole = clusterRole;
+        this.version = version;
+        this.policy = policy;
+        this.lastUpdatedTimeInMs = lastUpdatedTimeInMs;
+        this.peerZKUrl = peerZKUrl;
+    }
+
+    public static Optional<HAGroupStoreRecord> fromJson(byte[] bytes) {
+        if (bytes == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(JacksonUtil.getObjectReader(HAGroupStoreRecord.class).readValue(bytes));
+        } catch (Exception e) {
+            LOG.error("Fail to deserialize data to an HA group store record", e);
+            return Optional.empty();
+        }
+    }
+
+    public static byte[] toJson(HAGroupStoreRecord record) throws IOException {
+        return JacksonUtil.getObjectWriter().writeValueAsBytes(record);
+    }
+
+    /**
+     * @return true if this record is newer than the given record.
+     */
+    public boolean isNewerThan(HAGroupStoreRecord other) {
+        if (other == null) {
+            return true;
+        }
+        return this.hasSameInfo(other) && this.version > other.version;
+    }
+
+    public boolean hasSameInfo(HAGroupStoreRecord other) {
+        return haGroupName.equals(other.haGroupName) &&
+                protocolVersion.equals(other.protocolVersion) &&
+                policy.equals(other.policy);
+    }
+
+    public String getProtocolVersion() {
+        return protocolVersion;
+    }
+
+    public String getHaGroupName() {
+        return haGroupName;
+    }
+
+    public ClusterRoleRecord.ClusterRole getClusterRole() {
+        return clusterRole;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public String getPolicy() {
+        return policy;
+    }
+
+    public long getLastUpdatedTimeInMs() {
+        return lastUpdatedTimeInMs;
+    }
+
+    public String getPeerZKUrl() {
+        return peerZKUrl;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(protocolVersion)
+                .append(haGroupName)
+                .append(clusterRole)
+                .append(version)
+                .append(policy)
+                .append(lastUpdatedTimeInMs)
+                .append(peerZKUrl)
+                .hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        } else if (other == null) {
+            return false;
+        } else if (!(other instanceof HAGroupStoreRecord)) {
+            return false;
+        } else {
+            HAGroupStoreRecord otherRecord = (HAGroupStoreRecord) other;
+            return new EqualsBuilder()
+                    .append(protocolVersion, otherRecord.protocolVersion)
+                    .append(haGroupName, otherRecord.haGroupName)
+                    .append(clusterRole, otherRecord.clusterRole)
+                    .append(version, otherRecord.version)
+                    .append(policy, otherRecord.policy)
+                    .append(lastUpdatedTimeInMs, otherRecord.lastUpdatedTimeInMs)
+                    .append(peerZKUrl, otherRecord.peerZKUrl)
+                    .isEquals();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "HAGroupStoreRecord{"
+                + "protocolVersion='" + protocolVersion + '\''
+                + ", haGroupName='" + haGroupName + '\''
+                + ", clusterRole=" + clusterRole
+                + ", version=" + version
+                + ", policy='" + policy + '\''
+                + ", lastUpdatedTimeInMs=" + lastUpdatedTimeInMs
+                + ", peerZKUrl='" + peerZKUrl + '\''
+                + '}';
+    }
+
+    public String toPrettyString() {
+        try {
+            return JacksonUtil.getObjectWriterPretty().writeValueAsString(this);
+        } catch (Exception e) {
+            LOG.error("Fail to wrap this object as JSON, returning the oneliner using toString", e);
+            return toString();
+        }
+    }
+}

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixHAAdmin.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixHAAdmin.java
@@ -18,6 +18,7 @@
 package org.apache.phoenix.jdbc;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.atomic.AtomicValue;
@@ -26,10 +27,12 @@ import org.apache.curator.utils.ZKPaths;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.util.PairOfSameType;
+import org.apache.phoenix.exception.StaleHAGroupStoreRecordVersionException;
 import org.apache.phoenix.thirdparty.com.google.common.base.Preconditions;
 import org.apache.phoenix.util.JDBCUtil;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,8 +43,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+
+import static org.apache.phoenix.jdbc.HighAvailabilityGroup.PHOENIX_HA_ZOOKEEPER_ZNODE_NAMESPACE;
 
 /**
  * Helper class to update cluster role record for a ZK cluster.
@@ -63,6 +69,13 @@ public class PhoenixHAAdmin implements Closeable {
         public CuratorFramework getCurator(String zkUrl, Properties properties) throws IOException {
             return HighAvailabilityGroup.getCurator(zkUrl, properties);
         }
+
+        /**
+         * Gets curator with specific namespace blocking if necessary to create it
+         */
+        public CuratorFramework getCurator(String zkUrl, Properties properties, String namespace) throws IOException {
+            return HighAvailabilityGroup.getCurator(zkUrl, properties, namespace);
+        }
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(PhoenixHAAdmin.class);
@@ -76,17 +89,29 @@ public class PhoenixHAAdmin implements Closeable {
     /** Curator Provider **/
     private final HighAvailibilityCuratorProvider
             highAvailibilityCuratorProvider;
+    /** Namespace for Curator **/
+    private final String namespace;
 
     public PhoenixHAAdmin(Configuration conf) {
-        this(getLocalZkUrl(conf), conf, HighAvailibilityCuratorProvider.INSTANCE);
+        this(getLocalZkUrl(conf), conf, HighAvailibilityCuratorProvider.INSTANCE, null);
     }
 
-    public PhoenixHAAdmin(String zkUrl, Configuration conf) {
-        this(zkUrl, conf, HighAvailibilityCuratorProvider.INSTANCE);
+    public PhoenixHAAdmin(Configuration conf, String namespace) {
+        this(getLocalZkUrl(conf), conf, HighAvailibilityCuratorProvider.INSTANCE, namespace);
+    }
+
+    public PhoenixHAAdmin(String zkUrl, Configuration conf, String namespace) {
+        this(zkUrl, conf, HighAvailibilityCuratorProvider.INSTANCE, namespace);
     }
 
     public PhoenixHAAdmin(String zkUrl, Configuration conf,
-            HighAvailibilityCuratorProvider highAvailibilityCuratorProvider) {
+                          HighAvailibilityCuratorProvider highAvailibilityCuratorProvider) {
+        this(zkUrl, conf, highAvailibilityCuratorProvider, null);
+    }
+
+    public PhoenixHAAdmin(String zkUrl, Configuration conf,
+                          HighAvailibilityCuratorProvider highAvailibilityCuratorProvider,
+                          String namespace) {
         Preconditions.checkNotNull(zkUrl);
         Preconditions.checkNotNull(conf);
         Preconditions.checkNotNull(highAvailibilityCuratorProvider);
@@ -94,6 +119,7 @@ public class PhoenixHAAdmin implements Closeable {
         this.conf = conf;
         conf.iterator().forEachRemaining(k -> properties.setProperty(k.getKey(), k.getValue()));
         this.highAvailibilityCuratorProvider = highAvailibilityCuratorProvider;
+        this.namespace = Objects.toString(namespace, PHOENIX_HA_ZOOKEEPER_ZNODE_NAMESPACE);
     }
 
     /**
@@ -129,7 +155,7 @@ public class PhoenixHAAdmin implements Closeable {
      * Gets curator from the cache if available otherwise calls into getCurator to make it.
      */
     public CuratorFramework getCurator() throws IOException {
-        return highAvailibilityCuratorProvider.getCurator(zkUrl, properties);
+        return highAvailibilityCuratorProvider.getCurator(zkUrl, properties, namespace);
     }
 
 
@@ -160,20 +186,22 @@ public class PhoenixHAAdmin implements Closeable {
         }
     }
 
-    /**
-     * This lists all cluster role records stored in the zookeeper nodes.
-     * This read-only operation and hence no side effect on the ZK cluster.
-     */
-    public List<ClusterRoleRecord> listAllClusterRoleRecordsOnZookeeper() throws IOException {
-        List<String> haGroupNames;
+    public List<String> getHAGroupNames() throws IOException {
         try {
-            haGroupNames = getCurator().getChildren().forPath(ZKPaths.PATH_SEPARATOR);
+            return getCurator().getChildren().forPath(ZKPaths.PATH_SEPARATOR);
         } catch (Exception e) {
             String msg = String.format("Got exception when listing all HA groups in %s", zkUrl);
             LOG.error(msg);
             throw new IOException(msg, e);
         }
+    }
 
+    /**
+     * This lists all cluster role records stored in the zookeeper nodes.
+     * This read-only operation and hence no side effect on the ZK cluster.
+     */
+    public List<ClusterRoleRecord> listAllClusterRoleRecordsOnZookeeper() throws IOException {
+        List<String> haGroupNames = getHAGroupNames();
         List<ClusterRoleRecord> records = new ArrayList<>();
         List<String> failedHaGroups = new ArrayList<>();
         for (String haGroupName : haGroupNames) {
@@ -457,6 +485,70 @@ public class PhoenixHAAdmin implements Closeable {
                             haGroupPath, e.getMessage(), oldRecord, newRecord);
             LOG.error(msg, e);
             throw new IOException(msg, e);
+        }
+    }
+
+    /**
+     * Creates a new HAGroupStoreRecord in ZooKeeper.
+     *
+     * @param newHAGroupStoreRecord the new record to create
+     * @throws IOException if any error occurs during the creation
+     */
+    public void createHAGroupStoreRecordInZooKeeper(HAGroupStoreRecord newHAGroupStoreRecord)
+            throws IOException {
+        try {
+            getCurator()
+                    .create()
+                    .creatingParentsIfNeeded()
+                    .forPath(toPath(newHAGroupStoreRecord.getHaGroupName()), HAGroupStoreRecord.toJson(newHAGroupStoreRecord));
+        } catch (Exception e) {
+            LOG.error("Failed to create HAGroupStoreRecord for HA group {}", newHAGroupStoreRecord.getHaGroupName(), e);
+            throw new IOException("Failed to create HAGroupStoreRecord for HA group " + newHAGroupStoreRecord.getHaGroupName(), e);
+        }
+    }
+
+    /**
+     * Updates the HAGroupStoreRecord in ZooKeeper with version checking.
+     *
+     * @param haGroupName the HA group name
+     * @param newHAGroupStoreRecord the new record to store
+     * @param currentStatVersion the expected stat version for optimistic locking
+     * @throws StaleHAGroupStoreRecordVersionException if the version is stale
+     * @throws IOException if any other error occurs during the update
+     */
+    public void updateHAGroupStoreRecordInZooKeeper(String haGroupName, HAGroupStoreRecord newHAGroupStoreRecord, int currentStatVersion)
+            throws IOException, StaleHAGroupStoreRecordVersionException {
+        try {
+            getCurator()
+                    .setData()
+                    .withVersion(currentStatVersion)
+                    .forPath(toPath(haGroupName), HAGroupStoreRecord.toJson(newHAGroupStoreRecord));
+        } catch (KeeperException.BadVersionException e) {
+            LOG.error("Failed to set HAGroupStoreRecord for HA group {}, stale stat version", haGroupName, e);
+            throw new StaleHAGroupStoreRecordVersionException("Failed to set HAGroupStoreRecord for HA group "
+                    + haGroupName + " with cached stat version " + currentStatVersion, e);
+        } catch (Exception e) {
+            LOG.error("Failed to set HAGroupStoreRecord for HA group {}, unexpected error", haGroupName, e);
+            throw new IOException("Failed to set HAGroupStoreRecord for HA group " + haGroupName, e);
+        }
+    }
+
+    /**
+     * Gets the HAGroupStoreRecord and Stat from ZooKeeper.
+     *
+     * @param haGroupName the HA group name
+     * @return a pair of HAGroupStoreRecord and Stat
+     * @throws IOException if any error occurs during the retrieval
+     */
+    public Pair<HAGroupStoreRecord, Stat> getHAGroupStoreRecordInZooKeeper(String haGroupName) throws IOException {
+        try {
+            byte[] data = getCurator().getData().forPath(toPath(haGroupName));
+            HAGroupStoreRecord record = HAGroupStoreRecord.fromJson(data).orElse(null);
+            Stat stat = getCurator().checkExists().forPath(toPath(haGroupName));
+            return Pair.of(record, stat);
+        } catch (Exception e) {
+            LOG.error("Failed to get HAGroupStoreRecord for HA group {}", haGroupName, e);
+            throw new IOException("Failed to get HAGroupStoreRecord for HA group " + haGroupName, e);
         }
     }
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -141,6 +141,15 @@ public interface QueryServices extends SQLCloseable {
     public static final String MAX_SERVER_METADATA_CACHE_SIZE_ATTRIB = "phoenix.coprocessor.maxMetaDataCacheSize";
     public static final String MAX_CLIENT_METADATA_CACHE_SIZE_ATTRIB = "phoenix.client.maxMetaDataCacheSize";
     public static final String HA_GROUP_NAME_ATTRIB = "phoenix.ha.group";
+    public static final String HA_GROUP_STORE_MANAGER_IMPL_CLASS = "phoenix.ha.groupstore.manager.impl.class";
+    // TODO: Revisit this default value based on standard ZK update time
+    // and time it takes for an update to reach regionserver cache.
+    // Refresh interval for store and forward mode status updates in milliseconds
+    public static final String HA_STORE_AND_FORWARD_MODE_REFRESH_INTERVAL_MS = "phoenix.ha.store.forward.mode.refresh.interval.ms";
+    // TODO: Revisit this default value based on standard ZK update time
+    // and time it takes for an update to reach regionserver cache.
+    // Refresh interval for sync mode status updates in milliseconds
+    public static final String HA_SYNC_MODE_REFRESH_INTERVAL_MS = "phoenix.ha.sync.mode.refresh.interval.ms";
     public static final String AUTO_UPGRADE_WHITELIST_ATTRIB = "phoenix.client.autoUpgradeWhiteList";
     // Mainly for testing to force spilling
     public static final String MAX_MEMORY_SIZE_ATTRIB = "phoenix.query.maxGlobalMemorySize";

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -49,6 +49,9 @@ import static org.apache.phoenix.query.QueryServices.GLOBAL_METRICS_ENABLED;
 import static org.apache.phoenix.query.QueryServices.GROUPBY_MAX_CACHE_SIZE_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.GROUPBY_SPILLABLE_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.GROUPBY_SPILL_FILES_ATTRIB;
+import static org.apache.phoenix.query.QueryServices.HA_GROUP_STORE_MANAGER_IMPL_CLASS;
+import static org.apache.phoenix.query.QueryServices.HA_STORE_AND_FORWARD_MODE_REFRESH_INTERVAL_MS;
+import static org.apache.phoenix.query.QueryServices.HA_SYNC_MODE_REFRESH_INTERVAL_MS;
 import static org.apache.phoenix.query.QueryServices.HBASE_CLIENT_SCANNER_TIMEOUT_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.IMMUTABLE_ROWS_ATTRIB;
 import static org.apache.phoenix.query.QueryServices.INDEX_CREATE_DEFAULT_STATE;
@@ -471,6 +474,11 @@ public class QueryServicesOptions {
     public static final Boolean DEFAULT_CQSI_THREAD_POOL_METRICS_ENABLED = false;
 
     public static final Boolean DEFAULT_SYNCHRONOUS_REPLICATION_ENABLED = false;
+    // TODO: Revisit these default values based on standard ZK update time
+    // and time it takes for an update to reach regionserver cache.
+    public static final long DEFAULT_HA_STORE_AND_FORWARD_MODE_REFRESH_INTERVAL_MS = 1500L; // 1.5 seconds
+    public static final long DEFAULT_HA_SYNC_MODE_REFRESH_INTERVAL_MS = 3000L; // 3 seconds
+    public static final String DEFAULT_HA_GROUP_STORE_MANAGER_IMPL_CLASS = "org.apache.phoenix.jdbc.HAGroupStoreManagerV1Impl";
 
     private final Configuration config;
 
@@ -578,6 +586,11 @@ public class QueryServicesOptions {
                     DEFAULT_CONNECTION_ACTIVITY_LOGGING_INTERVAL_IN_MINS)
             .setIfUnset(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED,
                     DEFAULT_CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED)
+            .setIfUnset(HA_STORE_AND_FORWARD_MODE_REFRESH_INTERVAL_MS,
+                    DEFAULT_HA_STORE_AND_FORWARD_MODE_REFRESH_INTERVAL_MS)
+            .setIfUnset(HA_SYNC_MODE_REFRESH_INTERVAL_MS,
+                    DEFAULT_HA_SYNC_MODE_REFRESH_INTERVAL_MS)
+            .setIfUnset(HA_GROUP_STORE_MANAGER_IMPL_CLASS, DEFAULT_HA_GROUP_STORE_MANAGER_IMPL_CLASS)
             .setIfUnset(CQSI_THREAD_POOL_ENABLED, DEFAULT_CQSI_THREAD_POOL_ENABLED)
             .setIfUnset(CQSI_THREAD_POOL_KEEP_ALIVE_SECONDS,
                     DEFAULT_CQSI_THREAD_POOL_KEEP_ALIVE_SECONDS)

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/UngroupedAggregateRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/UngroupedAggregateRegionObserver.java
@@ -76,6 +76,7 @@ import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.phoenix.coprocessor.generated.PTableProtos;
 import org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants;
+import org.apache.phoenix.exception.MutationBlockedIOException;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.execute.TupleProjector;
 import org.apache.phoenix.expression.Expression;
@@ -90,6 +91,7 @@ import org.apache.phoenix.index.PhoenixIndexFailurePolicyHelper;
 import org.apache.phoenix.index.PhoenixIndexFailurePolicyHelper.MutateCommand;
 import org.apache.phoenix.index.PhoenixIndexMetaData;
 import org.apache.phoenix.jdbc.HAGroupStoreManager;
+import org.apache.phoenix.jdbc.HAGroupStoreManagerFactory;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
 import org.apache.phoenix.join.HashJoinInfo;
@@ -1062,10 +1064,16 @@ public class UngroupedAggregateRegionObserver extends BaseScannerRegionObserver 
             throws IOException {
         final Configuration conf = c.getEnvironment().getConfiguration();
         try {
-            final HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf);
-            if (haGroupStoreManager.isMutationBlocked()) {
-                throw new IOException("Blocking Mutation as Some CRRs are in ACTIVE_TO_STANDBY "
-                        + "state and CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED is true");
+            final Optional<HAGroupStoreManager> haGroupStoreManagerOptional
+                    = HAGroupStoreManagerFactory.getInstance(conf);
+            if (!haGroupStoreManagerOptional.isPresent()) {
+                throw new IOException("HAGroupStoreManager is null "
+                        + "for current cluster, check configuration");
+            }
+            if (haGroupStoreManagerOptional.get().isMutationBlocked(conf)) {
+                throw new MutationBlockedIOException("Blocking Mutation as Some CRRs are in "
+                        + "ACTIVE_TO_STANDBY state and "
+                        + "CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED is true");
             }
         } catch (Exception e) {
             throw new IOException(e);

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexRegionObserver.java
@@ -59,6 +59,7 @@ import org.apache.phoenix.coprocessor.DelegateRegionCoprocessorEnvironment;
 import org.apache.phoenix.coprocessor.generated.PTableProtos;
 import org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants;
 import org.apache.phoenix.exception.DataExceedsCapacityException;
+import org.apache.phoenix.exception.MutationBlockedIOException;
 import org.apache.phoenix.execute.MutationState;
 import org.apache.phoenix.expression.CaseExpression;
 import org.apache.phoenix.expression.Expression;
@@ -85,6 +86,7 @@ import org.apache.phoenix.index.IndexMaintainer;
 import org.apache.phoenix.index.PhoenixIndexBuilderHelper;
 import org.apache.phoenix.index.PhoenixIndexMetaData;
 import org.apache.phoenix.jdbc.HAGroupStoreManager;
+import org.apache.phoenix.jdbc.HAGroupStoreManagerFactory;
 import org.apache.phoenix.query.KeyRange;
 import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.query.QueryServicesOptions;
@@ -621,10 +623,16 @@ public class IndexRegionObserver implements RegionCoprocessor, RegionObserver {
       }
       try {
           final Configuration conf = c.getEnvironment().getConfiguration();
-          final HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf);
-          if (haGroupStoreManager.isMutationBlocked()) {
-              throw new IOException("Blocking Mutation as Some CRRs are in ACTIVE_TO_STANDBY "
-                      + "state and CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED is true");
+          final Optional<HAGroupStoreManager> haGroupStoreManagerOptional
+                  = HAGroupStoreManagerFactory.getInstance(conf);
+          if (!haGroupStoreManagerOptional.isPresent()) {
+              throw new IOException("HAGroupStoreManager is null "
+                      + "for current cluster, check configuration");
+          }
+          if (haGroupStoreManagerOptional.get().isMutationBlocked(conf)) {
+              throw new MutationBlockedIOException("Blocking Mutation as Some CRRs are in "
+                      + "ACTIVE_TO_STANDBY state and "
+                      + "CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED is true");
           }
           preBatchMutateWithExceptions(c, miniBatchOp);
           return;

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/IndexRegionObserverMutationBlockingIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/IndexRegionObserverMutationBlockingIT.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.end2end.index;
+
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
+import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
+import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
+import org.apache.phoenix.exception.MutationBlockedIOException;
+import org.apache.phoenix.execute.CommitException;
+import org.apache.phoenix.jdbc.ClusterRoleRecord;
+import org.apache.phoenix.jdbc.HighAvailabilityPolicy;
+import org.apache.phoenix.jdbc.PhoenixHAAdmin;
+import org.apache.phoenix.query.BaseTest;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
+import org.apache.phoenix.util.ReadOnlyProps;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Integration test for mutation blocking functionality in IndexRegionObserver.preBatchMutate()
+ * Tests that MutationBlockedIOException is properly thrown when cluster role-based mutation
+ * blocking is enabled and CRRs are in ACTIVE_TO_STANDBY state.
+ */
+@Category(NeedsOwnMiniClusterTest.class)
+public class IndexRegionObserverMutationBlockingIT extends BaseTest {
+
+    private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 1000L;
+    private PhoenixHAAdmin haAdmin;
+
+    @BeforeClass
+    public static synchronized void doSetup() throws Exception {
+        Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
+        // Enable cluster role-based mutation blocking
+        props.put(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, "true");
+        // No retries so that tests fail faster.
+        props.put("hbase.client.retries.number", "0");
+        setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        haAdmin = new PhoenixHAAdmin(config);
+
+        // Clean up all existing CRRs before each test
+        List<ClusterRoleRecord> crrs = haAdmin.listAllClusterRoleRecordsOnZookeeper();
+        for (ClusterRoleRecord crr : crrs) {
+            haAdmin.getCurator().delete().forPath(toPath(crr.getHaGroupName()));
+        }
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Clean up CRRs after each test
+        if (haAdmin != null) {
+            List<ClusterRoleRecord> crrs = haAdmin.listAllClusterRoleRecordsOnZookeeper();
+            for (ClusterRoleRecord crr : crrs) {
+                haAdmin.getCurator().delete().forPath(toPath(crr.getHaGroupName()));
+            }
+        }
+    }
+
+    @Test
+    public void testMutationBlockedOnDataTableWithIndex() throws Exception {
+        String dataTableName = generateUniqueName();
+        String indexName = generateUniqueName();
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            // Create data table and index
+            conn.createStatement().execute("CREATE TABLE " + dataTableName +
+                    " (id VARCHAR PRIMARY KEY, name VARCHAR, age INTEGER)");
+            conn.createStatement().execute("CREATE INDEX " + indexName +
+                    " ON " + dataTableName + "(name)");
+
+            // Initially, mutations should work - verify baseline
+            conn.createStatement().execute("UPSERT INTO " + dataTableName +
+                    " VALUES ('1', 'John', 25)");
+            conn.commit();
+
+            // Set up CRR that will block mutations (ACTIVE_TO_STANDBY state)
+            ClusterRoleRecord blockingCrr = new ClusterRoleRecord("failover_test",
+                    HighAvailabilityPolicy.FAILOVER,
+                    haAdmin.getZkUrl(),
+                    ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                    "standby-zk-url",
+                    ClusterRoleRecord.ClusterRole.STANDBY,
+                    1L);
+            haAdmin.createOrUpdateDataOnZookeeper(blockingCrr);
+
+            // Wait for the event to propagate
+            Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+            // Test that UPSERT throws MutationBlockedIOException
+            try {
+                conn.createStatement().execute("UPSERT INTO " + dataTableName +
+                        " VALUES ('2', 'Jane', 30)");
+                conn.commit();
+                fail("Expected MutationBlockedIOException to be thrown");
+            } catch (CommitException e) {
+                // Verify the exception chain contains MutationBlockedIOException
+                assertTrue("Expected MutationBlockedIOException in exception chain",
+                        containsMutationBlockedException(e));
+            }
+        }
+    }
+
+
+    @Test
+    public void testMutationAllowedWhenNotBlocked() throws Exception {
+        String dataTableName = generateUniqueName();
+        String indexName = generateUniqueName();
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            // Create data table and index
+            conn.createStatement().execute("CREATE TABLE " + dataTableName +
+                    " (id VARCHAR PRIMARY KEY, name VARCHAR, age INTEGER)");
+            conn.createStatement().execute("CREATE INDEX " + indexName +
+                    " ON " + dataTableName + "(name)");
+
+            // Set up CRR in ACTIVE state (should not block)
+            ClusterRoleRecord nonBlockingCrr = new ClusterRoleRecord("active_test",
+                    HighAvailabilityPolicy.FAILOVER,
+                    haAdmin.getZkUrl(),
+                    ClusterRoleRecord.ClusterRole.ACTIVE,
+                    "standby-zk-url",
+                    ClusterRoleRecord.ClusterRole.STANDBY,
+                    1L);
+            haAdmin.createOrUpdateDataOnZookeeper(nonBlockingCrr);
+
+            Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+            // Mutations should work fine
+            conn.createStatement().execute("UPSERT INTO " + dataTableName +
+                    " VALUES ('1', 'Bob', 35)");
+            conn.createStatement().execute("UPSERT INTO " + dataTableName +
+                    " VALUES ('2', 'Carol', 27)");
+            conn.commit();
+
+            // Verify data was inserted successfully
+            try (java.sql.ResultSet rs = conn.createStatement().executeQuery(
+                    "SELECT COUNT(*) FROM " + dataTableName)) {
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1));
+            }
+        }
+    }
+
+    @Test
+    public void testMutationBlockingTransition() throws Exception {
+        String dataTableName = generateUniqueName();
+        String indexName = generateUniqueName();
+
+        try (Connection conn = DriverManager.getConnection(getUrl())) {
+            // Create data table and index
+            conn.createStatement().execute("CREATE TABLE " + dataTableName +
+                    " (id VARCHAR PRIMARY KEY, name VARCHAR, age INTEGER)");
+            conn.createStatement().execute("CREATE INDEX " + indexName +
+                    " ON " + dataTableName + "(name)");
+
+            // Initially set up non-blocking CRR
+            ClusterRoleRecord crr = new ClusterRoleRecord("transition_test",
+                    HighAvailabilityPolicy.FAILOVER,
+                    haAdmin.getZkUrl(),
+                    ClusterRoleRecord.ClusterRole.ACTIVE,
+                    "standby-zk-url",
+                    ClusterRoleRecord.ClusterRole.STANDBY,
+                    1L);
+            haAdmin.createOrUpdateDataOnZookeeper(crr);
+            Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+            // Mutation should work
+            conn.createStatement().execute("UPSERT INTO " + dataTableName +
+                    " VALUES ('1', 'David', 40)");
+            conn.commit();
+
+            // Transition to ACTIVE_TO_STANDBY (blocking state)
+            crr = new ClusterRoleRecord("transition_test",
+                    HighAvailabilityPolicy.FAILOVER,
+                    haAdmin.getZkUrl(),
+                    ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                    "standby-zk-url",
+                    ClusterRoleRecord.ClusterRole.STANDBY,
+                    2L);
+            haAdmin.createOrUpdateDataOnZookeeper(crr);
+            Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+            // Now mutations should be blocked
+            try {
+                conn.createStatement().execute("UPSERT INTO " + dataTableName +
+                        " VALUES ('2', 'Eve', 33)");
+                conn.commit();
+                fail("Expected MutationBlockedIOException after transition to ACTIVE_TO_STANDBY");
+            } catch (CommitException e) {
+                assertTrue("Expected mutation blocked exception after transition",
+                        containsMutationBlockedException(e));
+            }
+
+            // Transition back to ACTIVE (non-blocking state) and peer cluster is in ATS state
+            crr = new ClusterRoleRecord("transition_test",
+                    HighAvailabilityPolicy.FAILOVER,
+                    haAdmin.getZkUrl(),
+                    ClusterRoleRecord.ClusterRole.ACTIVE,
+                    "standby-zk-url",
+                    ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                    3L);
+            haAdmin.createOrUpdateDataOnZookeeper(crr);
+            Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+            // Mutations should work again
+            conn.createStatement().execute("UPSERT INTO " + dataTableName +
+                    " VALUES ('3', 'Frank', 45)");
+            conn.commit();
+        }
+    }
+
+    private boolean containsMutationBlockedException(CommitException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof RetriesExhaustedWithDetailsException) {
+            RetriesExhaustedWithDetailsException re = (RetriesExhaustedWithDetailsException) cause;
+            return re.getCause(0) instanceof MutationBlockedIOException;
+        }
+        return false;
+    }
+}

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreClientIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreClientIT.java
@@ -17,31 +17,45 @@
  */
 package org.apache.phoenix.jdbc;
 
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
-import org.apache.curator.utils.ZKPaths;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
+import org.apache.phoenix.exception.InvalidClusterRoleTransitionException;
 import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 import org.apache.phoenix.util.ReadOnlyProps;
+import org.apache.zookeeper.data.Stat;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+
+import static org.apache.phoenix.jdbc.HAGroupStoreClient.ZK_CONSISTENT_HA_NAMESPACE;
 import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Integration tests for {@link HAGroupStoreClient}
@@ -49,171 +63,279 @@ import static org.junit.Assert.assertThrows;
 @Category(NeedsOwnMiniClusterTest.class)
 public class HAGroupStoreClientIT extends BaseTest {
 
-    private final PhoenixHAAdmin haAdmin = new PhoenixHAAdmin(config);
     private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 5000L;
+    private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS = new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
+    private PhoenixHAAdmin haAdmin;
+    private PhoenixHAAdmin peerHaAdmin;
+
+    @Rule
+    public TestName testName = new TestName();
 
     @BeforeClass
     public static synchronized void doSetup() throws Exception {
         Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
         setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+        CLUSTERS.start();
     }
 
     @Before
     public void before() throws Exception {
-        // Clean up all the existing CRRs
-        List<ClusterRoleRecord> crrs = haAdmin.listAllClusterRoleRecordsOnZookeeper();
-        for (ClusterRoleRecord crr : crrs) {
-            haAdmin.getCurator().delete().forPath(toPath(crr.getHaGroupName()));
+        haAdmin = new PhoenixHAAdmin(CLUSTERS.getHBaseCluster1().getConfiguration(), ZK_CONSISTENT_HA_NAMESPACE);
+        peerHaAdmin = new PhoenixHAAdmin(CLUSTERS.getHBaseCluster2().getConfiguration(), ZK_CONSISTENT_HA_NAMESPACE);
+        haAdmin.getCurator().delete().quietly().forPath(toPath(testName.getMethodName()));
+        peerHaAdmin.getCurator().delete().quietly().forPath(toPath(testName.getMethodName()));
+    }
+
+    @After
+    public void after() throws Exception {
+        haAdmin.getCurator().delete().quietly().forPath(toPath(testName.getMethodName()));
+        peerHaAdmin.getCurator().delete().quietly().forPath(toPath(testName.getMethodName()));
+        haAdmin.close();
+        peerHaAdmin.close();
+    }
+
+    @Test
+    public void testHAGroupStoreClientChangingPeerZKUrlToNull() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+        HAGroupStoreRecord record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+
+        HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+
+        // Check that peerPathChildrenCache is not null in HAGroupStoreClient via reflection
+        Field peerPathChildrenCache = HAGroupStoreClient.class.getDeclaredField("peerPathChildrenCache");
+        peerPathChildrenCache.setAccessible(true);
+        assertNotNull(peerPathChildrenCache.get(haGroupStoreClient));
+
+        record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 2, "FAILOVER", System.currentTimeMillis(), null);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Check that peerPathChildrenCache is null in HAGroupStoreClient via reflection
+        assertNull(peerPathChildrenCache.get(haGroupStoreClient));
+
+        // Check that haGroupStoreClient is working as normal
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
+    }
+
+    @Test
+    public void testHAGroupStoreClientChangingPeerZKUrlToInvalidUrlToValidUrl() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+        HAGroupStoreRecord record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+
+        HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+
+        // Check that peerPathChildrenCache is not null in HAGroupStoreClient via reflection
+        Field peerPathChildrenCache = HAGroupStoreClient.class.getDeclaredField("peerPathChildrenCache");
+        peerPathChildrenCache.setAccessible(true);
+        assertNotNull(peerPathChildrenCache.get(haGroupStoreClient));
+
+        record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 2, "FAILOVER", System.currentTimeMillis(), "randompeer:2181");
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Check that peerPathChildrenCache is null in HAGroupStoreClient via reflection
+        assertNull(peerPathChildrenCache.get(haGroupStoreClient));
+
+        // Check that haGroupStoreClient is working as normal
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
+
+
+        record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.STANDBY, 3, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS*2);
+
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.STANDBY;
+
+        // Check that peerPathChildrenCache is not null in HAGroupStoreClient via reflection
+        peerPathChildrenCache.setAccessible(true);
+        assertNotNull(peerPathChildrenCache.get(haGroupStoreClient));
+    }
+
+    @Test
+    public void testHAGroupStoreClientWithoutPeerZK() throws Exception {
+        String haGroupName = testName.getMethodName();
+        HAGroupStoreRecord record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), null);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+
+        HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+
+        // Check that peerPathChildrenCache is null in HAGroupStoreClient via reflection
+        Field peerPathChildrenCache = HAGroupStoreClient.class.getDeclaredField("peerPathChildrenCache");
+        peerPathChildrenCache.setAccessible(true);
+        assertNull(peerPathChildrenCache.get(haGroupStoreClient));
+    }
+
+    @Test
+    public void testHAGroupStoreClientWithSingleHAGroupStoreRecord() throws Exception {
+        String haGroupName = testName.getMethodName();
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+
+        // Create and store HAGroupStoreRecord with ACTIVE role, including peer ZK URL
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+        HAGroupStoreRecord record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+
+        // Now Update HAGroupStoreRecord so that current cluster has state ACTIVE_TO_STANDBY
+        record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 2, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        // Check that now the cluster should be in ActiveToStandby
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
+
+        // Change it back to ACTIVE so that cluster is not in ACTIVE_TO_STANDBY state
+        record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 3, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+
+        // Change it again to ACTIVE_TO_STANDBY so that we can validate watcher works repeatedly
+        record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 4, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
+
+        // Change it back to ACTIVE to verify transition works
+        record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 5, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+    }
+
+
+    /**
+     * Helper method to create or update HAGroupStoreRecord on ZooKeeper
+     */
+    private void createOrUpdateHAGroupStoreRecordOnZookeeper(PhoenixHAAdmin haAdmin, String haGroupName, HAGroupStoreRecord record) throws Exception {
+        String path = toPath(haGroupName);
+        if (haAdmin.getCurator().checkExists().forPath(path) == null) {
+            haAdmin.createHAGroupStoreRecordInZooKeeper(record);
+        } else {
+            final Pair<HAGroupStoreRecord, Stat> currentRecord = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+            if (currentRecord.getRight() != null && currentRecord.getLeft() != null) {
+                haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, record, currentRecord.getRight().getVersion());
+            } else {
+                throw new IOException("Current HAGroupStoreRecord in ZK is null, cannot update HAGroupStoreRecord " + haGroupName);
+            }
         }
     }
 
     @Test
-    public void testHAGroupStoreClientWithSingleCRR() throws Exception {
-        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(config);
-        ClusterRoleRecord crr = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr);
-        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+    public void testHAGroupStoreClientWithMultipleHAGroupStoreRecords() throws Exception {
+        String haGroupName1 = testName.getMethodName() + "1";
+        String haGroupName2 = testName.getMethodName() + "2";
+        String peerZKUrl = CLUSTERS.getZkUrl2();
 
-        // Now Update CRR so that current cluster has state ACTIVE_TO_STANDBY
-        crr = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr);
+        // Setup initial HAGroupStoreRecords
+        HAGroupStoreRecord record1 = new HAGroupStoreRecord("v1.0", haGroupName1,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        HAGroupStoreRecord record2 = new HAGroupStoreRecord("v1.0", haGroupName2,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "PARALLEL", System.currentTimeMillis(), peerZKUrl);
 
-        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        // Check that now the cluster should be in ActiveToStandby
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).isEmpty();
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
 
-
-        // Change it back to ACTIVE so that cluster is not in ACTIVE_TO_STANDBY state
-        crr = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 3L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr);
+        HAGroupStoreClient haGroupStoreClient1 = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName1);
+        HAGroupStoreClient haGroupStoreClient2 = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName2);
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+        HAGroupStoreRecord currentRecord1 = haGroupStoreClient1.getHAGroupStoreRecord();
+        HAGroupStoreRecord currentRecord2 = haGroupStoreClient2.getHAGroupStoreRecord();
+        assert currentRecord1 != null && currentRecord1.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+        assert currentRecord2 != null && currentRecord2.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
 
+        // Now Update HAGroupStoreRecord so that current cluster has state ACTIVE_TO_STANDBY for only 1 record
+        record1 = new HAGroupStoreRecord("v1.0", haGroupName1,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 2, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        record2 = new HAGroupStoreRecord("v1.0", haGroupName2,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 2, "PARALLEL", System.currentTimeMillis(), peerZKUrl);
 
-        // Change it again to ACTIVE_TO_STANDBY so that we can validate watcher works repeatedly
-        crr = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 4L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr);
-
-        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).isEmpty();
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
-
-
-        // Change peer cluster to ACTIVE_TO_STANDBY so that we can still process mutation on this cluster
-        crr = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 5L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr);
-
-        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
-    }
-
-
-    @Test
-    public void testHAGroupStoreClientWithMultipleCRRs() throws Exception {
-        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(config);
-        // Setup initial CRRs
-        ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
-
-        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
-
-        // Now Update CRR so that current cluster has state ACTIVE_TO_STANDBY for only 1 crr
-        crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
-        crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
         // Check that now the cluster should be in ActiveToStandby
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
-
+        currentRecord1 = haGroupStoreClient1.getHAGroupStoreRecord();
+        currentRecord2 = haGroupStoreClient2.getHAGroupStoreRecord();
+        assert currentRecord1 != null && currentRecord1.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
+        assert currentRecord2 != null && currentRecord2.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
 
         // Change it back to ACTIVE so that cluster is not in ACTIVE_TO_STANDBY state
-        crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 3L);
-        crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 3L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        record1 = new HAGroupStoreRecord("v1.0", haGroupName1,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 3, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        record2 = new HAGroupStoreRecord("v1.0", haGroupName2,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 3, "PARALLEL", System.currentTimeMillis(), peerZKUrl);
+
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+        currentRecord1 = haGroupStoreClient1.getHAGroupStoreRecord();
+        currentRecord2 = haGroupStoreClient2.getHAGroupStoreRecord();
+        assert currentRecord1 != null && currentRecord1.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+        assert currentRecord2 != null && currentRecord2.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
 
+        // Change other record to ACTIVE_TO_STANDBY and one in ACTIVE state so that we can validate watcher works repeatedly
+        record1 = new HAGroupStoreRecord("v1.0", haGroupName1,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 4, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        record2 = new HAGroupStoreRecord("v1.0", haGroupName2,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 4, "PARALLEL", System.currentTimeMillis(), peerZKUrl);
 
-        // Change other crr to ACTIVE_TO_STANDBY and one in ACTIVE state so that we can validate watcher works repeatedly
-        crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 4L);
-        crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 4L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
-
-        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
-
-
-        // Change peer cluster to ACTIVE_TO_STANDBY so that we can still process mutation on this cluster
-        crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 5L);
-        crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 5L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+        currentRecord1 = haGroupStoreClient1.getHAGroupStoreRecord();
+        currentRecord2 = haGroupStoreClient2.getHAGroupStoreRecord();
+        assert currentRecord1 != null && currentRecord1.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+        assert currentRecord2 != null && currentRecord2.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
     }
 
     @Test
     public void testMultiThreadedAccessToHACache() throws Exception {
-        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(config);
-        // Setup initial CRRs
-        ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Setup initial HAGroupStoreRecord
+        HAGroupStoreRecord record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -223,8 +345,8 @@ public class HAGroupStoreClientIT extends BaseTest {
         for (int i = 0; i < threadCount; i++) {
             executor.submit(() -> {
                 try {
-                    assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
-                    assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+                    HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+                    assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
                     latch.countDown();
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -233,15 +355,11 @@ public class HAGroupStoreClientIT extends BaseTest {
         }
         assert latch.await(10, TimeUnit.SECONDS);
 
-        // Update CRRs
-        crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
-        crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        // Update HAGroupStoreRecord
+        record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 2, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -250,8 +368,8 @@ public class HAGroupStoreClientIT extends BaseTest {
         for (int i = 0; i < threadCount; i++) {
             executor.submit(() -> {
                 try {
-                    assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-                    assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+                    HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+                    assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
                     latch2.countDown();
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -263,100 +381,288 @@ public class HAGroupStoreClientIT extends BaseTest {
 
     @Test
     public void testHAGroupStoreClientWithRootPathDeletion() throws Exception {
-        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(config);
-        ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
-        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
 
-        haAdmin.getCurator().delete().deletingChildrenIfNeeded().forPath(ZKPaths.PATH_SEPARATOR);
-        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).isEmpty();
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+        HAGroupStoreRecord record1 = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
 
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record1);
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
 
-        crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
-        crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+        HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
+
+        haAdmin.getCurator().delete().deletingChildrenIfNeeded().forPath(toPath(StringUtils.EMPTY));
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord == null;
+
+        record1 = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 2, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record1);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
     }
 
     @Test
     public void testThrowsExceptionWithZKDisconnectionAndThenConnection() throws Exception {
-        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(config);
-        // Setup initial CRRs
-        ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
-                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Setup initial HAGroupStoreRecord
+        HAGroupStoreRecord record = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
+        HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
 
         // Shutdown the ZK Cluster to simulate CONNECTION_SUSPENDED event
-        utility.shutdownMiniZKCluster();
+        CLUSTERS.getHBaseCluster1().shutdownMiniZKCluster();
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
         //Check that HAGroupStoreClient instance is not healthy and throws IOException
-        assertThrows(IOException.class, () -> haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE));
+        assertThrows(IOException.class, () -> haGroupStoreClient.getHAGroupStoreRecord());
+        // Check that the HAGroupStoreClient instance is not healthy via reflection
+        Field isHealthyField = HAGroupStoreClient.class.getDeclaredField("isHealthy");
+        isHealthyField.setAccessible(true);
+        assertFalse((boolean)isHealthyField.get(haGroupStoreClient));
 
         // Start ZK on the same port to simulate CONNECTION_RECONNECTED event
-        utility.startMiniZKCluster(1,Integer.parseInt(getZKClientPort(config)));
+        CLUSTERS.getHBaseCluster1().startMiniZKCluster(1,
+                Integer.parseInt(CLUSTERS.getHBaseCluster1().getConfiguration().get("hbase.zookeeper.property.clientPort")));
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
         //Check that HAGroupStoreClient instance is back to healthy and provides correct response
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assert currentRecord != null && currentRecord.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+        // Check that the HAGroupStoreClient instance is healthy via reflection
+        assertTrue((boolean)isHealthyField.get(haGroupStoreClient));
     }
-
 
     @Test
     public void testHAGroupStoreClientWithDifferentZKURLFormats() throws Exception {
-        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(config);
-        final String zkClientPort = getZKClientPort(config);
-        // Setup initial CRRs
+        String haGroupName1 = testName.getMethodName() + "1";
+        String haGroupName2 = testName.getMethodName() + "2";
+        String haGroupName3 = testName.getMethodName() + "3";
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        final String zkClientPort = CLUSTERS.getHBaseCluster1().getConfiguration().get("hbase.zookeeper.property.clientPort");
+        // Setup initial HAGroupStoreRecords with different ZK URL formats
         final String format1 = "127.0.0.1\\:"+zkClientPort+"::/hbase"; // 127.0.0.1\:53228::/hbase
         final String format2 = "127.0.0.1:"+zkClientPort+"::/hbase"; //   127.0.0.1:53228::/hbase
         final String format3 = "127.0.0.1\\:"+zkClientPort+":/hbase";   // 127.0.0.1\:53228:/hbase
 
-        ClusterRoleRecord crr1 = new ClusterRoleRecord("parallel1",
-                HighAvailabilityPolicy.PARALLEL, format1, ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        HAGroupStoreRecord record1 = new HAGroupStoreRecord("v1.0", haGroupName1,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "PARALLEL", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
 
-        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel2",
-                HighAvailabilityPolicy.PARALLEL, format2, ClusterRoleRecord.ClusterRole.STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        HAGroupStoreRecord record2 = new HAGroupStoreRecord("v1.0", haGroupName2,
+                ClusterRoleRecord.ClusterRole.STANDBY, 1, "PARALLEL", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
 
-        ClusterRoleRecord crr3 = new ClusterRoleRecord("parallel3",
-                HighAvailabilityPolicy.PARALLEL, format3, ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
-        haAdmin.createOrUpdateDataOnZookeeper(crr3);
+        HAGroupStoreRecord record3 = new HAGroupStoreRecord("v1.0", haGroupName3,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 1, "PARALLEL", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName3, record3);
+
+        HAGroupStoreClient haGroupStoreClient1 = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName1);
+        HAGroupStoreClient haGroupStoreClient2 = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName2);
+        HAGroupStoreClient haGroupStoreClient3 = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName3);
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
-        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.STANDBY).size() == 1;
+        HAGroupStoreRecord currentRecord1 = haGroupStoreClient1.getHAGroupStoreRecord();
+        HAGroupStoreRecord currentRecord2 = haGroupStoreClient2.getHAGroupStoreRecord();
+        HAGroupStoreRecord currentRecord3 = haGroupStoreClient3.getHAGroupStoreRecord();
+        assert currentRecord1 != null && currentRecord1.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE;
+        assert currentRecord2 != null && currentRecord2.getClusterRole() == ClusterRoleRecord.ClusterRole.STANDBY;
+        assert currentRecord3 != null && currentRecord3.getClusterRole() == ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
     }
 
+    // Tests for setHAGroupStatusIfNeeded method
+
+    @Test
+    public void testSetHAGroupStatusIfNeededCreateNewRecord() throws Exception {
+        String haGroupName = testName.getMethodName();
+
+        // Create HAGroupStoreClient without any existing record
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+
+        // This should fail because no record exists and fetchHAGroupStoreRecordFromSystemTable returns null
+        try {
+            haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.ACTIVE);
+            fail("Expected IOException for missing system table record");
+        } catch (IOException e) {
+            assertTrue("Exception should mention system table", e.getMessage().contains("system table"));
+        }
+    }
+
+    @Test
+    public void testSetHAGroupStatusIfNeededUpdateExistingRecord() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
+
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Verify initial state
+        HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE, currentRecord.getClusterRole());
+
+        // Update to STANDBY (this should succeed as it's a valid transition)
+        haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Verify the record was updated
+        currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, currentRecord.getClusterRole());
+
+        // Verify the version was incremented
+        HAGroupStoreRecord updatedRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assertEquals(2, updatedRecord.getVersion());
+    }
+
+    @Test
+    public void testSetHAGroupStatusIfNeededNoUpdateWhenNotNeeded() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record with current timestamp
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis(), peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
+
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+
+        // Get the current record
+        HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        long originalVersion = currentRecord.getVersion();
+        long originalTimestamp = currentRecord.getLastUpdatedTimeInMs();
+
+        // Try to set to ACTIVE_NOT_IN_SYNC immediately (should not update due to timing)
+        haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.ACTIVE_NOT_IN_SYNC);
+
+        // Add sleep if due to any bug the update might have gone through and we can assert below this.
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        // Verify no update occurred
+        HAGroupStoreRecord afterRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assertEquals("Version should not change", originalVersion, afterRecord.getVersion());
+        assertEquals("Timestamp should not change", originalTimestamp, afterRecord.getLastUpdatedTimeInMs());
+        assertEquals("Role should not change", ClusterRoleRecord.ClusterRole.ACTIVE, afterRecord.getClusterRole());
+    }
+
+    @Test
+    public void testSetHAGroupStatusIfNeededWithTimingLogic() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record with old timestamp to ensure timing check passes
+        long oldTimestamp = System.currentTimeMillis() - 10000; // 10 seconds ago
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", oldTimestamp, peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
+
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Update to ACTIVE_NOT_IN_SYNC (should succeed due to old timestamp)
+        haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.ACTIVE_NOT_IN_SYNC);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Verify the record was updated
+        HAGroupStoreRecord updatedRecord = haGroupStoreClient.getHAGroupStoreRecord();
+        assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE_NOT_IN_SYNC, updatedRecord.getClusterRole());
+        assertEquals(2, updatedRecord.getVersion());
+        assertTrue("Timestamp should be updated", updatedRecord.getLastUpdatedTimeInMs() > oldTimestamp);
+    }
+
+    @Test
+    public void testSetHAGroupStatusIfNeededWithInvalidTransition() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record with ACTIVE state
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis() - 10000, peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
+
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Try to transition to STANDBY (invalid transition from ACTIVE)
+        try {
+            haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.STANDBY);
+            fail("Expected InvalidClusterRoleTransitionException");
+        } catch (InvalidClusterRoleTransitionException e) {
+            // Should get InvalidClusterRoleTransitionException (might be wrapped)
+            assertTrue("Exception should be about invalid transition",
+                    e.getMessage().contains("Cannot transition from ACTIVE to STANDBY") ||
+                            e.getCause() != null && e.getCause().getMessage().contains("Cannot transition from ACTIVE to STANDBY"));
+        }
+    }
+
+    @Test
+    public void testSetHAGroupStatusIfNeededWithUnhealthyClient() throws Exception {
+        String haGroupName = testName.getMethodName();
+
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+
+        // Make client unhealthy by accessing private field
+        Field isHealthyField = HAGroupStoreClient.class.getDeclaredField("isHealthy");
+        isHealthyField.setAccessible(true);
+        isHealthyField.set(haGroupStoreClient, false);
+
+        // Try to set status on unhealthy client
+        try {
+            haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.ACTIVE);
+            fail("Expected IOException for unhealthy client");
+        } catch (IOException e) {
+            assertTrue("Exception should mention unhealthy client", e.getMessage().contains("not healthy"));
+        }
+    }
+
+
+    @Test
+    public void testSetHAGroupStatusIfNeededMultipleTransitions() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record with old timestamp
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, 1, "FAILOVER", System.currentTimeMillis() - 10000, peerZKUrl);
+        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
+
+        HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient.getInstance(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // First transition: ACTIVE -> ACTIVE_TO_STANDBY
+        haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        HAGroupStoreRecord afterFirst = haGroupStoreClient.getHAGroupStoreRecord();
+        assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, afterFirst.getClusterRole());
+        assertEquals(2, afterFirst.getVersion());
+
+        // Wait and make another transition: ACTIVE_TO_STANDBY -> STANDBY
+        Thread.sleep(100); // Small delay to ensure timestamp difference
+        haGroupStoreClient.setHAGroupStatusIfNeeded(ClusterRoleRecord.ClusterRole.STANDBY);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        HAGroupStoreRecord afterSecond = haGroupStoreClient.getHAGroupStoreRecord();
+        assertEquals(ClusterRoleRecord.ClusterRole.STANDBY, afterSecond.getClusterRole());
+        assertEquals(3, afterSecond.getVersion());
+    }
 
     /**
      * This test verifies that the updates coming via PathChildrenCacheListener are in order in which updates are sent to ZK
@@ -364,22 +670,27 @@ public class HAGroupStoreClientIT extends BaseTest {
      */
     @Test
     public void testHAGroupStoreClientWithMultiThreadedUpdates() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
         // Number of threads to execute
         int threadCount = 5;
 
-        // Capture versions of crr in a list(crrEventVersions)  in order they are received.
-        List<Integer> crrEventVersions = new ArrayList<>();
+        // Capture versions of records in a list(recordEventVersions) in order they are received.
+        List<Integer> recordEventVersions = new ArrayList<>();
         CountDownLatch eventsLatch = new CountDownLatch(threadCount);
         PathChildrenCacheListener pathChildrenCacheListener = (client, event) -> {
-            if(event.getData() != null && event.getData().getData() != null && ClusterRoleRecord.fromJson(event.getData().getData()).isPresent()) {
-                    ClusterRoleRecord crr = ClusterRoleRecord.fromJson(event.getData().getData()).get();
-                    crrEventVersions.add((int)crr.getVersion());
+            if(event.getData() != null && event.getData().getData() != null && HAGroupStoreRecord.fromJson(event.getData().getData()).isPresent()) {
+                HAGroupStoreRecord record = HAGroupStoreRecord.fromJson(event.getData().getData()).get();
+                if (record.getHaGroupName().equals(haGroupName)) {
+                    recordEventVersions.add((int)record.getVersion());
                     eventsLatch.countDown();
+                }
             }
         };
 
-        // Start a new HAGroupStoreClient.
-        new HAGroupStoreClient(config, pathChildrenCacheListener);
+        // Start a new HAGroupStoreClient with custom listener.
+        new HAGroupStoreClient(CLUSTERS.getHBaseCluster1().getConfiguration(), pathChildrenCacheListener, null, haGroupName);
 
         // Create multiple threads for update to ZK.
         final CountDownLatch updateLatch = new CountDownLatch(threadCount);
@@ -389,9 +700,9 @@ public class HAGroupStoreClientIT extends BaseTest {
         List<Integer> updateList = new ArrayList<>();
 
         // Create a queue which can be polled to send updates to ZK.
-        ConcurrentLinkedQueue<ClusterRoleRecord> updateQueue = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<HAGroupStoreRecord> updateQueue = new ConcurrentLinkedQueue<>();
         for(int i = 0; i < threadCount; i++) {
-            updateQueue.add(createCRR(i+1));
+            updateQueue.add(createHAGroupStoreRecord(haGroupName, peerZKUrl, i+1));
             updateList.add(i+1);
         }
 
@@ -400,7 +711,8 @@ public class HAGroupStoreClientIT extends BaseTest {
             executor.submit(() -> {
                 try {
                     synchronized (HAGroupStoreClientIT.class) {
-                        haAdmin.createOrUpdateDataOnZookeeper(Objects.requireNonNull(updateQueue.poll()));
+                        HAGroupStoreRecord record = Objects.requireNonNull(updateQueue.poll());
+                        createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
                     }
                     updateLatch.countDown();
                 } catch (Exception e) {
@@ -414,14 +726,12 @@ public class HAGroupStoreClientIT extends BaseTest {
         assert updateLatch.await(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS*threadCount, TimeUnit.MILLISECONDS);
 
         // Assert that the order of updates is same as order of events.
-        assert updateList.equals(crrEventVersions);
+        assert updateList.equals(recordEventVersions);
     }
 
-    private ClusterRoleRecord createCRR(Integer version) {
-        return new ClusterRoleRecord("parallel",
-                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
-                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, version);
+    private HAGroupStoreRecord createHAGroupStoreRecord(String haGroupName, String peerZKUrl, Integer version) {
+        return new HAGroupStoreRecord("v1.0", haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE, version, "PARALLEL", System.currentTimeMillis(), peerZKUrl);
     }
-
 
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreClientV1IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreClientV1IT.java
@@ -1,0 +1,426 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
+import org.apache.phoenix.query.BaseTest;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
+import org.apache.phoenix.util.ReadOnlyProps;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Integration tests for {@link HAGroupStoreClientV1}
+ */
+@Category(NeedsOwnMiniClusterTest.class)
+public class HAGroupStoreClientV1IT extends BaseTest {
+
+    private final PhoenixHAAdmin haAdmin = new PhoenixHAAdmin(config);
+    private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 5000L;
+
+    @BeforeClass
+    public static synchronized void doSetup() throws Exception {
+        Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
+        setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+    }
+
+    @Before
+    public void before() throws Exception {
+        // Clean up all the existing CRRs
+        List<ClusterRoleRecord> crrs = haAdmin.listAllClusterRoleRecordsOnZookeeper();
+        for (ClusterRoleRecord crr : crrs) {
+            haAdmin.getCurator().delete().forPath(toPath(crr.getHaGroupName()));
+        }
+    }
+
+    @Test
+    public void testHAGroupStoreClientWithSingleCRR() throws Exception {
+        HAGroupStoreClientV1 haGroupStoreClient = HAGroupStoreClientV1.getInstance(config);
+        ClusterRoleRecord crr = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+
+        // Now Update CRR so that current cluster has state ACTIVE_TO_STANDBY
+        crr = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        // Check that now the cluster should be in ActiveToStandby
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).isEmpty();
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+
+
+        // Change it back to ACTIVE so that cluster is not in ACTIVE_TO_STANDBY state
+        crr = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 3L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+
+
+        // Change it again to ACTIVE_TO_STANDBY so that we can validate watcher works repeatedly
+        crr = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 4L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).isEmpty();
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+
+
+        // Change peer cluster to ACTIVE_TO_STANDBY so that we can still process mutation on this cluster
+        crr = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 5L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+    }
+
+
+    @Test
+    public void testHAGroupStoreClientWithMultipleCRRs() throws Exception {
+        HAGroupStoreClientV1 haGroupStoreClient = HAGroupStoreClientV1.getInstance(config);
+        // Setup initial CRRs
+        ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+
+        // Now Update CRR so that current cluster has state ACTIVE_TO_STANDBY for only 1 crr
+        crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
+        crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        // Check that now the cluster should be in ActiveToStandby
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+
+
+        // Change it back to ACTIVE so that cluster is not in ACTIVE_TO_STANDBY state
+        crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 3L);
+        crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 3L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+
+
+        // Change other crr to ACTIVE_TO_STANDBY and one in ACTIVE state so that we can validate watcher works repeatedly
+        crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 4L);
+        crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 4L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+
+
+        // Change peer cluster to ACTIVE_TO_STANDBY so that we can still process mutation on this cluster
+        crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 5L);
+        crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, 5L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+    }
+
+    @Test
+    public void testMultiThreadedAccessToHACache() throws Exception {
+        HAGroupStoreClientV1 haGroupStoreClient = HAGroupStoreClientV1.getInstance(config);
+        // Setup initial CRRs
+        ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        int threadCount = 10;
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
+                    assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+                    latch.countDown();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        assert latch.await(10, TimeUnit.SECONDS);
+
+        // Update CRRs
+        crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
+        crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        final CountDownLatch latch2 = new CountDownLatch(threadCount);
+        executor = Executors.newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+                    assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+                    latch2.countDown();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        assert latch2.await(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testHAGroupStoreClientWithRootPathDeletion() throws Exception {
+        HAGroupStoreClientV1 haGroupStoreClient = HAGroupStoreClientV1.getInstance(config);
+        ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+
+        haAdmin.getCurator().delete().deletingChildrenIfNeeded().forPath(ZKPaths.PATH_SEPARATOR);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).isEmpty();
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).isEmpty();
+
+
+        crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
+        crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 2L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+    }
+
+    @Test
+    public void testThrowsExceptionWithZKDisconnectionAndThenConnection() throws Exception {
+        HAGroupStoreClientV1 haGroupStoreClient = HAGroupStoreClientV1.getInstance(config);
+        // Setup initial CRRs
+        ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
+                HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
+
+        // Shutdown the ZK Cluster to simulate CONNECTION_SUSPENDED event
+        utility.shutdownMiniZKCluster();
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        //Check that HAGroupStoreClient instance is not healthy and throws IOException
+        assertThrows(IOException.class, () -> haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE));
+
+        // Start ZK on the same port to simulate CONNECTION_RECONNECTED event
+        utility.startMiniZKCluster(1,Integer.parseInt(getZKClientPort(config)));
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        //Check that HAGroupStoreClient instance is back to healthy and provides correct response
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 2;
+    }
+
+
+    @Test
+    public void testHAGroupStoreClientWithDifferentZKURLFormats() throws Exception {
+        HAGroupStoreClientV1 haGroupStoreClient = HAGroupStoreClientV1.getInstance(config);
+        final String zkClientPort = getZKClientPort(config);
+        // Setup initial CRRs
+        final String format1 = "127.0.0.1\\:"+zkClientPort+"::/hbase"; // 127.0.0.1\:53228::/hbase
+        final String format2 = "127.0.0.1:"+zkClientPort+"::/hbase"; //   127.0.0.1:53228::/hbase
+        final String format3 = "127.0.0.1\\:"+zkClientPort+":/hbase";   // 127.0.0.1\:53228:/hbase
+
+        ClusterRoleRecord crr1 = new ClusterRoleRecord("parallel1",
+                HighAvailabilityPolicy.PARALLEL, format1, ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr1);
+
+        ClusterRoleRecord crr2 = new ClusterRoleRecord("parallel2",
+                HighAvailabilityPolicy.PARALLEL, format2, ClusterRoleRecord.ClusterRole.STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr2);
+
+        ClusterRoleRecord crr3 = new ClusterRoleRecord("parallel3",
+                HighAvailabilityPolicy.PARALLEL, format3, ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, 1L);
+        haAdmin.createOrUpdateDataOnZookeeper(crr3);
+
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY).size() == 1;
+        assert haGroupStoreClient.getCRRsByClusterRole(ClusterRoleRecord.ClusterRole.STANDBY).size() == 1;
+    }
+
+
+    /**
+     * This test verifies that the updates coming via PathChildrenCacheListener are in order in which updates are sent to ZK
+     * @throws Exception
+     */
+    @Test
+    public void testHAGroupStoreClientWithMultiThreadedUpdates() throws Exception {
+        // Number of threads to execute
+        int threadCount = 5;
+
+        // Capture versions of crr in a list(crrEventVersions)  in order they are received.
+        List<Integer> crrEventVersions = new ArrayList<>();
+        CountDownLatch eventsLatch = new CountDownLatch(threadCount);
+        PathChildrenCacheListener pathChildrenCacheListener = (client, event) -> {
+            if(event.getData() != null && event.getData().getData() != null && ClusterRoleRecord.fromJson(event.getData().getData()).isPresent()) {
+                ClusterRoleRecord crr = ClusterRoleRecord.fromJson(event.getData().getData()).get();
+                crrEventVersions.add((int)crr.getVersion());
+                eventsLatch.countDown();
+            }
+        };
+
+        // Start a new HAGroupStoreClient.
+        new HAGroupStoreClientV1(config, pathChildrenCacheListener);
+
+        // Create multiple threads for update to ZK.
+        final CountDownLatch updateLatch = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        // List captures the order of events that are sent.
+        List<Integer> updateList = new ArrayList<>();
+
+        // Create a queue which can be polled to send updates to ZK.
+        ConcurrentLinkedQueue<ClusterRoleRecord> updateQueue = new ConcurrentLinkedQueue<>();
+        for(int i = 0; i < threadCount; i++) {
+            updateQueue.add(createCRR(i+1));
+            updateList.add(i+1);
+        }
+
+        // Submit updates to ZK.
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    synchronized (HAGroupStoreClientV1IT.class) {
+                        haAdmin.createOrUpdateDataOnZookeeper(Objects.requireNonNull(updateQueue.poll()));
+                    }
+                    updateLatch.countDown();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        // Check if updates are sent and updates are received.
+        assert eventsLatch.await(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS*threadCount, TimeUnit.MILLISECONDS);
+        assert updateLatch.await(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS*threadCount, TimeUnit.MILLISECONDS);
+
+        // Assert that the order of updates is same as order of events.
+        assert updateList.equals(crrEventVersions);
+    }
+
+    private ClusterRoleRecord createCRR(Integer version) {
+        return new ClusterRoleRecord("parallel",
+                HighAvailabilityPolicy.PARALLEL, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
+                "random-zk-url", ClusterRoleRecord.ClusterRole.STANDBY, version);
+    }
+
+
+}

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerImplIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerImplIT.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
+import org.apache.phoenix.query.BaseTest;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
+import org.apache.phoenix.util.ReadOnlyProps;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.phoenix.jdbc.HAGroupStoreClient.ZK_CONSISTENT_HA_NAMESPACE;
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.getLocalZkUrl;
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
+import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration tests for {@link HAGroupStoreManagerImpl}.
+ */
+@Category(NeedsOwnMiniClusterTest.class)
+public class HAGroupStoreManagerImplIT extends BaseTest {
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private PhoenixHAAdmin haAdmin;
+    private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 2000L;
+
+    @BeforeClass
+    public static synchronized void doSetup() throws Exception {
+        Map<String, String> props = Maps.newHashMapWithExpectedSize(2);
+        props.put(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, "true");
+        props.put(QueryServices.HA_GROUP_STORE_MANAGER_IMPL_CLASS, org.apache.phoenix.jdbc.HAGroupStoreManagerImpl.class.getName());
+        setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+    }
+
+    @Before
+    public void before() throws Exception {
+        haAdmin = new PhoenixHAAdmin(config, ZK_CONSISTENT_HA_NAMESPACE);
+
+        // Clean up existing HAGroupStoreRecords
+        try {
+            List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(config);
+            for (String haGroupName : haGroupNames) {
+                haAdmin.getCurator().delete().quietly().forPath(toPath(haGroupName));
+            }
+        } catch (Exception e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    @Test
+    public void testHAGroupStoreManagerCreation() throws Exception {
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(config);
+
+        assertTrue(managerOpt.isPresent());
+        assertTrue(managerOpt.get() instanceof HAGroupStoreManagerImpl);
+    }
+
+    @Test
+    public void testMutationBlockingWithSingleHAGroup() throws Exception {
+        String haGroupName = testName.getMethodName();
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(config);
+        assertTrue(managerOpt.isPresent());
+        HAGroupStoreManager haGroupStoreManager = managerOpt.get();
+
+        // Initially no mutation should be blocked
+        assertFalse(haGroupStoreManager.isMutationBlocked(config));
+        assertFalse(haGroupStoreManager.isMutationBlocked(config, haGroupName));
+
+        // Create HAGroupStoreRecord with ACTIVE role
+        HAGroupStoreRecord activeRecord = new HAGroupStoreRecord(
+                "1.0", haGroupName, ClusterRoleRecord.ClusterRole.ACTIVE,
+                1, "FAILOVER", System.currentTimeMillis(), "peer1:2181,peer2:2181");
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(activeRecord);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Still no mutation blocking with ACTIVE role
+        assertFalse(haGroupStoreManager.isMutationBlocked(config));
+        assertFalse(haGroupStoreManager.isMutationBlocked(config, haGroupName));
+
+        // Update to ACTIVE_TO_STANDBY role (should block mutations)
+        HAGroupStoreRecord transitionRecord = new HAGroupStoreRecord(
+                "1.0", haGroupName, ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                2, "FAILOVER", System.currentTimeMillis(), "peer1:2181,peer2:2181");
+
+        haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, transitionRecord, 0);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Now mutations should be blocked
+        assertTrue(haGroupStoreManager.isMutationBlocked(config));
+        assertTrue(haGroupStoreManager.isMutationBlocked(config, haGroupName));
+    }
+
+    @Test
+    public void testMutationBlockingWithMultipleHAGroups() throws Exception {
+        String haGroupName1 = testName.getMethodName() + "_1";
+        String haGroupName2 = testName.getMethodName() + "_2";
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(config);
+        assertTrue(managerOpt.isPresent());
+        HAGroupStoreManager haGroupStoreManager = managerOpt.get();
+
+        // Create two HA groups with ACTIVE and ACTIVE_NOT_IN_SYNC roles
+        HAGroupStoreRecord activeRecord1 = new HAGroupStoreRecord(
+                "1.0", haGroupName1, ClusterRoleRecord.ClusterRole.ACTIVE,
+                1, "FAILOVER", System.currentTimeMillis(), "peer1:2181");
+
+        HAGroupStoreRecord activeRecord2 = new HAGroupStoreRecord(
+                "1.0", haGroupName2, ClusterRoleRecord.ClusterRole.ACTIVE_NOT_IN_SYNC,
+                1, "PARALLEL", System.currentTimeMillis(), "peer2:2181");
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(activeRecord1);
+        haAdmin.createHAGroupStoreRecordInZooKeeper(activeRecord2);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // No mutations should be blocked
+        assertFalse(haGroupStoreManager.isMutationBlocked(config));
+        assertFalse(haGroupStoreManager.isMutationBlocked(config, haGroupName1));
+        assertFalse(haGroupStoreManager.isMutationBlocked(config, haGroupName2));
+
+        // Update only second group to ACTIVE_NOT_IN_SYNC_TO_STANDBY
+        HAGroupStoreRecord transitionRecord2 = new HAGroupStoreRecord(
+                "1.0", haGroupName2, ClusterRoleRecord.ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY,
+                2, "PARALLEL", System.currentTimeMillis(), "peer2:2181");
+
+        haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName2, transitionRecord2, 0);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Global mutations should be blocked due to second group
+        assertTrue(haGroupStoreManager.isMutationBlocked(config));
+        assertFalse(haGroupStoreManager.isMutationBlocked(config, haGroupName1));
+        assertTrue(haGroupStoreManager.isMutationBlocked(config, haGroupName2));
+    }
+
+    @Test
+    public void testHAGroupStoreRecord() throws Exception {
+        String haGroupName = testName.getMethodName();
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(config);
+        assertTrue(managerOpt.isPresent());
+        HAGroupStoreManager haGroupStoreManager = managerOpt.get();
+
+        // Test getting non-existent record
+        Optional<HAGroupStoreRecord> recordOpt = haGroupStoreManager.getHAGroupStoreRecord(config, haGroupName);
+        assertFalse(recordOpt.isPresent());
+
+        long fixedTimestamp = 1640995200000L; // Fixed timestamp for consistent comparison
+
+        // Create sample record
+        HAGroupStoreRecord record = new HAGroupStoreRecord(
+                "1.0", haGroupName, ClusterRoleRecord.ClusterRole.ACTIVE,
+                1, "FAILOVER", fixedTimestamp, "peer1:2181,peer2:2181");
+
+        // Store record, then retrieve and compare
+        haAdmin.createHAGroupStoreRecordInZooKeeper(record);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        Optional<HAGroupStoreRecord> retrievedOpt = haGroupStoreManager.getHAGroupStoreRecord(config, haGroupName);
+        assertTrue(retrievedOpt.isPresent());
+
+        HAGroupStoreRecord retrieved = retrievedOpt.get();
+
+        // Complete object comparison instead of field-by-field
+        assertEquals(record, retrieved);
+    }
+
+    @Test
+    public void testInvalidateHAGroupStoreClient() throws Exception {
+        String haGroupName = testName.getMethodName();
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(config);
+        assertTrue(managerOpt.isPresent());
+        HAGroupStoreManager haGroupStoreManager = managerOpt.get();
+
+        // Create a HAGroupStoreRecord first
+        HAGroupStoreRecord record = new HAGroupStoreRecord(
+                "1.0", haGroupName, ClusterRoleRecord.ClusterRole.ACTIVE,
+                1, "FAILOVER", System.currentTimeMillis(), null);
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(record);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Ensure we can get the record
+        Optional<HAGroupStoreRecord> recordOpt = haGroupStoreManager.getHAGroupStoreRecord(config, haGroupName);
+        assertTrue(recordOpt.isPresent());
+
+        // Invalidate the specific HA group client
+        haGroupStoreManager.invalidateHAGroupStoreClient(config, haGroupName);
+
+        // Should still be able to get the record after invalidation
+        recordOpt = haGroupStoreManager.getHAGroupStoreRecord(config, haGroupName);
+        assertTrue(recordOpt.isPresent());
+
+        // Test global invalidation
+        haGroupStoreManager.invalidateHAGroupStoreClient(config);
+
+        // Should still be able to get the record after global invalidation
+        recordOpt = haGroupStoreManager.getHAGroupStoreRecord(config, haGroupName);
+        assertTrue(recordOpt.isPresent());
+    }
+
+    @Test
+    public void testMutationBlockDisabled() throws Exception {
+        String haGroupName = testName.getMethodName();
+        // Create configuration with mutation block disabled
+        Configuration conf = new Configuration();
+        conf.set(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, "false");
+        conf.set(QueryServices.HA_GROUP_STORE_MANAGER_IMPL_CLASS, org.apache.phoenix.jdbc.HAGroupStoreManagerImpl.class.getName());
+        conf.set(HConstants.ZOOKEEPER_QUORUM, getLocalZkUrl(config));
+
+
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(conf);
+        assertTrue(managerOpt.isPresent());
+        HAGroupStoreManager haGroupStoreManager = managerOpt.get();
+
+        // Create HAGroupStoreRecord with ACTIVE_TO_STANDBY role
+        HAGroupStoreRecord transitionRecord = new HAGroupStoreRecord(
+                "1.0", haGroupName, ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                1, "FAILOVER", System.currentTimeMillis(), "peer1:2181");
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(transitionRecord);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Mutations should not be blocked even with ACTIVE_TO_STANDBY role
+        assertFalse(haGroupStoreManager.isMutationBlocked(config));
+        assertFalse(haGroupStoreManager.isMutationBlocked(config, haGroupName));
+    }
+
+    @Test
+    public void testSetHAGroupStatusToStoreAndForward() throws Exception {
+        String haGroupName = testName.getMethodName();
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(config);
+        assertTrue(managerOpt.isPresent());
+        HAGroupStoreManager haGroupStoreManager = managerOpt.get();
+
+        // Create an initial HAGroupStoreRecord with ACTIVE status
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord(
+                "1.0", haGroupName, ClusterRoleRecord.ClusterRole.ACTIVE,
+                1, "FAILOVER", System.currentTimeMillis(), "peer1:2181");
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(initialRecord);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Set the HA group status to store and forward (ACTIVE_NOT_IN_SYNC)
+        haGroupStoreManager.setHAGroupStatusToStoreAndForward(config, haGroupName);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Verify the status was updated to ACTIVE_NOT_IN_SYNC
+        Optional<HAGroupStoreRecord> updatedRecordOpt = haGroupStoreManager.getHAGroupStoreRecord(config, haGroupName);
+        assertTrue(updatedRecordOpt.isPresent());
+        HAGroupStoreRecord updatedRecord = updatedRecordOpt.get();
+        assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE_NOT_IN_SYNC, updatedRecord.getClusterRole());
+        assertEquals(2, updatedRecord.getVersion()); // Version should be incremented
+    }
+
+    @Test
+    public void testSetHAGroupStatusRecordToSync() throws Exception {
+        String haGroupName = testName.getMethodName();
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(config);
+        assertTrue(managerOpt.isPresent());
+        HAGroupStoreManager haGroupStoreManager = managerOpt.get();
+
+        // Create an initial HAGroupStoreRecord with ACTIVE_NOT_IN_SYNC status
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord(
+                "1.0", haGroupName, ClusterRoleRecord.ClusterRole.ACTIVE_NOT_IN_SYNC,
+                1, "FAILOVER", System.currentTimeMillis(), "peer1:2181");
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(initialRecord);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Set the HA group status to sync (ACTIVE)
+        haGroupStoreManager.setHAGroupStatusRecordToSync(config, haGroupName);
+        Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+
+        // Verify the status was updated to ACTIVE
+        Optional<HAGroupStoreRecord> updatedRecordOpt = haGroupStoreManager.getHAGroupStoreRecord(config, haGroupName);
+        assertTrue(updatedRecordOpt.isPresent());
+        HAGroupStoreRecord updatedRecord = updatedRecordOpt.get();
+        assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE, updatedRecord.getClusterRole());
+        assertEquals(2, updatedRecord.getVersion()); // Version should be incremented
+    }
+
+    @Test
+    public void testSetHAGroupStatusMethodsWithNonExistentGroup() throws Exception {
+        String nonExistentGroupName = testName.getMethodName() + "_nonexistent";
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(config);
+        assertTrue(managerOpt.isPresent());
+        HAGroupStoreManager haGroupStoreManager = managerOpt.get();
+
+        // Test setHAGroupStatusToStoreAndForward with non-existent group
+        try {
+            haGroupStoreManager.setHAGroupStatusToStoreAndForward(config, nonExistentGroupName);
+            fail("Expected IOException to be thrown");
+        } catch (IOException e) {
+            assertEquals("HAGroupStoreRecord not found in system table for HA group " + nonExistentGroupName, e.getMessage());
+        }
+
+        // Test setHAGroupStatusRecordToSync with non-existent group
+        try {
+            haGroupStoreManager.setHAGroupStatusRecordToSync(config, nonExistentGroupName);
+            fail("Expected IOException to be thrown");
+        } catch (IOException e) {
+            assertEquals("HAGroupStoreRecord not found in system table for HA group " + nonExistentGroupName, e.getMessage());
+        }
+    }
+}

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerV1ImplIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerV1ImplIT.java
@@ -28,6 +28,7 @@ import org.junit.experimental.categories.Category;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
 import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
@@ -35,7 +36,7 @@ import static org.junit.Assert.assertFalse;
 
 
 @Category(NeedsOwnMiniClusterTest.class)
-public class HAGroupStoreManagerIT extends BaseTest {
+public class HAGroupStoreManagerV1ImplIT extends BaseTest {
     private final PhoenixHAAdmin haAdmin = new PhoenixHAAdmin(config);
     private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 1000L;
 
@@ -57,7 +58,9 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
     @Test
     public void testHAGroupStoreManagerWithSingleCRR() throws Exception {
-        HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+        Optional<HAGroupStoreManager> haGroupStoreManagerOptional = HAGroupStoreManagerFactory.getInstance(config);
+        assert haGroupStoreManagerOptional.isPresent();
+        HAGroupStoreManager haGroupStoreManager = haGroupStoreManagerOptional.get();
         // Setup initial CRRs
         ClusterRoleRecord crr1 = new ClusterRoleRecord("failover",
                 HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
@@ -70,7 +73,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
-        assertFalse(haGroupStoreManager.isMutationBlocked());
+        assertFalse(haGroupStoreManager.isMutationBlocked(config));
 
         crr1 = new ClusterRoleRecord("failover",
                 HighAvailabilityPolicy.FAILOVER, haAdmin.getZkUrl(), ClusterRoleRecord.ClusterRole.ACTIVE,
@@ -83,6 +86,6 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
         Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
-        assert haGroupStoreManager.isMutationBlocked();
+        assert haGroupStoreManager.isMutationBlocked(config);
     }
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityGroupTestIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityGroupTestIT.java
@@ -302,8 +302,9 @@ public class HighAvailabilityGroupTestIT {
         // Make ZK connectable and the cluster role record be missing
         CuratorFramework curator = mock(CuratorFramework.class);
         when(curator.blockUntilConnected(anyInt(), any(TimeUnit.class))).thenReturn(true);
-        HighAvailabilityGroup.CURATOR_CACHE.put(ZK2, curator);
-        HighAvailabilityGroup.CURATOR_CACHE.put(ZK1, curator);
+        // Use proper cache keys with default namespace
+        HighAvailabilityGroup.CURATOR_CACHE.put(HighAvailabilityGroup.generateCacheKey(ZK2, null), curator);
+        HighAvailabilityGroup.CURATOR_CACHE.put(HighAvailabilityGroup.generateCacheKey(ZK1, null), curator);
 
         ExistsBuilder eb = mock(ExistsBuilder.class);
         when(eb.forPath(anyString())).thenReturn(null);

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/ParallelPhoenixConnectionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/ParallelPhoenixConnectionIT.java
@@ -36,6 +36,7 @@ import static org.apache.phoenix.monitoring.GlobalClientMetrics.GLOBAL_HA_PARALL
 import static org.apache.phoenix.monitoring.GlobalClientMetrics.GLOBAL_HA_PARALLEL_POOL2_TASK_REJECTED_COUNTER;
 import static org.apache.phoenix.query.BaseTest.extractThreadPoolExecutorFromCQSI;
 import static org.apache.phoenix.query.QueryServices.AUTO_COMMIT_ATTRIB;
+import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
 import static org.apache.phoenix.query.QueryServices.CQSI_THREAD_POOL_ALLOW_CORE_THREAD_TIMEOUT;
 import static org.apache.phoenix.query.QueryServices.CQSI_THREAD_POOL_CORE_POOL_SIZE;
 import static org.apache.phoenix.query.QueryServices.CQSI_THREAD_POOL_ENABLED;
@@ -51,14 +52,17 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.doAnswer;
 
-import java.lang.reflect.Field;
 import java.sql.Connection;
+import java.lang.reflect.Field;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -66,9 +70,11 @@ import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
 import org.apache.hadoop.hbase.util.VersionInfo;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
+import org.apache.phoenix.exception.MutationBlockedIOException;
 import org.apache.phoenix.jdbc.ClusterRoleRecord.ClusterRole;
 import org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.HBaseTestingUtilityPair;
 import org.apache.phoenix.jdbc.PhoenixStatement.Operation;
@@ -118,6 +124,8 @@ public class ParallelPhoenixConnectionIT {
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
+        CLUSTERS.getHBaseCluster1().getConfiguration().setBoolean(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, true);
+        CLUSTERS.getHBaseCluster2().getConfiguration().setBoolean(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, true);
         CLUSTERS.start();
         DriverManager.registerDriver(PhoenixDriver.INSTANCE);
         DriverManager.registerDriver(new PhoenixTestDriver());
@@ -131,6 +139,7 @@ public class ParallelPhoenixConnectionIT {
         GLOBAL_PROPERTIES.setProperty(CQSI_THREAD_POOL_MAX_QUEUE, String.valueOf(23));
         GLOBAL_PROPERTIES.setProperty(CQSI_THREAD_POOL_ALLOW_CORE_THREAD_TIMEOUT,
             String.valueOf(true));
+        GLOBAL_PROPERTIES.setProperty("hbase.client.retries.number", "0");
         GLOBAL_PROPERTIES.setProperty(CQSI_THREAD_POOL_METRICS_ENABLED, String.valueOf(true));
     }
 
@@ -354,6 +363,67 @@ public class ParallelPhoenixConnectionIT {
         try (Connection conn = getParallelConnection()) {
             doTestBasicOperationsWithConnection(conn, tableName, haGroupName);
         }
+    }
+
+    /**
+     * Test Phoenix connection creation and basic operations with HBase both cluster is ACTIVE_TO_STANDBY role.
+     */
+    @Test
+    public void testBothClusterATSRole() throws Exception {
+        CLUSTERS.transitClusterRole(haGroup, ClusterRole.ACTIVE_TO_STANDBY, ClusterRole.ACTIVE_TO_STANDBY);
+        try (Connection conn = getParallelConnection()) {
+            doTestBasicOperationsWithConnection(conn, tableName, haGroupName);
+            fail("Expected MutationBlockedIOException to be thrown");
+        } catch (SQLException e) {
+            assertTrue(containsMutationBlockedException(e));
+        } finally {
+            CLUSTERS.transitClusterRole(haGroup, ClusterRole.ACTIVE, ClusterRole.STANDBY);
+        }
+    }
+
+    /**
+     * Test Phoenix connection creation and
+     * basic operations with HBase one cluster is ACTIVE_TO_STANDBY role
+     * and other in ACTIVE role.
+     */
+    @Test
+    public void testOneClusterATSRoleWithActive() throws Exception {
+        testOneClusterATSRole(ClusterRole.ACTIVE);
+    }
+
+    /**
+     * Test Phoenix connection creation and
+     * basic operations with HBase one cluster is ACTIVE_TO_STANDBY role
+     * and other in STANDBY role.
+     */
+    @Test
+    public void testOneClusterATSRoleWithStandby() throws Exception {
+        testOneClusterATSRole(ClusterRole.STANDBY);
+    }
+
+    private void testOneClusterATSRole(ClusterRole otherRole) throws Exception {
+        CLUSTERS.transitClusterRole(haGroup, ClusterRole.ACTIVE_TO_STANDBY, otherRole);
+        try (Connection conn = getParallelConnection()) {
+            doTestBasicOperationsWithConnection(conn, tableName, haGroupName);
+        } catch (SQLException e) {
+            fail("Expected no exception to be thrown as one cluster is "
+                    + "in ACTIVE_TO_STANDBY and other in " + otherRole);
+        } finally {
+            CLUSTERS.transitClusterRole(haGroup, ClusterRole.ACTIVE, ClusterRole.STANDBY);
+        }
+    }
+
+    private boolean containsMutationBlockedException(SQLException e) {
+        Throwable cause = e.getCause();
+        // Recursively check for MutationBlockedIOException buried in exception stack.
+        while (cause != null) {
+            if (cause instanceof RetriesExhaustedWithDetailsException) {
+                RetriesExhaustedWithDetailsException re = (RetriesExhaustedWithDetailsException) cause;
+                return re.getCause(0) instanceof MutationBlockedIOException;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 
     /**

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/PhoenixHAAdminIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/PhoenixHAAdminIT.java
@@ -1,0 +1,551 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
+import org.apache.phoenix.exception.StaleHAGroupStoreRecordVersionException;
+import org.apache.phoenix.query.BaseTest;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
+import org.apache.phoenix.util.ReadOnlyProps;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.phoenix.jdbc.HAGroupStoreClient.ZK_CONSISTENT_HA_NAMESPACE;
+import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration tests for {@link PhoenixHAAdmin} HAGroupStoreRecord operations
+ */
+@Category(NeedsOwnMiniClusterTest.class)
+public class PhoenixHAAdminIT extends BaseTest {
+
+    private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS = new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
+    private PhoenixHAAdmin haAdmin;
+    private PhoenixHAAdmin peerHaAdmin;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @BeforeClass
+    public static synchronized void doSetup() throws Exception {
+        Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
+        setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+        CLUSTERS.start();
+    }
+
+    @Before
+    public void before() throws Exception {
+        haAdmin = new PhoenixHAAdmin(CLUSTERS.getHBaseCluster1().getConfiguration(), ZK_CONSISTENT_HA_NAMESPACE);
+        peerHaAdmin = new PhoenixHAAdmin(CLUSTERS.getHBaseCluster2().getConfiguration(), ZK_CONSISTENT_HA_NAMESPACE);
+        cleanupTestZnodes();
+    }
+
+    @After
+    public void after() throws Exception {
+        cleanupTestZnodes();
+        if (haAdmin != null) {
+            haAdmin.close();
+        }
+        if (peerHaAdmin != null) {
+            peerHaAdmin.close();
+        }
+    }
+
+    private void cleanupTestZnodes() throws Exception {
+        haAdmin.getCurator().delete().quietly().forPath(toPath(testName.getMethodName()));
+        peerHaAdmin.getCurator().delete().quietly().forPath(toPath(testName.getMethodName()));
+    }
+
+    @Test
+    public void testCreateHAGroupStoreRecordInZooKeeper() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        HAGroupStoreRecord record = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE,
+                1,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        // Create the record in ZooKeeper
+        haAdmin.createHAGroupStoreRecordInZooKeeper(record);
+
+        // Verify the record was created by reading it back
+        byte[] data = haAdmin.getCurator().getData().forPath(toPath(haGroupName));
+        HAGroupStoreRecord savedRecord = HAGroupStoreRecord.fromJson(data).get();
+
+        assertEquals(record.getHaGroupName(), savedRecord.getHaGroupName());
+        assertEquals(record.getClusterRole(), savedRecord.getClusterRole());
+        assertEquals(record.getVersion(), savedRecord.getVersion());
+        assertEquals(record.getPolicy(), savedRecord.getPolicy());
+        assertEquals(record.getPeerZKUrl(), savedRecord.getPeerZKUrl());
+    }
+
+    @Test
+    public void testCreateHAGroupStoreRecordInZooKeeperWithExistingNode() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        HAGroupStoreRecord record1 = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE,
+                1,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        // Create the first record
+        haAdmin.createHAGroupStoreRecordInZooKeeper(record1);
+
+        // Try to create again with different data
+        HAGroupStoreRecord record2 = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.STANDBY,
+                2,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        // This should throw an exception due to NodeExistsException handling
+        try {
+            haAdmin.createHAGroupStoreRecordInZooKeeper(record2);
+            fail("Expected NodeExistsException");
+        } catch (IOException e) {
+            // Expected exception
+            assertTrue(e.getCause() instanceof KeeperException.NodeExistsException);
+            assertTrue(e.getMessage().contains("Failed to create HAGroupStoreRecord for HA group"));
+        }
+
+        // Verify the original record is still there (not overwritten)
+        byte[] data = haAdmin.getCurator().getData().forPath(toPath(haGroupName));
+        HAGroupStoreRecord savedRecord = HAGroupStoreRecord.fromJson(data).get();
+
+        assertEquals(record1.getClusterRole(), savedRecord.getClusterRole());
+        assertEquals(record1.getVersion(), savedRecord.getVersion());
+    }
+
+    @Test
+    public void testUpdateHAGroupStoreRecordInZooKeeper() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE,
+                1,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(initialRecord);
+
+        // Get the current stat for version checking
+        Stat stat = haAdmin.getCurator().checkExists().forPath(toPath(haGroupName));
+        assertNotNull(stat);
+        int currentVersion = stat.getVersion();
+
+        // Update the record
+        HAGroupStoreRecord updatedRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.STANDBY,
+                2,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, currentVersion);
+
+        // Verify the record was updated
+        byte[] data = haAdmin.getCurator().getData().forPath(toPath(haGroupName));
+        HAGroupStoreRecord savedRecord = HAGroupStoreRecord.fromJson(data).get();
+
+        assertEquals(updatedRecord.getClusterRole(), savedRecord.getClusterRole());
+        assertEquals(updatedRecord.getVersion(), savedRecord.getVersion());
+    }
+
+    @Test
+    public void testUpdateHAGroupStoreRecordInZooKeeperWithStaleVersion() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE,
+                1,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(initialRecord);
+
+        // Get the current stat for version checking
+        Stat stat = haAdmin.getCurator().checkExists().forPath(toPath(haGroupName));
+        assertNotNull(stat);
+        int currentVersion = stat.getVersion();
+
+        // Update the record with current version (should succeed)
+        HAGroupStoreRecord updatedRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.STANDBY,
+                2,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, currentVersion);
+
+        // Try to update again with the same (now stale) version - should fail
+        HAGroupStoreRecord anotherUpdate = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+                3,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        try {
+            haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, anotherUpdate, currentVersion);
+            fail("Expected StaleHAGroupStoreRecordVersionException");
+        } catch (StaleHAGroupStoreRecordVersionException e) {
+            // Expected exception
+            assertTrue(e.getMessage().contains("with cached stat version"));
+        }
+    }
+
+    @Test
+    public void testGetHAGroupStoreRecordInZooKeeper() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE,
+                1,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(initialRecord);
+
+        // Get the record and stat
+        Pair<HAGroupStoreRecord, Stat> result = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+
+        assertNotNull(result);
+        assertNotNull(result.getLeft());
+        assertNotNull(result.getRight());
+
+        HAGroupStoreRecord retrievedRecord = result.getLeft();
+        Stat stat = result.getRight();
+
+        assertEquals(initialRecord.getHaGroupName(), retrievedRecord.getHaGroupName());
+        assertEquals(initialRecord.getClusterRole(), retrievedRecord.getClusterRole());
+        assertEquals(initialRecord.getVersion(), retrievedRecord.getVersion());
+        assertEquals(initialRecord.getPolicy(), retrievedRecord.getPolicy());
+        assertEquals(initialRecord.getPeerZKUrl(), retrievedRecord.getPeerZKUrl());
+
+        // Verify stat is valid
+        assertTrue(stat.getVersion() >= 0);
+        assertTrue(stat.getCtime() > 0);
+        assertTrue(stat.getMtime() > 0);
+    }
+
+    @Test
+    public void testGetHAGroupStoreRecordInZooKeeperNonExistentNode() throws Exception {
+        String haGroupName = testName.getMethodName();
+
+        try {
+            haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+            fail("Expected IOException for non-existent node");
+        } catch (IOException e) {
+            // Expected exception
+            assertTrue(e.getMessage().contains("Failed to get HAGroupStoreRecord"));
+        }
+    }
+
+    @Test
+    public void testCompleteWorkflowCreateUpdateGet() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Step 1: Create initial record
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE,
+                1,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(initialRecord);
+
+        // Step 2: Get the record
+        Pair<HAGroupStoreRecord, Stat> result = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+        HAGroupStoreRecord retrievedRecord = result.getLeft();
+        Stat stat = result.getRight();
+
+        assertEquals(initialRecord.getHaGroupName(), retrievedRecord.getHaGroupName());
+        assertEquals(initialRecord.getClusterRole(), retrievedRecord.getClusterRole());
+        assertEquals(initialRecord.getVersion(), retrievedRecord.getVersion());
+
+        // Step 3: Update the record
+        HAGroupStoreRecord updatedRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.STANDBY,
+                2,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, stat.getVersion());
+
+        // Step 4: Get the updated record
+        Pair<HAGroupStoreRecord, Stat> updatedResult = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+        HAGroupStoreRecord finalRecord = updatedResult.getLeft();
+        Stat finalStat = updatedResult.getRight();
+
+        assertEquals(updatedRecord.getClusterRole(), finalRecord.getClusterRole());
+        assertEquals(updatedRecord.getVersion(), finalRecord.getVersion());
+
+        // Verify stat version increased
+        assertTrue(finalStat.getVersion() > stat.getVersion());
+    }
+
+    @Test
+    public void testMultiThreadedUpdatesConcurrentVersionConflict() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE,
+                1,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(initialRecord);
+
+        // Get the current stat for version checking
+        Pair<HAGroupStoreRecord, Stat> result = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+        int currentVersion = result.getRight().getVersion();
+
+        // Number of threads to run concurrently
+        int threadCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(threadCount);
+
+        // Counters for tracking results
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger staleVersionExceptionCount = new AtomicInteger(0);
+        AtomicInteger otherExceptionCount = new AtomicInteger(0);
+
+        // Submit multiple threads that will all try to update with the same version
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executorService.submit(() -> {
+                try {
+                    // Wait for all threads to be ready
+                    startLatch.await();
+
+                    // Create a unique update record for this thread
+                    HAGroupStoreRecord updatedRecord = new HAGroupStoreRecord(
+                            "v1.0",
+                            haGroupName,
+                            ClusterRoleRecord.ClusterRole.STANDBY,
+                            2 + threadId, // Different version for each thread
+                            "FAILOVER",
+                            System.currentTimeMillis(),
+                            peerZKUrl
+                    );
+
+                    // All threads use the same currentVersion, causing conflicts
+                    haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, currentVersion);
+                    successCount.incrementAndGet();
+
+                } catch (StaleHAGroupStoreRecordVersionException e) {
+                    staleVersionExceptionCount.incrementAndGet();
+                } catch (Exception e) {
+                    otherExceptionCount.incrementAndGet();
+                } finally {
+                    finishLatch.countDown();
+                }
+            });
+        }
+
+        // Start all threads at the same time
+        startLatch.countDown();
+
+        // Wait for all threads to complete
+        assertTrue("Threads did not complete within timeout",
+                finishLatch.await(10, TimeUnit.SECONDS));
+
+        executorService.shutdown();
+        assertTrue("ExecutorService did not shutdown within timeout",
+                executorService.awaitTermination(5, TimeUnit.SECONDS));
+
+        // Verify results
+        assertEquals("No other exceptions should occur", 0, otherExceptionCount.get());
+        assertEquals("Exactly one thread should succeed", 1, successCount.get());
+        assertEquals("All other threads should get stale version exception",
+                threadCount - 1, staleVersionExceptionCount.get());
+
+        // Verify the final state - should contain the update from the successful thread
+        Pair<HAGroupStoreRecord, Stat> finalResult = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+        HAGroupStoreRecord finalRecord = finalResult.getLeft();
+        Stat finalStat = finalResult.getRight();
+
+        // The successful update should have changed the role to STANDBY
+        assertEquals(ClusterRoleRecord.ClusterRole.STANDBY, finalRecord.getClusterRole());
+
+        // The ZooKeeper version should have increased
+        assertTrue("ZooKeeper version should have increased", finalStat.getVersion() > currentVersion);
+    }
+
+    @Test
+    public void testMultiThreadedUpdatesWithDifferentVersions() throws Exception {
+        String haGroupName = testName.getMethodName();
+        String peerZKUrl = CLUSTERS.getZkUrl2();
+
+        // Create initial record
+        HAGroupStoreRecord initialRecord = new HAGroupStoreRecord(
+                "v1.0",
+                haGroupName,
+                ClusterRoleRecord.ClusterRole.ACTIVE,
+                1,
+                "FAILOVER",
+                System.currentTimeMillis(),
+                peerZKUrl
+        );
+
+        haAdmin.createHAGroupStoreRecordInZooKeeper(initialRecord);
+
+        // Number of threads to run sequentially (each gets the latest version)
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(1); // Single thread pool for sequential execution
+        CountDownLatch finishLatch = new CountDownLatch(threadCount);
+
+        // Counter for tracking results
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        // Submit multiple threads that will update sequentially
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executorService.submit(() -> {
+                try {
+                    // Get the current version for this thread
+                    Pair<HAGroupStoreRecord, Stat> currentResult = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+                    int currentVersion = currentResult.getRight().getVersion();
+
+                    // Create update record for this thread
+                    HAGroupStoreRecord updatedRecord = new HAGroupStoreRecord(
+                            "v1.0",
+                            haGroupName,
+                            threadId % 2 == 0 ? ClusterRoleRecord.ClusterRole.ACTIVE : ClusterRoleRecord.ClusterRole.STANDBY,
+                            2 + threadId,
+                            "FAILOVER",
+                            System.currentTimeMillis(),
+                            peerZKUrl
+                    );
+
+                    // Update with the current version
+                    haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, currentVersion);
+                    successCount.incrementAndGet();
+
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    finishLatch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to complete
+        assertTrue("Threads did not complete within timeout",
+                finishLatch.await(15, TimeUnit.SECONDS));
+
+        executorService.shutdown();
+        assertTrue("ExecutorService did not shutdown within timeout",
+                executorService.awaitTermination(5, TimeUnit.SECONDS));
+
+        // Verify results - all should succeed since they each get the latest version
+        assertEquals("All threads should succeed when using correct versions",
+                threadCount, successCount.get());
+        assertEquals("No threads should fail", 0, failureCount.get());
+
+        // Verify the final state
+        Pair<HAGroupStoreRecord, Stat> finalResult = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName);
+        HAGroupStoreRecord finalRecord = finalResult.getLeft();
+
+        // The final record should have the version from the last update
+        assertEquals(threadCount + 1, finalRecord.getVersion());
+    }
+
+
+}

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ClusterRoleRecordTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/ClusterRoleRecordTest.java
@@ -17,18 +17,18 @@
  */
 package org.apache.phoenix.jdbc;
 
+import static org.apache.phoenix.query.QueryServices.HA_STORE_AND_FORWARD_MODE_REFRESH_INTERVAL_MS;
+import static org.apache.phoenix.query.QueryServices.HA_SYNC_MODE_REFRESH_INTERVAL_MS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -47,6 +47,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+// Additional imports for configuration and exceptions
+import org.apache.hadoop.conf.Configuration;
+import org.apache.phoenix.exception.InvalidClusterRoleTransitionException;
 
 /**
  * Unit test for {@link ClusterRoleRecord}.
@@ -275,10 +279,305 @@ public class ClusterRoleRecordTest {
         assertNotEquals(record.toString(), record.toPrettyString());
     }
 
+    // Tests for ClusterRole enum
+
+    @Test
+    public void testClusterRoleValues() {
+        ClusterRole[] expectedRoles = {
+                ClusterRole.ABORT_TO_ACTIVE,
+                ClusterRole.ABORT_TO_STANDBY,
+                ClusterRole.ACTIVE,
+                ClusterRole.ACTIVE_NOT_IN_SYNC,
+                ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY,
+                ClusterRole.ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER,
+                ClusterRole.ACTIVE_TO_STANDBY,
+                ClusterRole.ACTIVE_WITH_OFFLINE_PEER,
+                ClusterRole.DEGRADED_STANDBY,
+                ClusterRole.DEGRADED_STANDBY_FOR_READER,
+                ClusterRole.DEGRADED_STANDBY_FOR_WRITER,
+                ClusterRole.OFFLINE,
+                ClusterRole.STANDBY,
+                ClusterRole.STANDBY_TO_ACTIVE,
+                ClusterRole.UNKNOWN
+        };
+
+        ClusterRole[] actualRoles = ClusterRole.values();
+        assertEquals("Number of ClusterRole values", expectedRoles.length, actualRoles.length);
+
+        for (int i = 0; i < expectedRoles.length; i++) {
+            assertEquals("ClusterRole at index " + i, expectedRoles[i], actualRoles[i]);
+        }
+    }
+
+    @Test
+    public void testClusterRoleValueOf() {
+        assertEquals(ClusterRole.ABORT_TO_ACTIVE, ClusterRole.valueOf("ABORT_TO_ACTIVE"));
+        assertEquals(ClusterRole.ABORT_TO_STANDBY, ClusterRole.valueOf("ABORT_TO_STANDBY"));
+        assertEquals(ClusterRole.ACTIVE, ClusterRole.valueOf("ACTIVE"));
+        assertEquals(ClusterRole.ACTIVE_NOT_IN_SYNC, ClusterRole.valueOf("ACTIVE_NOT_IN_SYNC"));
+        assertEquals(ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY, ClusterRole.valueOf("ACTIVE_NOT_IN_SYNC_TO_STANDBY"));
+        assertEquals(ClusterRole.ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER, ClusterRole.valueOf("ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER"));
+        assertEquals(ClusterRole.ACTIVE_TO_STANDBY, ClusterRole.valueOf("ACTIVE_TO_STANDBY"));
+        assertEquals(ClusterRole.ACTIVE_WITH_OFFLINE_PEER, ClusterRole.valueOf("ACTIVE_WITH_OFFLINE_PEER"));
+        assertEquals(ClusterRole.DEGRADED_STANDBY, ClusterRole.valueOf("DEGRADED_STANDBY"));
+        assertEquals(ClusterRole.DEGRADED_STANDBY_FOR_READER, ClusterRole.valueOf("DEGRADED_STANDBY_FOR_READER"));
+        assertEquals(ClusterRole.DEGRADED_STANDBY_FOR_WRITER, ClusterRole.valueOf("DEGRADED_STANDBY_FOR_WRITER"));
+        assertEquals(ClusterRole.OFFLINE, ClusterRole.valueOf("OFFLINE"));
+        assertEquals(ClusterRole.STANDBY, ClusterRole.valueOf("STANDBY"));
+        assertEquals(ClusterRole.STANDBY_TO_ACTIVE, ClusterRole.valueOf("STANDBY_TO_ACTIVE"));
+        assertEquals(ClusterRole.UNKNOWN, ClusterRole.valueOf("UNKNOWN"));
+    }
+
+    @Test
+    public void testClusterRoleValueOfInvalid() {
+        try {
+            ClusterRole.valueOf("INVALID_ROLE");
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            ClusterRole.valueOf(null);
+            fail("Expected NullPointerException");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testClusterRoleCanConnect() {
+        // Roles that can connect
+        assertTrue(ClusterRole.ABORT_TO_ACTIVE.canConnect());
+        assertTrue(ClusterRole.ABORT_TO_STANDBY.canConnect());
+        assertTrue(ClusterRole.ACTIVE.canConnect());
+        assertTrue(ClusterRole.ACTIVE_NOT_IN_SYNC.canConnect());
+        assertTrue(ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY.canConnect());
+        assertTrue(ClusterRole.ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER.canConnect());
+        assertTrue(ClusterRole.ACTIVE_TO_STANDBY.canConnect());
+        assertTrue(ClusterRole.ACTIVE_WITH_OFFLINE_PEER.canConnect());
+        assertTrue(ClusterRole.DEGRADED_STANDBY.canConnect());
+        assertTrue(ClusterRole.DEGRADED_STANDBY_FOR_READER.canConnect());
+        assertTrue(ClusterRole.DEGRADED_STANDBY_FOR_WRITER.canConnect());
+        assertTrue(ClusterRole.STANDBY.canConnect());
+        assertTrue(ClusterRole.STANDBY_TO_ACTIVE.canConnect());
+
+        // Roles that cannot connect
+        assertFalse(ClusterRole.OFFLINE.canConnect());
+        assertFalse(ClusterRole.UNKNOWN.canConnect());
+    }
+
+    @Test
+    public void testClusterRoleIsActive() {
+        // Active roles
+        assertTrue(ClusterRole.ACTIVE.isActive());
+        assertTrue(ClusterRole.ACTIVE_NOT_IN_SYNC.isActive());
+        assertTrue(ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY.isActive());
+        assertTrue(ClusterRole.ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER.isActive());
+        assertTrue(ClusterRole.ACTIVE_TO_STANDBY.isActive());
+        assertTrue(ClusterRole.ACTIVE_WITH_OFFLINE_PEER.isActive());
+
+        // Non-active roles
+        assertFalse(ClusterRole.ABORT_TO_ACTIVE.isActive());
+        assertFalse(ClusterRole.ABORT_TO_STANDBY.isActive());
+        assertFalse(ClusterRole.DEGRADED_STANDBY.isActive());
+        assertFalse(ClusterRole.DEGRADED_STANDBY_FOR_READER.isActive());
+        assertFalse(ClusterRole.DEGRADED_STANDBY_FOR_WRITER.isActive());
+        assertFalse(ClusterRole.OFFLINE.isActive());
+        assertFalse(ClusterRole.STANDBY.isActive());
+        assertFalse(ClusterRole.STANDBY_TO_ACTIVE.isActive());
+        assertFalse(ClusterRole.UNKNOWN.isActive());
+    }
+
+    @Test
+    public void testClusterRoleIsStandby() {
+        // Standby roles
+        assertTrue(ClusterRole.DEGRADED_STANDBY.isStandby());
+        assertTrue(ClusterRole.DEGRADED_STANDBY_FOR_READER.isStandby());
+        assertTrue(ClusterRole.DEGRADED_STANDBY_FOR_WRITER.isStandby());
+        assertTrue(ClusterRole.STANDBY.isStandby());
+        assertTrue(ClusterRole.STANDBY_TO_ACTIVE.isStandby());
+
+        // Non-standby roles
+        assertFalse(ClusterRole.ABORT_TO_ACTIVE.isStandby());
+        assertFalse(ClusterRole.ABORT_TO_STANDBY.isStandby());
+        assertFalse(ClusterRole.ACTIVE.isStandby());
+        assertFalse(ClusterRole.ACTIVE_NOT_IN_SYNC.isStandby());
+        assertFalse(ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY.isStandby());
+        assertFalse(ClusterRole.ACTIVE_TO_STANDBY.isStandby());
+        assertFalse(ClusterRole.ACTIVE_WITH_OFFLINE_PEER.isStandby());
+        assertFalse(ClusterRole.OFFLINE.isStandby());
+        assertFalse(ClusterRole.UNKNOWN.isStandby());
+    }
+
+    @Test
+    public void testClusterRoleIsMutationBlocked() {
+        assertTrue(ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY.isMutationBlocked());
+        assertTrue(ClusterRole.ACTIVE_TO_STANDBY.isMutationBlocked());
+
+        assertFalse(ClusterRole.DEGRADED_STANDBY.isMutationBlocked());
+        assertFalse(ClusterRole.DEGRADED_STANDBY_FOR_READER.isMutationBlocked());
+        assertFalse(ClusterRole.DEGRADED_STANDBY_FOR_WRITER.isMutationBlocked());
+        assertFalse(ClusterRole.STANDBY.isMutationBlocked());
+        assertFalse(ClusterRole.STANDBY_TO_ACTIVE.isMutationBlocked());
+        assertFalse(ClusterRole.ABORT_TO_ACTIVE.isMutationBlocked());
+        assertFalse(ClusterRole.ABORT_TO_STANDBY.isMutationBlocked());
+        assertFalse(ClusterRole.ACTIVE.isMutationBlocked());
+        assertFalse(ClusterRole.ACTIVE_NOT_IN_SYNC.isMutationBlocked());
+        assertFalse(ClusterRole.ACTIVE_WITH_OFFLINE_PEER.isMutationBlocked());
+        assertFalse(ClusterRole.OFFLINE.isMutationBlocked());
+        assertFalse(ClusterRole.UNKNOWN.isMutationBlocked());
+    }
+
+    @Test
+    public void testClusterRoleFromBytes() {
+        // Test valid role names
+        assertEquals(ClusterRole.ACTIVE, ClusterRole.from("ACTIVE".getBytes()));
+        assertEquals(ClusterRole.ACTIVE_TO_STANDBY, ClusterRole.from("ACTIVE_TO_STANDBY".getBytes()));
+        assertEquals(ClusterRole.OFFLINE, ClusterRole.from("OFFLINE".getBytes()));
+        assertEquals(ClusterRole.STANDBY, ClusterRole.from("STANDBY".getBytes()));
+        assertEquals(ClusterRole.UNKNOWN, ClusterRole.from("UNKNOWN".getBytes()));
+
+        // Test case insensitive
+        assertEquals(ClusterRole.ACTIVE, ClusterRole.from("active".getBytes()));
+        assertEquals(ClusterRole.ACTIVE_TO_STANDBY, ClusterRole.from("active_to_standby".getBytes()));
+        assertEquals(ClusterRole.STANDBY, ClusterRole.from("standby".getBytes()));
+
+        // Test mixed case
+        assertEquals(ClusterRole.ACTIVE, ClusterRole.from("Active".getBytes()));
+        assertEquals(ClusterRole.STANDBY, ClusterRole.from("StAnDbY".getBytes()));
+
+        // Test invalid role name - should return UNKNOWN
+        assertEquals(ClusterRole.UNKNOWN, ClusterRole.from("".getBytes()));
+        assertEquals(ClusterRole.UNKNOWN, ClusterRole.from("INVALID_ROLE".getBytes()));
+        assertEquals(ClusterRole.UNKNOWN, ClusterRole.from("null".getBytes()));
+    }
+
+    @Test
+    public void testClusterRoleToString() {
+        assertEquals("ABORT_TO_ACTIVE", ClusterRole.ABORT_TO_ACTIVE.toString());
+        assertEquals("ABORT_TO_STANDBY", ClusterRole.ABORT_TO_STANDBY.toString());
+        assertEquals("ACTIVE", ClusterRole.ACTIVE.toString());
+        assertEquals("ACTIVE_NOT_IN_SYNC", ClusterRole.ACTIVE_NOT_IN_SYNC.toString());
+        assertEquals("ACTIVE_NOT_IN_SYNC_TO_STANDBY", ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY.toString());
+        assertEquals("ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER", ClusterRole.ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER.toString());
+        assertEquals("ACTIVE_TO_STANDBY", ClusterRole.ACTIVE_TO_STANDBY.toString());
+        assertEquals("ACTIVE_WITH_OFFLINE_PEER", ClusterRole.ACTIVE_WITH_OFFLINE_PEER.toString());
+        assertEquals("DEGRADED_STANDBY", ClusterRole.DEGRADED_STANDBY.toString());
+        assertEquals("DEGRADED_STANDBY_FOR_READER", ClusterRole.DEGRADED_STANDBY_FOR_READER.toString());
+        assertEquals("DEGRADED_STANDBY_FOR_WRITER", ClusterRole.DEGRADED_STANDBY_FOR_WRITER.toString());
+        assertEquals("OFFLINE", ClusterRole.OFFLINE.toString());
+        assertEquals("STANDBY", ClusterRole.STANDBY.toString());
+        assertEquals("STANDBY_TO_ACTIVE", ClusterRole.STANDBY_TO_ACTIVE.toString());
+        assertEquals("UNKNOWN", ClusterRole.UNKNOWN.toString());
+    }
+
+    @Test
+    public void testClusterRoleEquality() {
+        // Test enum equality
+        assertNotEquals(ClusterRole.ACTIVE, ClusterRole.STANDBY);
+        assertNotEquals(ClusterRole.ACTIVE, ClusterRole.UNKNOWN);
+
+        // Test with valueOf
+        assertEquals(ClusterRole.ACTIVE, ClusterRole.valueOf("ACTIVE"));
+        assertEquals(ClusterRole.STANDBY, ClusterRole.valueOf("STANDBY"));
+    }
+
+    @Test
+    public void testClusterRoleHashCode() {
+        // Test that different enum values have different hash codes
+        assertNotEquals(ClusterRole.ACTIVE.hashCode(), ClusterRole.STANDBY.hashCode());
+        assertNotEquals(ClusterRole.ACTIVE.hashCode(), ClusterRole.OFFLINE.hashCode());
+        assertNotEquals(ClusterRole.STANDBY.hashCode(), ClusterRole.UNKNOWN.hashCode());
+
+        // Test that same enum values have same hash codes
+        assertEquals(ClusterRole.ACTIVE.hashCode(), ClusterRole.valueOf("ACTIVE").hashCode());
+        assertEquals(ClusterRole.STANDBY.hashCode(), ClusterRole.valueOf("STANDBY").hashCode());
+    }
+
+    @Test
+    public void testClusterRoleCheckTransitionAndGetWaitTime() throws Exception {
+        Configuration conf = new Configuration();
+        conf.set(HA_SYNC_MODE_REFRESH_INTERVAL_MS, "3999");
+        conf.set(HA_STORE_AND_FORWARD_MODE_REFRESH_INTERVAL_MS, "1999");
+
+        // Test valid transitions with specific configuration values
+
+        // Test ACTIVE_NOT_IN_SYNC transitions
+        long waitTime = ClusterRole.ACTIVE_NOT_IN_SYNC.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE, conf);
+        assertEquals("ACTIVE_NOT_IN_SYNC -> ACTIVE should return sync mode interval", 3999L, waitTime);
+
+        waitTime = ClusterRole.ACTIVE_NOT_IN_SYNC.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE_NOT_IN_SYNC, conf);
+        assertEquals("ACTIVE_NOT_IN_SYNC -> ACTIVE_NOT_IN_SYNC should return store and forward interval", 1999L, waitTime);
+
+        waitTime = ClusterRole.ACTIVE_NOT_IN_SYNC.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE_NOT_IN_SYNC_TO_STANDBY, conf);
+        assertEquals("ACTIVE_NOT_IN_SYNC -> ACTIVE_NOT_IN_SYNC_TO_STANDBY should return default", 0L, waitTime);
+
+        // Test ACTIVE transitions
+        waitTime = ClusterRole.ACTIVE.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE_NOT_IN_SYNC, conf);
+        assertEquals("ACTIVE -> ACTIVE_NOT_IN_SYNC should return store and forward interval", 1999L, waitTime);
+
+        waitTime = ClusterRole.ACTIVE.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE_WITH_OFFLINE_PEER, conf);
+        assertEquals("ACTIVE -> ACTIVE_WITH_OFFLINE_PEER should return default", 0L, waitTime);
+
+        waitTime = ClusterRole.ACTIVE.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE_TO_STANDBY, conf);
+        assertEquals("ACTIVE -> ACTIVE_TO_STANDBY should return default", 0L, waitTime);
+
+        // Test STANDBY transitions (should all return default 0L)
+        waitTime = ClusterRole.STANDBY.checkTransitionAndGetWaitTime(ClusterRole.STANDBY_TO_ACTIVE, conf);
+        assertEquals("STANDBY -> STANDBY_TO_ACTIVE should return default", 0L, waitTime);
+
+        waitTime = ClusterRole.STANDBY.checkTransitionAndGetWaitTime(ClusterRole.DEGRADED_STANDBY_FOR_READER, conf);
+        assertEquals("STANDBY -> DEGRADED_STANDBY_FOR_READER should return default", 0L, waitTime);
+
+        waitTime = ClusterRole.STANDBY.checkTransitionAndGetWaitTime(ClusterRole.DEGRADED_STANDBY_FOR_WRITER, conf);
+        assertEquals("STANDBY -> DEGRADED_STANDBY_FOR_WRITER should return default", 0L, waitTime);
+
+        // Test other transitions that should return default 0L
+        waitTime = ClusterRole.ACTIVE_TO_STANDBY.checkTransitionAndGetWaitTime(ClusterRole.ABORT_TO_ACTIVE, conf);
+        assertEquals("ACTIVE_TO_STANDBY -> ABORT_TO_ACTIVE should return default", 0L, waitTime);
+
+        waitTime = ClusterRole.STANDBY_TO_ACTIVE.checkTransitionAndGetWaitTime(ClusterRole.ABORT_TO_STANDBY, conf);
+        assertEquals("STANDBY_TO_ACTIVE -> ABORT_TO_STANDBY should return default", 0L, waitTime);
+
+        // Test invalid transitions should throw exception
+        try {
+            ClusterRole.ACTIVE.checkTransitionAndGetWaitTime(ClusterRole.STANDBY, conf);
+            fail("Expected InvalidClusterRoleTransitionException");
+        } catch (InvalidClusterRoleTransitionException e) {
+            assertTrue("Exception message should contain transition info",
+                    e.getMessage().contains("Cannot transition from ACTIVE to STANDBY"));
+        }
+
+        try {
+            ClusterRole.STANDBY.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE, conf);
+            fail("Expected InvalidClusterRoleTransitionException");
+        } catch (InvalidClusterRoleTransitionException e) {
+            assertTrue("Exception message should contain transition info",
+                    e.getMessage().contains("Cannot transition from STANDBY to ACTIVE"));
+        }
+
+        try {
+            ClusterRole.OFFLINE.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE, conf);
+            fail("Expected InvalidClusterRoleTransitionException");
+        } catch (InvalidClusterRoleTransitionException e) {
+            assertTrue("Exception message should contain transition info",
+                    e.getMessage().contains("Cannot transition from OFFLINE to ACTIVE"));
+        }
+
+        try {
+            ClusterRole.UNKNOWN.checkTransitionAndGetWaitTime(ClusterRole.ACTIVE, conf);
+            fail("Expected InvalidClusterRoleTransitionException");
+        } catch (InvalidClusterRoleTransitionException e) {
+            assertTrue("Exception message should contain transition info",
+                    e.getMessage().contains("Cannot transition from UNKNOWN to ACTIVE"));
+        }
+    }
+
     //Private Helper Methods
 
     private ClusterRoleRecord getClusterRoleRecord(String name, HighAvailabilityPolicy policy,
-                              String url1, ClusterRole role1, String url2, ClusterRole role2, int version) {
+                                                   String url1, ClusterRole role1, String url2, ClusterRole role2, int version) {
         url1 = getUrlWithSuffix(url1);
         url2 = getUrlWithSuffix(url2);
         if (registryType == null) {

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/HAGroupStoreManagerFactoryTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/HAGroupStoreManagerFactoryTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.query.QueryServicesOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/**
+ * Unit tests for {@link HAGroupStoreManagerFactory}.
+ */
+public class HAGroupStoreManagerFactoryTest {
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private Configuration testConfig;
+    private static final String TEST_ZK_HOST_1 = "test-zk1,test-zk2";
+    private static final String TEST_ZK_HOST_2 = "test-zk3,test-zk4";
+    private static final String TEST_ZK_PORT = "2181";
+    private static final String TEST_ZK_ZNODE = "/hbase";
+
+    @Before
+    public void setUp() throws Exception {
+        testConfig = createTestConfiguration(TEST_ZK_HOST_1);
+        // Clear the static instances cache before each test
+        clearStaticInstances();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Clear the static instances cache after each test
+        clearStaticInstances();
+    }
+
+    private Configuration createTestConfiguration(String zkHosts) {
+        Configuration config = new Configuration();
+        config.set(HConstants.ZOOKEEPER_QUORUM, zkHosts);
+        config.set(HConstants.ZOOKEEPER_CLIENT_PORT, HAGroupStoreManagerFactoryTest.TEST_ZK_PORT);
+        config.set(HConstants.ZOOKEEPER_ZNODE_PARENT, HAGroupStoreManagerFactoryTest.TEST_ZK_ZNODE);
+        return config;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearStaticInstances() throws Exception {
+        Field instancesField = HAGroupStoreManagerFactory.class.getDeclaredField("INSTANCES");
+        instancesField.setAccessible(true);
+        Map<String, HAGroupStoreManager> instances = (Map<String, HAGroupStoreManager>) instancesField.get(null);
+        instances.clear();
+    }
+
+    @Test
+    public void testGetInstanceWithDefaultImplementation() {
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(testConfig);
+
+        assertTrue(managerOpt.isPresent());
+        assertTrue(managerOpt.get() instanceof HAGroupStoreManagerV1Impl);
+    }
+
+    @Test
+    public void testGetInstanceWithExplicitV1Implementation() {
+        testConfig.set(QueryServices.HA_GROUP_STORE_MANAGER_IMPL_CLASS, QueryServicesOptions.DEFAULT_HA_GROUP_STORE_MANAGER_IMPL_CLASS);
+
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(testConfig);
+
+        assertTrue(managerOpt.isPresent());
+        assertTrue(managerOpt.get() instanceof HAGroupStoreManagerV1Impl);
+    }
+
+    @Test
+    public void testGetInstanceWithMainImplementation() {
+        testConfig.set(QueryServices.HA_GROUP_STORE_MANAGER_IMPL_CLASS, HAGroupStoreManagerImpl.class.getName());
+
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(testConfig);
+
+        assertTrue(managerOpt.isPresent());
+        assertTrue(managerOpt.get() instanceof HAGroupStoreManagerImpl);
+    }
+
+    @Test
+    public void testGetInstanceWitInvalidImplementation() {
+        testConfig.set(QueryServices.HA_GROUP_STORE_MANAGER_IMPL_CLASS, "randomClass");
+
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(testConfig);
+
+        assertFalse(managerOpt.isPresent());
+    }
+
+    @Test
+    public void testGetInstanceWithNonHAGroupStoreManagerImplementation() {
+        testConfig.set(QueryServices.HA_GROUP_STORE_MANAGER_IMPL_CLASS, PhoenixConnection.class.getName());
+
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(testConfig);
+
+        assertFalse(managerOpt.isPresent());
+    }
+
+    @Test
+    public void testSingletonBehaviorSameZkUrl() {
+        Optional<HAGroupStoreManager> manager1Opt = HAGroupStoreManagerFactory.getInstance(testConfig);
+        Optional<HAGroupStoreManager> manager2Opt = HAGroupStoreManagerFactory.getInstance(testConfig);
+
+        assertTrue(manager1Opt.isPresent());
+        assertTrue(manager2Opt.isPresent());
+        assertSame(manager1Opt.get(), manager2Opt.get());
+    }
+
+    @Test
+    public void testDifferentInstancesForDifferentZkUrls() {
+        Configuration testConfig2 = createTestConfiguration(TEST_ZK_HOST_2);
+
+        Optional<HAGroupStoreManager> manager1Opt = HAGroupStoreManagerFactory.getInstance(testConfig);
+        Optional<HAGroupStoreManager> manager2Opt = HAGroupStoreManagerFactory.getInstance(testConfig2);
+
+        assertTrue(manager1Opt.isPresent());
+        assertTrue(manager2Opt.isPresent());
+        assertNotSame(manager1Opt.get(), manager2Opt.get()); // Different instances for different ZK URLs
+    }
+
+    @Test
+    public void testThreadSafety() throws InterruptedException {
+        int threadCount = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicReference<HAGroupStoreManager> managerReference = new AtomicReference<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(testConfig);
+
+                    assertTrue(managerOpt.isPresent());
+                    HAGroupStoreManager manager = managerOpt.get();
+
+                    // All threads should get the same instance
+                    if (managerReference.get() == null) {
+                        managerReference.set(manager);
+                    } else {
+                        assertSame(managerReference.get(), manager);
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        executor.shutdown();
+
+        assertNotNull(managerReference.get());
+    }
+
+    @Test
+    public void testCreateInstanceWithNullConfiguration() {
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(null);
+
+        assertFalse(managerOpt.isPresent());
+    }
+
+    @Test
+    public void testNullZkUrlHandling() {
+        Configuration nullZkConfig = new Configuration();
+
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(nullZkConfig);
+
+        assertFalse(managerOpt.isPresent());
+    }
+
+    @Test
+    public void testEmptyStringZkUrlHandling() {
+        Configuration emptyZkConfig = createTestConfiguration("");
+
+        Optional<HAGroupStoreManager> managerOpt = HAGroupStoreManagerFactory.getInstance(emptyZkConfig);
+
+        assertFalse(managerOpt.isPresent());
+    }
+}

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/HAGroupStoreRecordTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/HAGroupStoreRecordTest.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.phoenix.jdbc.ClusterRoleRecord.ClusterRole;
+import org.apache.phoenix.util.JacksonUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit test for {@link HAGroupStoreRecord}.
+ */
+public class HAGroupStoreRecordTest {
+    private static final Logger LOG = LoggerFactory.getLogger(HAGroupStoreRecordTest.class);
+    private static final String PROTOCOL_VERSION = "1.0";
+    private static final String POLICY = "FAILOVER";
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    /**
+     * Helper method to create a temp JSON file with the given array of HA group store records.
+     */
+    public static String createJsonFileWithRecords(HAGroupStoreRecord record)
+            throws IOException {
+        File file = File.createTempFile("phoenix.ha.group.store.records", ".test.json");
+        file.deleteOnExit();
+        JacksonUtil.getObjectWriterPretty().writeValue(file, record);
+        LOG.info("Prepared the JSON file for testing, file:{}, content:\n{}", file,
+                FileUtils.readFileToString(file, "UTF-8"));
+        return file.getPath();
+    }
+
+    @Test
+    public void testReadWriteJsonToFile() throws IOException {
+        HAGroupStoreRecord record = getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, System.currentTimeMillis(), "peer1:2181,peer2:2181");
+        String fileName = createJsonFileWithRecords(record);
+        String fileContent = FileUtils.readFileToString(new File(fileName), "UTF-8");
+        assertTrue(fileContent.contains(record.getHaGroupName()));
+        assertTrue(fileContent.contains(record.getProtocolVersion()));
+        assertTrue(fileContent.contains(record.getPolicy()));
+    }
+
+    @Test
+    public void testToAndFromJson() throws IOException {
+        long currentTime = System.currentTimeMillis();
+        HAGroupStoreRecord record = getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, "backup1:2181,backup2:2181");
+        byte[] bytes = HAGroupStoreRecord.toJson(record);
+        Optional<HAGroupStoreRecord> record2 = HAGroupStoreRecord.fromJson(bytes);
+        assertTrue(record2.isPresent());
+        assertEquals(record, record2.get());
+    }
+
+    @Test
+    public void testFromJsonWithNullBytes() {
+        Optional<HAGroupStoreRecord> record = HAGroupStoreRecord.fromJson(null);
+        assertFalse(record.isPresent());
+    }
+
+    @Test
+    public void testFromJsonWithInvalidJson() {
+        byte[] invalidJson = "invalid json".getBytes();
+        Optional<HAGroupStoreRecord> record = HAGroupStoreRecord.fromJson(invalidJson);
+        assertFalse(record.isPresent());
+    }
+
+    @Test
+    public void testIsNewerThan() {
+        String haGroupName = testName.getMethodName();
+        long currentTime = System.currentTimeMillis();
+        HAGroupStoreRecord recordV0 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 0, POLICY, currentTime, "primary1:2181,primary2:2181");
+        HAGroupStoreRecord recordV2 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 2, POLICY, currentTime, "primary1:2181,primary2:2181");
+
+        assertTrue(recordV2.isNewerThan(recordV0));  // v2 is indeed newer
+        assertFalse(recordV2.isNewerThan(recordV2)); // irreflexive
+        assertFalse(recordV0.isNewerThan(recordV2)); // antisymmetry
+        assertTrue(recordV0.isNewerThan(null));      // null comparison
+
+        // Create a new record for a different HA group name.
+        // Records for different HA groups can not compare in reality,
+        // so they are not newer than each other.
+        String haGroupName2 = haGroupName + RandomStringUtils.randomAlphabetic(2);
+        HAGroupStoreRecord record2 = getHAGroupStoreRecord(haGroupName2,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, "secondary1:2181,secondary2:2181");
+        assertFalse(recordV0.isNewerThan(record2));
+        assertFalse(recordV2.isNewerThan(record2));
+        assertFalse(record2.isNewerThan(recordV0));
+        assertFalse(record2.isNewerThan(recordV2));
+    }
+
+    @Test
+    public void testHasSameInfo() {
+        String haGroupName = testName.getMethodName();
+        long currentTime = System.currentTimeMillis();
+        HAGroupStoreRecord recordV0 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 0, POLICY, currentTime, "cluster1:2181,cluster2:2181");
+        HAGroupStoreRecord recordV1 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.STANDBY, 1, POLICY, currentTime + 1000, "cluster1:2181,cluster2:2181");
+
+        assertTrue(recordV1.hasSameInfo(recordV0)); // Same core info despite different role/version/time
+        assertTrue(recordV1.hasSameInfo(recordV1)); // reflexive
+        assertTrue(recordV0.hasSameInfo(recordV1)); // symmetric
+    }
+
+    @Test
+    public void testHasSameInfoNegative() {
+        String haGroupName = testName.getMethodName();
+        long currentTime = System.currentTimeMillis();
+        HAGroupStoreRecord record = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 0, POLICY, currentTime, "base1:2181,base2:2181");
+
+        // Different protocol version
+        HAGroupStoreRecord recordDifferentProtocol = getHAGroupStoreRecord(haGroupName,
+                "2.0", ClusterRole.ACTIVE, 1, POLICY, currentTime, "protocol1:2181,protocol2:2181");
+        assertFalse(record.hasSameInfo(recordDifferentProtocol));
+        assertFalse(recordDifferentProtocol.hasSameInfo(record));
+
+        // Different policy
+        HAGroupStoreRecord recordDifferentPolicy = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, "PARALLEL", currentTime, "policy1:2181,policy2:2181");
+        assertFalse(record.hasSameInfo(recordDifferentPolicy));
+        assertFalse(recordDifferentPolicy.hasSameInfo(record));
+
+        // Different HA group name
+        String haGroupName2 = haGroupName + RandomStringUtils.randomAlphabetic(2);
+        HAGroupStoreRecord record2 = getHAGroupStoreRecord(haGroupName2,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, "group1:2181,group2:2181");
+        assertFalse(record.hasSameInfo(record2));
+        assertFalse(record2.hasSameInfo(record));
+    }
+
+    @Test
+    public void testGetters() {
+        String haGroupName = testName.getMethodName();
+        String protocolVersion = "1.5";
+        ClusterRole clusterRole = ClusterRole.STANDBY;
+        int version = 42;
+        String policy = "CUSTOM_POLICY";
+        long lastUpdatedTime = System.currentTimeMillis();
+
+        HAGroupStoreRecord record = getHAGroupStoreRecord(haGroupName, protocolVersion,
+                clusterRole, version, policy, lastUpdatedTime, null);
+
+        assertEquals(haGroupName, record.getHaGroupName());
+        assertEquals(protocolVersion, record.getProtocolVersion());
+        assertEquals(clusterRole, record.getClusterRole());
+        assertEquals(version, record.getVersion());
+        assertEquals(policy, record.getPolicy());
+        assertEquals(lastUpdatedTime, record.getLastUpdatedTimeInMs());
+        assertNull(record.getPeerZKUrl()); // Default should be null
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        String haGroupName = testName.getMethodName();
+        long currentTime = System.currentTimeMillis();
+        HAGroupStoreRecord record1 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, "equal1:2181,equal2:2181");
+        HAGroupStoreRecord record2 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, "equal1:2181,equal2:2181");
+        HAGroupStoreRecord record3 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 2, POLICY, currentTime, "equal1:2181,equal2:2181"); // Different version
+
+        // Test equals
+        assertEquals(record1, record2); // symmetric
+        assertEquals(record2, record1); // symmetric
+        assertNotEquals(record1, record3); // different version
+        assertNotEquals(null, record1); // null comparison
+        assertNotEquals("not a record", record1); // different type
+
+        // Test hashCode
+        assertEquals(record1.hashCode(), record2.hashCode()); // equal objects have same hash
+        assertNotEquals(record1.hashCode(), record3.hashCode()); // different objects likely have different hash
+    }
+
+    @Test
+    public void testToString() {
+        HAGroupStoreRecord record = getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, System.currentTimeMillis(), "tostring1:2181,tostring2:2181");
+        String toString = record.toString();
+
+        // Verify all fields are present in toString
+        assertTrue(toString.contains(record.getHaGroupName()));
+        assertTrue(toString.contains(record.getProtocolVersion()));
+        assertTrue(toString.contains(record.getClusterRole().toString()));
+        assertTrue(toString.contains(String.valueOf(record.getVersion())));
+        assertTrue(toString.contains(record.getPolicy()));
+        assertTrue(toString.contains(String.valueOf(record.getLastUpdatedTimeInMs())));
+    }
+
+    @Test
+    public void testToPrettyString() {
+        HAGroupStoreRecord record = getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, System.currentTimeMillis(), "pretty1:2181,pretty2:2181");
+        LOG.info("toString(): {}", record.toString());
+        LOG.info("toPrettyString:\n{}", record.toPrettyString());
+        assertNotEquals(record.toString(), record.toPrettyString());
+        assertTrue(record.toPrettyString().contains(record.getHaGroupName()));
+    }
+
+    @Test
+    public void testPeerZKUrlWithNullValue() {
+        HAGroupStoreRecord record = getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, System.currentTimeMillis(), null);
+        assertNull(record.getPeerZKUrl());
+
+        // Test toString includes peerZKUrl field
+        String toString = record.toString();
+        assertTrue(toString.contains("peerZKUrl"));
+        assertTrue(toString.contains("null"));
+    }
+
+    @Test
+    public void testPeerZKUrlWithValidValue() {
+        String peerZKUrl = "peer1:2181,peer2:2181,peer3:2181";
+        HAGroupStoreRecord record = getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, System.currentTimeMillis(), peerZKUrl);
+        assertEquals(peerZKUrl, record.getPeerZKUrl());
+
+        // Test toString includes peerZKUrl field
+        String toString = record.toString();
+        assertTrue(toString.contains("peerZKUrl"));
+        assertTrue(toString.contains(peerZKUrl));
+    }
+
+    @Test
+    public void testJsonSerializationWithPeerZKUrl() throws IOException {
+        String peerZKUrl = "peer1:2181,peer2:2181,peer3:2181";
+        HAGroupStoreRecord record = getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, System.currentTimeMillis(), peerZKUrl);
+
+        // Test serialization and deserialization
+        byte[] bytes = HAGroupStoreRecord.toJson(record);
+        Optional<HAGroupStoreRecord> deserialized = HAGroupStoreRecord.fromJson(bytes);
+
+        assertTrue(deserialized.isPresent());
+        assertEquals(record, deserialized.get());
+        assertEquals(peerZKUrl, deserialized.get().getPeerZKUrl());
+    }
+
+    @Test
+    public void testJsonSerializationWithNullPeerZKUrl() throws IOException {
+        HAGroupStoreRecord record = getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, System.currentTimeMillis(), null);
+
+        // Test serialization and deserialization
+        byte[] bytes = HAGroupStoreRecord.toJson(record);
+        Optional<HAGroupStoreRecord> deserialized = HAGroupStoreRecord.fromJson(bytes);
+
+        assertTrue(deserialized.isPresent());
+        assertEquals(record, deserialized.get());
+        assertNull(deserialized.get().getPeerZKUrl());
+    }
+
+    @Test
+    public void testEqualsAndHashCodeWithPeerZKUrl() {
+        String haGroupName = testName.getMethodName();
+        long currentTime = System.currentTimeMillis();
+        String peerZKUrl = "peer1:2181,peer2:2181";
+
+        HAGroupStoreRecord record1 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, peerZKUrl);
+        HAGroupStoreRecord record2 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, peerZKUrl);
+        HAGroupStoreRecord record3 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, "different:2181");
+        HAGroupStoreRecord record4 = getHAGroupStoreRecord(haGroupName,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, currentTime, null);
+
+        // Test equals with same peerZKUrl
+        assertEquals(record1, record2);
+        assertEquals(record2, record1);
+        assertEquals(record1.hashCode(), record2.hashCode());
+
+        // Test equals with different peerZKUrl
+        assertNotEquals(record1, record3);
+        assertNotEquals(record3, record1);
+        assertNotEquals(record1.hashCode(), record3.hashCode());
+
+        // Test equals with null vs non-null peerZKUrl
+        assertNotEquals(record1, record4);
+        assertNotEquals(record4, record1);
+        assertNotEquals(record1.hashCode(), record4.hashCode());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorWithNullHaGroupName() {
+        getHAGroupStoreRecord(null,
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, POLICY, System.currentTimeMillis(), "peer:2181");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorWithNullClusterRole() {
+        getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, null, 1, POLICY, System.currentTimeMillis(), "peer:2181");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorWithNullPolicy() {
+        getHAGroupStoreRecord(testName.getMethodName(),
+                PROTOCOL_VERSION, ClusterRole.ACTIVE, 1, null, System.currentTimeMillis(), "peer:2181");
+    }
+
+    // Private Helper Methods
+    private HAGroupStoreRecord getHAGroupStoreRecord(String haGroupName, String protocolVersion,
+                                                     ClusterRole clusterRole, int version,
+                                                     String policy, long lastUpdatedTimeInMs,
+                                                     String peerZKUrl) {
+        return new HAGroupStoreRecord(protocolVersion, haGroupName, clusterRole,
+                version, policy, lastUpdatedTimeInMs, peerZKUrl);
+    }
+}

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixHAAdminToolTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/PhoenixHAAdminToolTest.java
@@ -87,7 +87,7 @@ public class PhoenixHAAdminToolTest {
 
     @Before
     public void setup() throws Exception {
-        when(mockHighAvailibilityCuratorProvider.getCurator(Mockito.anyString(), any(Properties.class))).thenReturn(curator);
+        when(mockHighAvailibilityCuratorProvider.getCurator(Mockito.anyString(), any(Properties.class), anyString())).thenReturn(curator);
         haGroupName = testName.getMethodName();
         recordV1 = new ClusterRoleRecord(
                 haGroupName, HighAvailabilityPolicy.FAILOVER,


### PR DESCRIPTION
**Summary of Changes:-**

1. Created HAGroupStoreRecord to hold cluster role information for single cluster. This will be used for consistent HA instead of existing ClusterRoleRecord.
2. Created 2 vertical stacks of classes (HAGroupStoreManagerImpl -> HAGroupStoreClient) and (HAGroupStoreManagerV1Impl -> HAGroupStoreClientV1) to support HAGroupStoreRecord and ClusterRoleRecord respectively.
Note that previously the CRR handling classes were named as HAGroupStoreManager and HAGroupStoreClient but now I have renamed them to V1 as eventually we want to deprecate the V1 and keep the ones without V1
3.New Features in HAGroupStoreManagerImpl -> HAGroupStoreClient
i. Created singleton instance of HAGroupStoreClient for each HAGroupName
ii. Added watcher for PeerZK. If Peer ZK url is present in HAGroupStoreClient, it will watch that in addition to local ZK
iii. Added support for checkAndPut for records in ZK for serialization of concurrent updates to HAGroupStoreRecord
iv. Added new methods to be used by ReplicationLogWriter
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;a. getHAGroupStoreRecord(haGroupName)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b. setStoreAndForwardMode(haGroupName)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;c. setSyncMode(haGroupName)
v. Added ITs for new classes and new methods introduced.


**Changes in ClusterRoleRecord**
i. Added new states needed for consistent HA
ii. Added transition allowList for selectively allowing transitions between roles
iii. Adding transition wait time before transitioning between specific roles(cache entry has to be older than wait time for update to succeed)

**Next PRs**
Adding support for getting HAGroupStoreRecord from System table for recovery.
Adding more ITs for parallel connection with one cluster supporting CRR and other supporting HAGroupStoreRecord
Add Parallel and Failover tests with new HAGroupStoreRecord