### PR TITLE
PHOENIX-7671 Sync maxLookback from data table to indexes

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
@@ -55,6 +55,7 @@ import org.apache.phoenix.util.MetaDataUtil;
 
 import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 
+import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.CHANGE_DETECTION_ENABLED;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SALT_BUCKETS;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TTL;
@@ -398,6 +399,8 @@ public enum SQLExceptionCode {
 
     CDC_ALREADY_ENABLED(10963, "44A45",
             "CDC on this table is either enabled or is in the process of being enabled."),
+    CANNOT_SET_OR_ALTER_MAX_LOOKBACK_FOR_INDEX(10964, "44A46",
+            "Cannot set or alter " + PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY + " on an index"),
 
     /** Sequence related */
     SEQUENCE_ALREADY_EXIST(1200, "42Z00", "Sequence already exists.", new Factory() {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder.REPLI
 import static org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder.TTL;
 import static org.apache.hadoop.hbase.client.MetricsConnection.CLIENT_SIDE_METRICS_ENABLED_KEY;
 import static org.apache.hadoop.hbase.ipc.RpcControllerFactory.CUSTOM_CONTROLLER_CONF_KEY;
+import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY;
 import static org.apache.phoenix.coprocessorclient.MetaDataProtocol.MIN_SYSTEM_TABLE_TIMESTAMP;
 import static org.apache.phoenix.coprocessorclient.MetaDataProtocol.MIN_SYSTEM_TABLE_TIMESTAMP_4_15_0;
 import static org.apache.phoenix.coprocessorclient.MetaDataProtocol.MIN_SYSTEM_TABLE_TIMESTAMP_4_16_0;
@@ -1317,6 +1318,11 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                 // In case this a local index created on a view of a multi-tenant table, the
                 // PHYSICAL_DATA_TABLE_NAME points to the name of the view instead of the physical base table
                 baseTableDesc = existingDesc;
+            }
+            String baseTableMaxLookbackVal =
+                    baseTableDesc.getValue(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY);
+            if (baseTableMaxLookbackVal != null) {
+                tableProps.put(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY, baseTableMaxLookbackVal);
             }
             dataTableColDescForIndexTablePropSyncing = baseTableDesc.getColumnFamily(defaultFamilyBytes);
             // It's possible that the table has specific column families and none of them are declared

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -3208,6 +3208,12 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                             .buildException();
                         }
                         if (PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY.equals(propName)) {
+                            if (table.getType() == PTableType.INDEX) {
+                                throw new SQLExceptionInfo.Builder(
+                                        SQLExceptionCode.CANNOT_SET_OR_ALTER_MAX_LOOKBACK_FOR_INDEX)
+                                        .setMessage("Property: " + propName)
+                                        .build().buildException();
+                            }
                             newMaxLookback = (Integer) propValue;
                         }
                         tableProps.put(propName, propValue);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -17,6 +17,7 @@
  */
 package org.apache.phoenix.schema;
 
+import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY;
 import static org.apache.phoenix.exception.SQLExceptionCode.CANNOT_SET_CONDITIONAL_TTL_ON_TABLE_WITH_MULTIPLE_COLUMN_FAMILIES;
 import static org.apache.phoenix.exception.SQLExceptionCode.CANNOT_TRANSFORM_TRANSACTIONAL_TABLE;
 import static org.apache.phoenix.exception.SQLExceptionCode.CDC_ALREADY_ENABLED;
@@ -27,7 +28,6 @@ import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.CDC_INCLUDE_TABLE;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CDC_STREAM_NAME;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CDC_STREAM_STATUS_NAME;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.STREAMING_TOPIC_NAME;
-import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CDC_STREAM_STATUS_TABLE;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_TASK_TABLE;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TTL;
 import static org.apache.phoenix.query.QueryConstants.SPLITS_FILE;
@@ -136,7 +136,6 @@ import static org.apache.phoenix.schema.PTable.ImmutableStorageScheme.ONE_CELL_P
 import static org.apache.phoenix.schema.PTable.ImmutableStorageScheme.SINGLE_CELL_ARRAY_WITH_OFFSETS;
 import static org.apache.phoenix.schema.PTable.QualifierEncodingScheme.NON_ENCODED_QUALIFIERS;
 import static org.apache.phoenix.schema.PTable.ViewType.MAPPED;
-import static org.apache.phoenix.schema.PTable.ViewType.UPDATABLE;
 import static org.apache.phoenix.schema.PTableType.INDEX;
 import static org.apache.phoenix.schema.PTableType.TABLE;
 import static org.apache.phoenix.schema.PTableType.VIEW;
@@ -1250,6 +1249,13 @@ public class MetaDataClient {
                     throw new SQLExceptionInfo.Builder(SQLExceptionCode.CANNOT_SET_OR_ALTER_PROPERTY_FOR_INDEX)
                             .setMessage("Property: " + prop.getFirst()).build()
                             .buildException();
+                }
+                if (tableType == PTableType.INDEX
+                        && PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY.equals(prop.getFirst())) {
+                    throw new SQLExceptionInfo.Builder(
+                            SQLExceptionCode.CANNOT_SET_OR_ALTER_MAX_LOOKBACK_FOR_INDEX)
+                            .setMessage("Property: " + prop.getFirst())
+                            .build().buildException();
                 }
                 // Handle when TTL property is set
                 if (prop.getFirst().equalsIgnoreCase(TTL)

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -17,7 +17,6 @@
  */
 package org.apache.phoenix.schema;
 
-import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY;
 import static org.apache.phoenix.exception.SQLExceptionCode.CANNOT_SET_CONDITIONAL_TTL_ON_TABLE_WITH_MULTIPLE_COLUMN_FAMILIES;
 import static org.apache.phoenix.exception.SQLExceptionCode.CANNOT_TRANSFORM_TRANSACTIONAL_TABLE;
 import static org.apache.phoenix.exception.SQLExceptionCode.CDC_ALREADY_ENABLED;
@@ -2013,10 +2012,6 @@ public class MetaDataClient {
         Object columnEncodedBytes = TableProperty.COLUMN_ENCODED_BYTES.getValue(tableProps);
         if (columnEncodedBytes != null) {
             indexProps.add("COLUMN_ENCODED_BYTES=" + columnEncodedBytes);
-        }
-        if (tableProps.containsKey(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY)) {
-            indexProps.add("\"" + PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY + "\"="
-                    + tableProps.get(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY));
         }
         createIndexSql = createIndexSql + " " + String.join(", ", indexProps);
         try (Connection internalConnection = QueryUtil.getConnection(props, connection.getQueryServices().getConfiguration())) {

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -17,6 +17,7 @@
  */
 package org.apache.phoenix.schema;
 
+import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY;
 import static org.apache.phoenix.exception.SQLExceptionCode.CANNOT_SET_CONDITIONAL_TTL_ON_TABLE_WITH_MULTIPLE_COLUMN_FAMILIES;
 import static org.apache.phoenix.exception.SQLExceptionCode.CANNOT_TRANSFORM_TRANSACTIONAL_TABLE;
 import static org.apache.phoenix.exception.SQLExceptionCode.CDC_ALREADY_ENABLED;
@@ -2012,6 +2013,10 @@ public class MetaDataClient {
         Object columnEncodedBytes = TableProperty.COLUMN_ENCODED_BYTES.getValue(tableProps);
         if (columnEncodedBytes != null) {
             indexProps.add("COLUMN_ENCODED_BYTES=" + columnEncodedBytes);
+        }
+        if (tableProps.containsKey(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY)) {
+            indexProps.add("\"" + PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY + "\"="
+                    + tableProps.get(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY));
         }
         createIndexSql = createIndexSql + " " + String.join(", ", indexProps);
         try (Connection internalConnection = QueryUtil.getConnection(props, connection.getQueryServices().getConfiguration())) {

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCStreamIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCStreamIT.java
@@ -107,14 +107,14 @@ public class CDCStreamIT extends CDCBaseIT {
         Connection conn = newConnection();
         String tableName = generateUniqueName();
         String cdcName = generateUniqueName();
+        String cdcDdl = "CREATE CDC " + cdcName + " ON " + tableName;
         // maxLookback 27 hr
-        String cdcDdl = "CREATE CDC " + cdcName + " ON " + tableName
-                + "\"phoenix.max.lookback.age.seconds\"=97200";
         conn.createStatement().execute(
                 "CREATE TABLE  " + tableName + " ( k VARCHAR NOT NULL,"
                         + " v1 VARCHAR, v2 BIGINT CONSTRAINT PK PRIMARY KEY(k))"
                         + " \"phoenix.max.lookback.age.seconds\"=97200,"
                         + "TTL='TO_NUMBER(CURRENT_TIME()) > v2', IS_STRICT_TTL=false");
+        // cdc index should get 27 hr maxLookback (for cdc index, maxLookback = TTL)
         createCDC(conn, cdcDdl, null);
 
         long expiry = (System.currentTimeMillis() + TimeUnit.DAYS.toMillis(3)) / 1000;

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCStreamIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCStreamIT.java
@@ -21,11 +21,13 @@ package org.apache.phoenix.end2end;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.coprocessor.PhoenixMasterObserver;
 import org.apache.phoenix.coprocessor.TaskRegionObserver;
-import org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
@@ -59,6 +61,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CDC_STREAM_NAME;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_CDC_STREAM_STATUS_NAME;
 import static org.apache.phoenix.query.QueryConstants.CDC_EVENT_TYPE;
@@ -82,7 +85,7 @@ public class CDCStreamIT extends CDCBaseIT {
     @BeforeClass
     public static synchronized void doSetup() throws Exception {
         Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
-        props.put(BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY, Integer.toString(60*60)); // An hour
+        props.put(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY, Integer.toString(60 * 60)); // An hour
         props.put(QueryServices.USE_STATS_FOR_PARALLELIZATION, Boolean.toString(false));
         props.put(QueryServices.TASK_HANDLING_INTERVAL_MS_ATTRIB,
                 Long.toString(Long.MAX_VALUE));
@@ -156,6 +159,82 @@ public class CDCStreamIT extends CDCBaseIT {
             // row, which was last updated (24 hr + 3 hr + 1 sec) in the past.
             // The compaction should also generate ttl expired event
             verifyTtlExpiredPreImage(conn, sql, expiry);
+        } finally {
+            EnvironmentEdgeManager.reset();
+        }
+    }
+
+    /**
+     * Test to verify CDC events with index/table level maxLookback and TTL.
+     */
+    @Test
+    public void testCdcWithMaxLookbackAlterTable() throws Exception {
+        Connection conn = newConnection();
+        String tableName = generateUniqueName();
+        String cdcName = generateUniqueName();
+        String cdcDdl = "CREATE CDC " + cdcName + " ON " + tableName;
+        // maxLookback 27 hr
+        conn.createStatement().execute(
+                "CREATE TABLE  " + tableName + " ( k VARCHAR NOT NULL,"
+                        + " v1 VARCHAR, v2 BIGINT CONSTRAINT PK PRIMARY KEY(k))"
+                        + " \"phoenix.max.lookback.age.seconds\"=97200,"
+                        + "TTL='TO_NUMBER(CURRENT_TIME()) > v2', IS_STRICT_TTL=false");
+        // cdc index should get 27 hr maxLookback (for cdc index, maxLookback = TTL)
+        createCDC(conn, cdcDdl, null);
+
+        long expiry = (System.currentTimeMillis() + TimeUnit.DAYS.toMillis(3)) / 1000;
+        conn.createStatement()
+                .execute("UPSERT INTO " + tableName + " VALUES('a', 'aa', " + expiry + ")");
+        conn.commit();
+
+        Admin admin = conn.unwrap(PhoenixConnection.class).getQueryServices().getAdmin();
+
+        TableDescriptor tableDescriptor =
+                admin.getDescriptor(TableName.valueOf(CDCUtil.getCDCIndexName(cdcName)));
+        String maxLookbackVal = tableDescriptor.getValue(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY);
+        assertEquals(97200, Integer.parseInt(maxLookbackVal));
+
+        tableDescriptor = admin.getDescriptor(TableName.valueOf(tableName));
+        maxLookbackVal = tableDescriptor.getValue(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY);
+        assertEquals(97200, Integer.parseInt(maxLookbackVal));
+
+        String sql = "SELECT /*+ CDC_INCLUDE(PRE, POST) */ * FROM " + cdcName;
+        // verify only pre-image exists, new row insert
+        verifyOnlyPostImage(conn, sql, expiry);
+
+        // update maxLookback of data table and cdc index both to 50 sec
+        conn.createStatement().execute("ALTER TABLE " + tableName +
+                " SET \"phoenix.max.lookback.age.seconds\"=50");
+
+        ManualEnvironmentEdge injectEdge = new ManualEnvironmentEdge();
+        long t = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(3);
+        t = ((t / 1000) + 100) * 1000;
+        EnvironmentEdgeManager.injectEdge(injectEdge);
+        try {
+            injectEdge.setValue(t);
+            conn.createStatement()
+                    .execute("UPSERT INTO " + tableName + " VALUES('a', 'bb', " + expiry + ")");
+            conn.commit();
+
+            // verify insert + update event of the same row
+            verifyPreAndPostImages(conn, sql, expiry);
+
+            injectEdge.incrementValue(TimeUnit.DAYS.toMillis(1));
+            TestUtil.doMajorCompaction(conn, CDCUtil.getCDCIndexName(cdcName));
+
+            // compaction will expire all rows from CDC index because the maxLookback of
+            // CDC index is no longer 27 hr, but it has been altered to 50 sec
+            ResultSet rs = conn.createStatement().executeQuery(sql);
+            assertFalse(rs.next());
+
+            tableDescriptor =
+                    admin.getDescriptor(TableName.valueOf(CDCUtil.getCDCIndexName(cdcName)));
+            maxLookbackVal = tableDescriptor.getValue(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY);
+            assertEquals(50, Integer.parseInt(maxLookbackVal));
+
+            tableDescriptor = admin.getDescriptor(TableName.valueOf(tableName));
+            maxLookbackVal = tableDescriptor.getValue(PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY);
+            assertEquals(50, Integer.parseInt(maxLookbackVal));
         } finally {
             EnvironmentEdgeManager.reset();
         }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/PropertiesInSyncIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/PropertiesInSyncIT.java
@@ -162,6 +162,35 @@ public class PropertiesInSyncIT extends ParallelStatsDisabledIT {
                         SQLExceptionCode.CANNOT_SET_OR_ALTER_PROPERTY_FOR_INDEX.getErrorCode(), sqlE.getErrorCode());
             }
         }
+        try {
+            conn.createStatement().execute("create local index " + localIndexName
+                    + " on " + tableName + "(name) "
+                    + "\"phoenix.max.lookback.age.seconds\"=12345");
+            fail("Should fail with SQLException when setting synced property for a local index");
+        } catch (SQLException sqlE) {
+            assertEquals("Should fail to set synced property for a local index",
+                    SQLExceptionCode.CANNOT_SET_OR_ALTER_MAX_LOOKBACK_FOR_INDEX.getErrorCode(),
+                    sqlE.getErrorCode());
+        }
+        try {
+            conn.createStatement().execute("create index " + globalIndexName
+                    + " on " + tableName + "(flag) "
+                    + "\"phoenix.max.lookback.age.seconds\"=12345");
+            fail("Should fail with SQLException when setting synced property for a global index");
+        } catch (SQLException sqlE) {
+            assertEquals("Should fail to set synced property for a global index",
+                    SQLExceptionCode.CANNOT_SET_OR_ALTER_MAX_LOOKBACK_FOR_INDEX.getErrorCode(),
+                    sqlE.getErrorCode());
+        }
+        try {
+            conn.createStatement().execute("create index view_index"
+                    + " on " + viewName + " (flag)" + "\"phoenix.max.lookback.age.seconds\"=12345");
+            fail("Should fail with SQLException when setting synced property for a view index");
+        } catch (SQLException sqlE) {
+            assertEquals("Should fail to set synced property for a view index",
+                    SQLExceptionCode.CANNOT_SET_OR_ALTER_MAX_LOOKBACK_FOR_INDEX.getErrorCode(),
+                    sqlE.getErrorCode());
+        }
         conn.close();
     }
 
@@ -326,6 +355,15 @@ public class PropertiesInSyncIT extends ParallelStatsDisabledIT {
                 assertEquals("Should fail to alter synced property for a global index",
                         SQLExceptionCode.CANNOT_SET_OR_ALTER_PROPERTY_FOR_INDEX.getErrorCode(), sqlE.getErrorCode());
             }
+        }
+        try {
+            conn.createStatement().execute("alter table " + globalIndexName + " set "
+                    + "\"phoenix.max.lookback.age.seconds\"=12345");
+            fail("Should fail with SQLException when altering synced property for a global index");
+        } catch (SQLException sqlE) {
+            assertEquals("Should fail to alter synced property for a global index",
+                    SQLExceptionCode.CANNOT_SET_OR_ALTER_MAX_LOOKBACK_FOR_INDEX.getErrorCode(),
+                    sqlE.getErrorCode());
         }
         conn.close();
     }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/TableTTLIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/TableTTLIT.java
@@ -583,9 +583,8 @@ public class TableTTLIT extends BaseTest {
             conn.createStatement().execute("Alter Table " + tableName
                     + " set \"phoenix.max.lookback.age.seconds\" = " + tableLevelMaxLookback);
             String indexName = "I_" + generateUniqueName();
-            String indexDDL = String.format("create index %s on %s (val1) include (val2, val3) " +
-                            "\"phoenix.max.lookback.age.seconds\" = %d",
-                    indexName, tableName, tableLevelMaxLookback);
+            String indexDDL = String.format("create index %s on %s (val1) include (val2, val3) ",
+                    indexName, tableName);
             conn.createStatement().execute(indexDDL);
             updateRow(conn, tableName, "a1");
             String indexColumnValue;

--- a/phoenix-core/src/it/java/org/apache/phoenix/schema/ConditionalTTLExpressionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/schema/ConditionalTTLExpressionIT.java
@@ -1465,10 +1465,6 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
             String cdcIndexName = CDCUtil.getCDCIndexName(cdcName);
             String fullCdcIndexName = SchemaUtil.getTableName(schemaName,
                     CDCUtil.getCDCIndexName(cdcName));
-            // Explicitly set table level max lookback on CDC index
-            String cdcIndexSetMaxLookbackDdl = String.format("ALTER INDEX %s ON %s ACTIVE SET ",
-                    cdcIndexName, tableName);
-            conn.createStatement().execute(cdcIndexSetMaxLookbackDdl);
             PTable cdcIndex = ((PhoenixConnection) conn).getTableNoCache(fullCdcIndexName);
             assertEquals(cdcIndex.getTTLExpression(), TTL_EXPRESSION_FOREVER);
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/schema/ConditionalTTLExpressionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/schema/ConditionalTTLExpressionIT.java
@@ -838,8 +838,7 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
             // now create the index async
             String indexName = generateUniqueName();
             String fullIndexName = SchemaUtil.getTableName(schemaName, indexName);
-            String indexDDL = String.format("create index %s on %s (%s) include (%s) async "
-                            + "\"phoenix.max.lookback.age.seconds\" = %d",
+            String indexDDL = String.format("create index %s on %s (%s) include (%s) async ",
                     indexName, fullDataTableName, "VAL1", ttlCol, tableLevelMaxLookback);
             conn.createStatement().execute(indexDDL);
             IndexTool it = IndexToolIT.runIndexTool(false, schemaName, tableName, indexName,
@@ -949,8 +948,7 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
         }
         String ddl = String.format(ddlTemplate, tableName,
                 String.format(tableDDLOptions, retainSingleQuotes(ttlExpression)));
-        String indexDDL = String.format("create index %s ON %s (col1) INCLUDE(col2) " +
-                "\"phoenix.max.lookback.age.seconds\" = %d",
+        String indexDDL = String.format("create index %s ON %s (col1) INCLUDE(col2) ",
                 indexName, tableName, tableLevelMaxLookback, isStrictTTL);
         try (Connection conn = DriverManager.getConnection(getUrl())) {
             conn.createStatement().execute(ddl);
@@ -1303,8 +1301,7 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
         String ddl = String.format("CREATE TABLE %s (ID BIGINT NOT NULL PRIMARY KEY, " +
                         "EVENT_TYPE CHAR(15), CREATED_TS TIMESTAMP) %s", tableName,
                 String.format(tableDDLOptions, ttlExpression));
-        String indexDDL = String.format("CREATE INDEX %s ON %s (EVENT_TYPE) INCLUDE(CREATED_TS) "
-                        + "\"phoenix.max.lookback.age.seconds\" = %d",
+        String indexDDL = String.format("CREATE INDEX %s ON %s (EVENT_TYPE) INCLUDE(CREATED_TS) ",
                 indexName, tableName, tableLevelMaxLookback);
         try (Connection conn = DriverManager.getConnection(getUrl())) {
             conn.createStatement().execute(ddl);
@@ -1469,9 +1466,8 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
             String fullCdcIndexName = SchemaUtil.getTableName(schemaName,
                     CDCUtil.getCDCIndexName(cdcName));
             // Explicitly set table level max lookback on CDC index
-            String cdcIndexSetMaxLookbackDdl = String.format("ALTER INDEX %s ON %s ACTIVE SET "
-                    + "\"phoenix.max.lookback.age.seconds\" = %d",
-                    cdcIndexName, tableName, tableLevelMaxLookback);
+            String cdcIndexSetMaxLookbackDdl = String.format("ALTER INDEX %s ON %s ACTIVE SET ",
+                    cdcIndexName, tableName);
             conn.createStatement().execute(cdcIndexSetMaxLookbackDdl);
             PTable cdcIndex = ((PhoenixConnection) conn).getTableNoCache(fullCdcIndexName);
             assertEquals(cdcIndex.getTTLExpression(), TTL_EXPRESSION_FOREVER);
@@ -1553,11 +1549,10 @@ public class ConditionalTTLExpressionIT extends ParallelStatsDisabledIT {
         String indexName = "I_" + generateUniqueName();
         String tableName = schemaBuilder.getEntityTableName();
         String schema = SchemaUtil.getSchemaNameFromFullName(tableName);
-        String indexDDL = String.format("create index %s on %s (%s) include (%s) "
-                        + "\"phoenix.max.lookback.age.seconds\" = %d",
+        String indexDDL = String.format("create index %s on %s (%s) include (%s) ",
                 indexName, tableName,
                 Joiner.on(",").join(indexedColumns),
-                Joiner.on(",").join(includedColumns), tableLevelMaxLookback);
+                Joiner.on(",").join(includedColumns));
         try (Connection conn = DriverManager.getConnection(getUrl())) {
             conn.createStatement().execute(indexDDL);
         }


### PR DESCRIPTION
Co-authored-by: Palash Chauhan <palashc983@gmail.com>

Jira: PHOENIX-7671

TTL of the CDC index is same as the maxLookback configured at the cluster level. If the data table has different value of maxLookback than cluster level, the table level maxLookback is not used as TTL by the cdc index of the same data table.

The purpose of this PR is to sync the value of maxLookback from data table to index table's TableDescriptor while creating the index. Similarly, when the maxLookback value of the data table is altered using ALTER TABLE DDL, same value should be applied to all indexes.
The major compaction of CDC index should therefore consider data table's maxLookback value (from data table's descriptor) as it's TTL value.