### PR TITLE
PHOENIX-7667 Strict vs Relaxed TTL

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServices.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServices.java
@@ -383,6 +383,8 @@ public interface QueryServices extends SQLCloseable {
     public static final String WAL_EDIT_CODEC_ATTRIB = "hbase.regionserver.wal.codec";
     //Property to know whether TTL at View Level is enabled
     public static final String PHOENIX_VIEW_TTL_ENABLED = "phoenix.view.ttl.enabled";
+    // TTL strict mode - when false, TTL is considered relaxed
+    public static final String PHOENIX_TTL_STRICT = "phoenix.ttl.strict";
 
     public static final String PHOENIX_VIEW_TTL_TENANT_VIEWS_PER_SCAN_LIMIT = "phoenix.view.ttl.tenant_views_per_scan.limit";
     // Block mutations based on cluster role record

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/QueryServicesOptions.java
@@ -451,6 +451,7 @@ public class QueryServicesOptions {
     public static final boolean DEFAULT_PHOENIX_TABLE_TTL_ENABLED = true;
     public static final boolean DEFAULT_PHOENIX_COMPACTION_ENABLED = true;
     public static final boolean DEFAULT_PHOENIX_VIEW_TTL_ENABLED = true;
+    public static final boolean DEFAULT_PHOENIX_TTL_STRICT = true;
     public static final int DEFAULT_PHOENIX_VIEW_TTL_TENANT_VIEWS_PER_SCAN_LIMIT = 100;
 
     public static final int DEFAULT_MAX_REGION_LOCATIONS_SIZE_EXPLAIN_PLAN = 5;

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/TTLRegionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/TTLRegionScanner.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.isPhoenixCompactionEnabled;
 import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.EMPTY_COLUMN_FAMILY_NAME;
 import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.EMPTY_COLUMN_QUALIFIER_NAME;
+import static org.apache.phoenix.query.QueryServices.PHOENIX_TTL_STRICT;
+import static org.apache.phoenix.query.QueryServicesOptions.DEFAULT_PHOENIX_TTL_STRICT;
 import static org.apache.phoenix.schema.LiteralTTLExpression.TTL_EXPRESSION_DEFINED_IN_TABLE_DESCRIPTOR;
 import static org.apache.phoenix.schema.LiteralTTLExpression.TTL_EXPRESSION_FOREVER;
 
@@ -104,7 +106,9 @@ public class TTLRegionScanner extends BaseRegionScanner {
         // be done here. We also disable masking when TTL is HConstants.FOREVER.
         isMaskingEnabled = emptyCF != null && emptyCQ != null
                 && !ttlExpression.equals(TTL_EXPRESSION_FOREVER)
-                && (isPhoenixCompactionEnabled(env.getConfiguration()));
+                && (isPhoenixCompactionEnabled(env.getConfiguration()))
+                && env.getConfiguration().getBoolean(
+                        PHOENIX_TTL_STRICT, DEFAULT_PHOENIX_TTL_STRICT);
     }
 
     private void init() throws IOException {

--- a/phoenix-core/src/test/java/org/apache/phoenix/index/PrepareIndexMutationsForRebuildTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/index/PrepareIndexMutationsForRebuildTest.java
@@ -135,7 +135,8 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
         addEmptyColumnToDataPutMutation(dataPut, info.pDataTable, 1);
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
-                .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, null, null, null);
+                .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, null, null, null,
+                        true);
 
         // Expect one row of index with row key "v1_k1"
         Put idxPut1 = new Put(generateIndexRowKey("v1"));
@@ -166,7 +167,8 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
         addEmptyColumnToDataPutMutation(dataPut, info.pDataTable, 1);
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
-                .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, null, null, null);
+                .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, null, null, null,
+                        true);
 
         // Expect one row of index with row key "_k1", as indexed column C1 is nullable.
         Put idxPut1 = new Put(generateIndexRowKey(null));
@@ -212,7 +214,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, dataDel,
-                        null, null);
+                        null, null, true);
 
         List<Mutation> expectedIndexMutation = new ArrayList<>();
 
@@ -278,7 +280,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, dataDel,
-                        null, null);
+                        null, null, true);
 
         List<Mutation> expectedIndexMutations = new ArrayList<>();
 
@@ -338,7 +340,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, dataDel,
-                        null, null);
+                        null, null, true);
 
         List<Mutation> expectedIndexMutations = new ArrayList<>();
 
@@ -406,7 +408,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, dataDel,
-                        null, null);
+                        null, null, true);
 
         List<Mutation> expectedIndexMutations = new ArrayList<>();
 
@@ -458,7 +460,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, dataDel,
-                        null, null);
+                        null, null, true);
 
         List<Mutation> expectedIndexMutations = new ArrayList<>();
         byte[] idxKeyBytes = generateIndexRowKey("v2");
@@ -521,7 +523,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, dataDel,
-                        null, null);
+                        null, null, true);
 
         List<Mutation> expectedIndexMutations = new ArrayList<>();
         byte[] idxKeyBytes = generateIndexRowKey("v2");
@@ -577,7 +579,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, dataDel,
-                        null, null);
+                        null, null, true);
 
         List<Mutation> expectedIndexMutations = new ArrayList<>();
         byte[] idxKeyBytes = generateIndexRowKey("v1");
@@ -653,7 +655,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, dataDel,
-                        null, null);
+                        null, null, true);
 
         List<Mutation> expectedIndexMutation = new ArrayList<>();
 
@@ -718,7 +720,7 @@ public class PrepareIndexMutationsForRebuildTest extends BaseConnectionlessQuery
 
         List<Mutation> actualIndexMutations = IndexRebuildRegionScanner
                 .prepareIndexMutationsForRebuild(info.indexMaintainer, dataPut, null,
-                        null, null);
+                        null, null, true);
 
         byte[] idxKeyBytes = generateIndexRowKey(null);
 

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/TestUtil.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/TestUtil.java
@@ -1059,6 +1059,14 @@ public class TestUtil {
             CellCount other = (CellCount) o;
             return rowCountMap.equals(other.rowCountMap);
         }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("CellCount{");
+            sb.append("rowCountMap=").append(rowCountMap);
+            sb.append('}');
+            return sb.toString();
+        }
     }
 
 


### PR DESCRIPTION
Jira: PHOENIX-7667

Types of TTLs supported by Phoenix:

1. Literal TTL: A simple numeric value specifying the TTL in seconds.
e.g.
`CREATE TABLE T1 (id VARCHAR PRIMARY KEY, COL1 VARCHAR, COL2 INTEGER) TTL = 86400`

Literal TTL values:

- NONE / TTL_EXPRESSION_NOT_DEFINED: TTL is not specified for the table.
- FOREVER / TTL_EXPRESSION_FOREVER: TTL is set to not expire for the rows.
- TTL_EXPRESSION_DEFINED_IN_TABLE_DESCRIPTOR: Clients older than Phoenix 5.3 sets TTL value to the HBase TableDescriptor.
- User provided TTL: Literal value of TTL in seconds.


2. Conditional TTL: A boolean expression to determine the row expiration based on column values.
e.g.
`CREATE TABLE T1 (id VARCHAR PRIMARY KEY, status VARCHAR) TTL = 'status = ''EXPIRED'' OR TO_NUMBER(CURRENT_TIME()) - TO_NUMBER(PHOENIX_ROW_TIMESTAMP()) >= 108000000'`

As of Phoenix 5.3.0 (client and server), both types of TTLs are stored in SYSTEM.CATALOG table.

The default behavior of conditional TTL includes parsing and compilation of the TTL expression, serializing the compiled expression into bytes and sending the serialized bytes as the Scan attribute. The scan attribute for Conditional TTL is deserialized and used by many region coprocessors and scanner implementations including TTLRegionScanner, GlobalIndexRegionScanner and IndexRegionObserver.

In order to provide strict TTL view for the users, the region observers perform extra computation on the row to determine whether the row has already expired and therefore should not be processed. For instance, IndexRegionObserver performs read for the given upsert to identify whether the row has already expired. While the extra cost incurred by the region observers help provide strict TTL expiration, some use case might not require strict TTL expiry.

Let’s define the types of TTL use cases:

- Strict TTL expiration: As soon as the TTL expires for the given row, the row must not be visible to the user queries.
- Relaxed TTL expiration: After the TTL expiration, it can take several hours to days for the row to not be visible to the user queries.

Costs involved to achieve strict Conditional TTL expiry:

- TTLRegionScanner achieves masking of the row (Literal and Conditional TTL)
- IndexRegionObserver performs read for each update operation (No additional cost when the table has covered index)
- GlobalIndexRegionScanner evaluates TTL expression for each data table row during rebuild

For users that do not care about the immediate row masking after the TTL expiry, we can provide optional configuration to avoid the extra cost associated with making the strict TTL expiration. The relaxed TTL expiration is expected to rely only on the Major compaction. After the major compaction successfully expires or deletes the given row, the client will no longer be able to read the expired row.