### PR TITLE
PHOENIX-7768 Addendum Use HDFS urls from HAGroupStore when writing and during replay

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreClient.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreClient.java
@@ -613,6 +613,8 @@ public class HAGroupStoreClient implements Closeable {
         Preconditions.checkNotNull(peerZKUrl, "Peer ZK URL in System Table cannot be null");
         Preconditions.checkNotNull(peerClusterUrl,
           "Peer Cluster URL in System Table cannot be null");
+        Preconditions.checkNotNull(hdfsUrl, "Local HDFS URL in System Table cannot be null");
+        Preconditions.checkNotNull(peerHdfsUrl, "Peer HDFS URL in System Table cannot be null");
 
         return new SystemTableHAGroupRecord(policy, clusterRole, peerClusterRole, clusterUrl,
           peerClusterUrl, formattedZkUrl, peerZKUrl, hdfsUrl, peerHdfsUrl, adminCRRVersion);

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/ReplicationLogDiscoveryForwarder.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/ReplicationLogDiscoveryForwarder.java
@@ -49,7 +49,7 @@ public class ReplicationLogDiscoveryForwarder extends ReplicationLogDiscovery {
   public static final String REPLICATION_LOG_COPY_THROUGHPUT_BYTES_PER_MS_KEY =
     "phoenix.replication.log.copy.throughput.bytes.per.ms";
   // TODO: come up with a better default after testing
-  public static final double DEFAULT_LOG_COPY_THROUGHPUT_BYTES_PER_MS = 1.0;
+  public static final double DEFAULT_LOG_COPY_THROUGHPUT_BYTES_PER_MS = 0.1;
 
   /**
    * Configuration key for waiting buffer percentage

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/ReplicationLogDiscoveryForwarder.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/ReplicationLogDiscoveryForwarder.java
@@ -67,7 +67,7 @@ public class ReplicationLogDiscoveryForwarder extends ReplicationLogDiscovery {
    * @param logGroup HAGroup
    */
   private static ReplicationLogTracker createLogTracker(ReplicationLogGroup logGroup) {
-    ReplicationShardDirectoryManager localShardManager = logGroup.getFallbackShardManager();
+    ReplicationShardDirectoryManager localShardManager = logGroup.getLocalShardManager();
     return new ReplicationLogTracker(logGroup.conf, logGroup.getHAGroupName(), localShardManager,
       MetricsReplicationLogForwarderSourceFactory.getInstanceForTracker(logGroup.getHAGroupName()));
   }
@@ -134,7 +134,7 @@ public class ReplicationLogDiscoveryForwarder extends ReplicationLogDiscovery {
     FileSystem srcFS = replicationLogTracker.getFileSystem();
     FileStatus srcStat = srcFS.getFileStatus(src);
     long ts = replicationLogTracker.getFileTimestamp(srcStat.getPath());
-    ReplicationShardDirectoryManager remoteShardManager = logGroup.getStandbyShardManager();
+    ReplicationShardDirectoryManager remoteShardManager = logGroup.getPeerShardManager();
     Path dst = remoteShardManager.getWriterPath(ts, logGroup.getServerName().getServerName());
     long startTime = EnvironmentEdgeManager.currentTimeMillis();
     FileUtil.copy(srcFS, srcStat, remoteShardManager.getFileSystem(), dst, false, false, conf);

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/ReplicationLogGroup.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/ReplicationLogGroup.java
@@ -140,11 +140,6 @@ public class ReplicationLogGroup {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReplicationLogGroup.class);
 
-  // Configuration constants from original ReplicationLog
-  public static final String REPLICATION_STANDBY_HDFS_URL_KEY =
-    "phoenix.replication.log.standby.hdfs.url";
-  public static final String REPLICATION_FALLBACK_HDFS_URL_KEY =
-    "phoenix.replication.log.fallback.hdfs.url";
   public static final String REPLICATION_LOG_ROTATION_TIME_MS_KEY =
     "phoenix.replication.log.rotation.time.ms";
   public static final long DEFAULT_REPLICATION_LOG_ROTATION_TIME_MS = 60 * 1000L;
@@ -185,8 +180,8 @@ public class ReplicationLogGroup {
   protected final String haGroupName;
   protected final HAGroupStoreManager haGroupStoreManager;
   protected final MetricsReplicationLogGroupSource metrics;
-  protected ReplicationShardDirectoryManager standbyShardManager;
-  protected ReplicationShardDirectoryManager fallbackShardManager;
+  protected ReplicationShardDirectoryManager peerShardManager;
+  protected ReplicationShardDirectoryManager localShardManager;
   protected ReplicationLogDiscoveryForwarder logForwarder;
   protected long syncTimeoutMs;
   protected volatile boolean closed = false;
@@ -417,15 +412,23 @@ public class ReplicationLogGroup {
    * @throws IOException if initialization fails
    */
   protected void init() throws IOException {
+    Optional<HAGroupStoreRecord> haRecord = haGroupStoreManager.getHAGroupStoreRecord(haGroupName);
+    if (!haRecord.isPresent()) {
+      String message =
+        String.format("HAGroup %s got an empty group store record while initializing mode", this);
+      LOG.error(message);
+      throw new IOException(message);
+    }
+    HAGroupStoreRecord record = haRecord.get();
     // First initialize the shard managers
-    this.standbyShardManager = createStandbyShardManager();
-    this.fallbackShardManager = createFallbackShardManager();
+    this.peerShardManager = createPeerShardManager(record);
+    this.localShardManager = createLocalShardManager(record);
     // Initialize the replication log forwarder. The log forwarder is only activated when
     // we switch to STORE_AND_FORWARD or SYNC_AND_FORWARD mode
     this.logForwarder = new ReplicationLogDiscoveryForwarder(this);
     this.logForwarder.init();
     // Initialize the replication mode based on the HAGroupStore state
-    initializeReplicationMode();
+    initializeReplicationMode(record);
     // Use the override value if provided in the config, else use a derived value
     this.syncTimeoutMs = conf.getLong(REPLICATION_LOG_SYNC_TIMEOUT_KEY, calculateSyncTimeout());
     // Initialize the disruptor so that we start processing events
@@ -455,29 +458,13 @@ public class ReplicationLogGroup {
   /**
    * Initialize the replication mode based on the HAGroupStore state
    */
-  protected void initializeReplicationMode() throws IOException {
-    Optional<HAGroupStoreRecord> haGroupStoreRecord =
-      haGroupStoreManager.getHAGroupStoreRecord(haGroupName);
-    if (haGroupStoreRecord.isPresent()) {
-      HAGroupStoreRecord record = haGroupStoreRecord.get();
-      HAGroupState haGroupState = record.getHAGroupState();
-      LOG.info("HAGroup {} initializing mode from state {}", this, haGroupState);
-      if (haGroupState.equals(HAGroupState.ACTIVE_IN_SYNC)) {
-        setMode(SYNC);
-      } else {
-        setMode(STORE_AND_FORWARD);
-      }
-      /*
-       * else if (haGroupState.equals(HAGroupState.ACTIVE_NOT_IN_SYNC)) {
-       * setMode(STORE_AND_FORWARD); } else { String message =
-       * String.format("HAGroup %s got an unexpected state %s while " + "initializing mode", this,
-       * haGroupState); LOG.error(message); throw new IOException(message); }
-       */
+  protected void initializeReplicationMode(HAGroupStoreRecord record) throws IOException {
+    HAGroupState haGroupState = record.getHAGroupState();
+    LOG.info("HAGroup {} initializing mode from state {}", this, haGroupState);
+    if (haGroupState.equals(HAGroupState.ACTIVE_IN_SYNC)) {
+      setMode(SYNC);
     } else {
-      String message = String
-        .format("HAGroup %s got an empty group store record while " + "initializing mode", this);
-      LOG.error(message);
-      throw new IOException(message);
+      setMode(STORE_AND_FORWARD);
     }
   }
 
@@ -757,55 +744,49 @@ public class ReplicationLogGroup {
 
   /**
    * Creates the top level directory on the cluster determined by the URI
-   * @param urlKey     Config property for the URI
+   * @param uri        HDFS uri
    * @param logDirName Top level directory underneath which the shards will be created
    */
-  private ReplicationShardDirectoryManager createShardManager(String urlKey, String logDirName)
+  private ReplicationShardDirectoryManager createShardManager(String uri, String logDirName)
     throws IOException {
-    URI rootURI = getLogURI(urlKey);
-    FileSystem fs = getFileSystem(rootURI);
-    LOG.info("HAGroup {} initialized filesystem at {}", this, rootURI);
-    // root dir path is <URI>/<HAGroupName>/[in|out]
-    Path rootDirPath = new Path(new Path(rootURI.getPath(), getHAGroupName()), logDirName);
-    if (!fs.exists(rootDirPath)) {
-      LOG.info("HAGroup {} creating root directory at {}", this, rootDirPath);
-      if (!fs.mkdirs(rootDirPath)) {
-        throw new IOException("Failed to create directory: " + rootDirPath);
+    try {
+      URI rootURI = new URI(uri);
+      FileSystem fs = getFileSystem(rootURI);
+      LOG.info("HAGroup {} initialized filesystem at {}", this, rootURI);
+      // root dir path is <URI>/<HAGroupName>/[in|out]
+      Path rootDirPath = new Path(new Path(rootURI.getPath(), getHAGroupName()), logDirName);
+      if (!fs.exists(rootDirPath)) {
+        LOG.info("HAGroup {} creating root directory at {}", this, rootDirPath);
+        if (!fs.mkdirs(rootDirPath)) {
+          throw new IOException("Failed to create directory: " + rootDirPath);
+        }
       }
+      return new ReplicationShardDirectoryManager(conf, fs, rootDirPath);
+    } catch (URISyntaxException e) {
+      throw new IOException("Invalid HDFS URI: " + uri, e);
     }
-    return new ReplicationShardDirectoryManager(conf, fs, rootDirPath);
   }
 
   /** create shard manager for the standby cluster */
-  protected ReplicationShardDirectoryManager createStandbyShardManager() throws IOException {
-    return createShardManager(REPLICATION_STANDBY_HDFS_URL_KEY, STANDBY_DIR);
+  protected ReplicationShardDirectoryManager createPeerShardManager(HAGroupStoreRecord record)
+    throws IOException {
+    return createShardManager(record.getPeerHdfsUrl(), STANDBY_DIR);
   }
 
   /** create shard manager for the fallback cluster */
-  protected ReplicationShardDirectoryManager createFallbackShardManager() throws IOException {
-    return createShardManager(REPLICATION_FALLBACK_HDFS_URL_KEY, FALLBACK_DIR);
+  protected ReplicationShardDirectoryManager createLocalShardManager(HAGroupStoreRecord record)
+    throws IOException {
+    return createShardManager(record.getHdfsUrl(), FALLBACK_DIR);
   }
 
   /** return shard manager for the standby cluster */
-  protected ReplicationShardDirectoryManager getStandbyShardManager() {
-    return standbyShardManager;
+  protected ReplicationShardDirectoryManager getPeerShardManager() {
+    return peerShardManager;
   }
 
   /** return shard manager for the fallback cluster */
-  protected ReplicationShardDirectoryManager getFallbackShardManager() {
-    return fallbackShardManager;
-  }
-
-  private URI getLogURI(String urlKey) throws IOException {
-    String urlString = conf.get(urlKey);
-    if (urlString == null || urlString.trim().isEmpty()) {
-      throw new IOException("HDFS URL not configured: " + urlKey);
-    }
-    try {
-      return new URI(urlString);
-    } catch (URISyntaxException e) {
-      throw new IOException("Invalid HDFS URL: " + urlString, e);
-    }
+  protected ReplicationShardDirectoryManager getLocalShardManager() {
+    return localShardManager;
   }
 
   private FileSystem getFileSystem(URI uri) throws IOException {
@@ -814,12 +795,12 @@ public class ReplicationLogGroup {
 
   /** Create the standby(synchronous) writer */
   protected ReplicationLog createStandbyLog() throws IOException {
-    return new ReplicationLog(this, standbyShardManager);
+    return new ReplicationLog(this, peerShardManager);
   }
 
   /** Create the fallback writer */
   protected ReplicationLog createFallbackLog() throws IOException {
-    return new ReplicationLog(this, fallbackShardManager);
+    return new ReplicationLog(this, localShardManager);
   }
 
   /** Returns the log forwarder for this replication group */

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogReplay.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/reader/ReplicationLogReplay.java
@@ -20,10 +20,13 @@ package org.apache.phoenix.replication.reader;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.phoenix.jdbc.HAGroupStoreManager;
+import org.apache.phoenix.jdbc.HAGroupStoreRecord;
 import org.apache.phoenix.replication.ReplicationLogTracker;
 import org.apache.phoenix.replication.ReplicationShardDirectoryManager;
 import org.apache.phoenix.replication.metrics.MetricsReplicationLogTrackerReplayImpl;
@@ -39,12 +42,6 @@ import org.slf4j.LoggerFactory;
 public class ReplicationLogReplay {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReplicationLogReplay.class);
-
-  /**
-   * The path on the HDFS where log files are to be read.
-   */
-  public static final String REPLICATION_LOG_REPLAY_HDFS_URL_KEY =
-    "phoenix.replication.log.replay.hdfs.url";
 
   public static final String IN_DIRECTORY_NAME = "in";
   /**
@@ -106,7 +103,16 @@ public class ReplicationLogReplay {
    */
   protected void init() throws IOException {
     LOG.info("Initializing ReplicationLogReplay for haGroup: {}", haGroupName);
-    initializeFileSystem();
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf);
+    Optional<HAGroupStoreRecord> haRecord = haGroupStoreManager.getHAGroupStoreRecord(haGroupName);
+    if (!haRecord.isPresent()) {
+      String message = String.format(
+        "HAGroup %s got an empty group store record while initializing ReplicationLogReplay",
+        haGroupName);
+      LOG.error(message);
+      throw new IOException(message);
+    }
+    initializeFileSystem(haRecord.get().getHdfsUrl());
     Path newFilesDirectory =
       new Path(new Path(rootURI.getPath(), haGroupName), ReplicationLogReplay.IN_DIRECTORY_NAME);
     ReplicationShardDirectoryManager replicationShardDirectoryManager =
@@ -129,11 +135,7 @@ public class ReplicationLogReplay {
   }
 
   /** Initializes the filesystem and creates root log directory. */
-  private void initializeFileSystem() throws IOException {
-    String uriString = conf.get(REPLICATION_LOG_REPLAY_HDFS_URL_KEY);
-    if (uriString == null || uriString.isEmpty()) {
-      throw new IOException(REPLICATION_LOG_REPLAY_HDFS_URL_KEY + " is not configured");
-    }
+  private void initializeFileSystem(String uriString) throws IOException {
     try {
       this.rootURI = new URI(uriString);
       this.fileSystem = FileSystem.get(rootURI, conf);
@@ -145,7 +147,7 @@ public class ReplicationLogReplay {
         }
       }
     } catch (URISyntaxException e) {
-      throw new IOException(REPLICATION_LOG_REPLAY_HDFS_URL_KEY + " is not valid", e);
+      throw new IOException(uriString + " is not valid", e);
     }
   }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/PhoenixRegionServerEndpointWithConsistentFailoverIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/PhoenixRegionServerEndpointWithConsistentFailoverIT.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNotNull;
 
 import com.google.protobuf.RpcCallback;
 import java.io.IOException;
-import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.Connection;
@@ -39,15 +38,13 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.coprocessor.PhoenixRegionServerEndpoint;
 import org.apache.phoenix.coprocessor.generated.RegionServerEndpointProtos;
 import org.apache.phoenix.jdbc.ClusterRoleRecord;
+import org.apache.phoenix.jdbc.HABaseIT;
 import org.apache.phoenix.jdbc.HAGroupStoreRecord;
 import org.apache.phoenix.jdbc.HAGroupStoreRecord.HAGroupState;
 import org.apache.phoenix.jdbc.HighAvailabilityPolicy;
-import org.apache.phoenix.jdbc.HighAvailabilityTestingUtility;
 import org.apache.phoenix.jdbc.PhoenixHAAdmin;
-import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
-import org.apache.phoenix.util.ReadOnlyProps;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -58,17 +55,12 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
-
 @Category({ NeedsOwnMiniClusterTest.class })
-public class PhoenixRegionServerEndpointWithConsistentFailoverIT extends BaseTest {
+public class PhoenixRegionServerEndpointWithConsistentFailoverIT extends HABaseIT {
 
   private static final Logger LOGGER =
     LoggerFactory.getLogger(PhoenixRegionServerEndpointWithConsistentFailoverIT.class);
   private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 5000L;
-  private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS =
-    new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
-  private String zkUrl;
   private String peerZkUrl;
 
   @Rule
@@ -76,8 +68,6 @@ public class PhoenixRegionServerEndpointWithConsistentFailoverIT extends BaseTes
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
-    Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
-    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
     // Set prewarm enabled to true for cluster 1 and false for cluster 2 for comparison.
     CLUSTERS.getHBaseCluster1().getConfiguration()
       .setBoolean(QueryServices.HA_GROUP_STORE_CLIENT_PREWARM_ENABLED, true);
@@ -97,11 +87,11 @@ public class PhoenixRegionServerEndpointWithConsistentFailoverIT extends BaseTes
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(testName.getMethodName(),
       CLUSTERS.getZkUrl1(), CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress1(),
       CLUSTERS.getMasterAddress2(), ClusterRoleRecord.ClusterRole.ACTIVE,
-      ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(testName.getMethodName(),
       CLUSTERS.getZkUrl2(), CLUSTERS.getZkUrl1(), CLUSTERS.getMasterAddress2(),
       CLUSTERS.getMasterAddress1(), ClusterRoleRecord.ClusterRole.STANDBY,
-      ClusterRoleRecord.ClusterRole.ACTIVE, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
   }
 
@@ -120,12 +110,13 @@ public class PhoenixRegionServerEndpointWithConsistentFailoverIT extends BaseTes
     // inserted into the system table.
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, CLUSTERS.getZkUrl1(),
       CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, CLUSTERS.getZkUrl1(),
       CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
       ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY,
-      CLUSTERS.getZkUrl2());
+      CLUSTERS.getZkUrl2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Get RegionServer instances from both clusters
     HRegionServer regionServer1 = CLUSTERS.getHBaseCluster1().getHBaseCluster().getRegionServer(0);
@@ -195,7 +186,7 @@ public class PhoenixRegionServerEndpointWithConsistentFailoverIT extends BaseTes
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
           CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress2(), CLUSTERS.getMasterAddress1(),
-          localUri.toString(), standbyUri.toString(), 0L);
+          CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
       peerHAAdmin.createHAGroupStoreRecordInZooKeeper(peerHAGroupStoreRecord);
     }
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -225,7 +216,8 @@ public class PhoenixRegionServerEndpointWithConsistentFailoverIT extends BaseTes
     // Update the row
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(testName.getMethodName(),
       CLUSTERS.getZkUrl1(), peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     // Now Invalidate the Cache
     controller = new ServerRpcController();
     coprocessor.invalidateHAGroupStoreClient(controller,

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/IndexRegionObserverMutationBlockingIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/IndexRegionObserverMutationBlockingIT.java
@@ -56,11 +56,8 @@ import org.junit.rules.TestName;
 public class IndexRegionObserverMutationBlockingIT extends HABaseIT {
 
   private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 1000L;
-  private static final String TEST_HDFS_URL = fallbackUri.toString();
-  private static final String TEST_PEER_HDFS_URL = standbyUri.toString();
   private PhoenixHAAdmin haAdmin;
 
-  private String zkUrl;
   private String peerZkUrl;
 
   @Rule
@@ -86,7 +83,6 @@ public class IndexRegionObserverMutationBlockingIT extends HABaseIT {
     haAdmin = CLUSTERS.getHaAdmin1();
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
     CLUSTERS.initClusterRole(haGroupName, HighAvailabilityPolicy.FAILOVER);
-    this.zkUrl = CLUSTERS.getZkUrl1();
     this.peerZkUrl = CLUSTERS.getZkUrl2();
   }
 
@@ -112,7 +108,7 @@ public class IndexRegionObserverMutationBlockingIT extends HABaseIT {
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
           HighAvailabilityPolicy.FAILOVER.toString(), this.peerZkUrl, CLUSTERS.getMasterAddress1(),
-          CLUSTERS.getMasterAddress2(), TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
       haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, haGroupStoreRecord, -1);
 
       // Wait for the event to propagate
@@ -180,7 +176,7 @@ public class IndexRegionObserverMutationBlockingIT extends HABaseIT {
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
           HighAvailabilityPolicy.FAILOVER.toString(), this.peerZkUrl, CLUSTERS.getMasterAddress1(),
-          CLUSTERS.getMasterAddress2(), TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
       haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, haGroupStoreRecord, -1);
       Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -199,7 +195,7 @@ public class IndexRegionObserverMutationBlockingIT extends HABaseIT {
       haGroupStoreRecord = new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION,
         haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0L,
         HighAvailabilityPolicy.FAILOVER.toString(), this.peerZkUrl, CLUSTERS.getMasterAddress1(),
-        CLUSTERS.getMasterAddress2(), TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
       haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, haGroupStoreRecord, -1);
       Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -237,7 +233,7 @@ public class IndexRegionObserverMutationBlockingIT extends HABaseIT {
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
           HighAvailabilityPolicy.FAILOVER.toString(), this.peerZkUrl, CLUSTERS.getMasterAddress1(),
-          CLUSTERS.getMasterAddress2(), TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
       haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, haGroupStoreRecord, -1);
 
       // Wait for the event to propagate

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/FailoverPhoenixConnection2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/FailoverPhoenixConnection2IT.java
@@ -29,6 +29,7 @@ import static org.apache.phoenix.jdbc.HighAvailabilityGroup.PHOENIX_HA_GROUP_ATT
 import static org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.doTestBasicOperationsWithConnection;
 import static org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.getHighAvailibilityGroup;
 import static org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.sleepThreadFor;
+import static org.apache.phoenix.replication.reader.ReplicationLogReplayService.PHOENIX_REPLICATION_REPLAY_ENABLED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -86,6 +87,9 @@ public class FailoverPhoenixConnection2IT extends HABaseIT {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
+    // Disable replication replay service
+    conf1.setBoolean(PHOENIX_REPLICATION_REPLAY_ENABLED, false);
+    conf2.setBoolean(PHOENIX_REPLICATION_REPLAY_ENABLED, false);
     CLUSTERS.start();
     DriverManager.registerDriver(PhoenixDriver.INSTANCE);
   }

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HABaseIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HABaseIT.java
@@ -18,40 +18,26 @@
 package org.apache.phoenix.jdbc;
 
 import static org.apache.phoenix.query.QueryServices.SYNCHRONOUS_REPLICATION_ENABLED;
+import static org.apache.phoenix.replication.reader.ReplicationLogReplayService.PHOENIX_REPLICATION_REPLAY_ENABLED;
 
-import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.HBaseTestingUtilityPair;
-import org.apache.phoenix.replication.ReplicationLogGroup;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
 
 public class HABaseIT {
-  @ClassRule
-  public static TemporaryFolder standbyFolder = new TemporaryFolder();
-  @ClassRule
-  public static TemporaryFolder localFolder = new TemporaryFolder();
-
   protected static final HBaseTestingUtilityPair CLUSTERS = new HBaseTestingUtilityPair();
 
   protected static Configuration conf1;
   protected static Configuration conf2;
-  protected static URI standbyUri;
-  protected static URI fallbackUri;
 
   @BeforeClass
   public static synchronized void doBaseSetup() {
     conf1 = CLUSTERS.getHBaseCluster1().getConfiguration();
     conf2 = CLUSTERS.getHBaseCluster2().getConfiguration();
-    standbyUri = new Path(standbyFolder.getRoot().toString()).toUri();
-    fallbackUri = new Path(localFolder.getRoot().toString()).toUri();
     conf1.setBoolean(SYNCHRONOUS_REPLICATION_ENABLED, true);
     conf2.setBoolean(SYNCHRONOUS_REPLICATION_ENABLED, true);
-    conf1.set(ReplicationLogGroup.REPLICATION_STANDBY_HDFS_URL_KEY, standbyUri.toString());
-    conf1.set(ReplicationLogGroup.REPLICATION_FALLBACK_HDFS_URL_KEY, fallbackUri.toString());
-    conf2.set(ReplicationLogGroup.REPLICATION_STANDBY_HDFS_URL_KEY, standbyUri.toString());
-    conf2.set(ReplicationLogGroup.REPLICATION_FALLBACK_HDFS_URL_KEY, fallbackUri.toString());
+    // Enable replication replay service
+    conf1.setBoolean(PHOENIX_REPLICATION_REPLAY_ENABLED, true);
+    conf2.setBoolean(PHOENIX_REPLICATION_REPLAY_ENABLED, true);
   }
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStateSubscriptionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStateSubscriptionIT.java
@@ -23,7 +23,6 @@ import static org.apache.phoenix.jdbc.HAGroupStoreRecord.HAGroupState.ACTIVE_IN_
 import static org.apache.phoenix.jdbc.HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC;
 import static org.apache.phoenix.jdbc.PhoenixHAAdmin.getLocalZkUrl;
 import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
-import static org.apache.phoenix.query.QueryServices.CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -31,7 +30,6 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.CountDownLatch;
@@ -42,9 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.jdbc.HAGroupStoreRecord.HAGroupState;
-import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
-import org.apache.phoenix.util.ReadOnlyProps;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -54,15 +50,13 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
-
 /**
  * Integration tests for HA Group State Change subscription functionality. Tests the new
  * subscription system where HAGroupStoreClient directly manages subscriptions and
  * HAGroupStoreManager acts as a passthrough.
  */
 @Category(NeedsOwnMiniClusterTest.class)
-public class HAGroupStateSubscriptionIT extends BaseTest {
+public class HAGroupStateSubscriptionIT extends HABaseIT {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HAGroupStateSubscriptionIT.class);
 
@@ -74,25 +68,22 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 2000L;
   private String zkUrl;
   private String peerZKUrl;
-  private static final String TEST_HDFS_URL = localUri.toString();
-  private static final String TEST_PEER_HDFS_URL = standbyUri.toString();
-  private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS =
-    new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
+  private String hdfsUrl1;
+  private String hdfsUrl2;
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
-    Map<String, String> props = Maps.newHashMapWithExpectedSize(2);
-    props.put(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, "true");
-    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
     CLUSTERS.start();
   }
 
   @Before
   public void before() throws Exception {
-    haAdmin = new PhoenixHAAdmin(config, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
-    zkUrl = getLocalZkUrl(config);
+    haAdmin = new PhoenixHAAdmin(conf1, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
+    zkUrl = getLocalZkUrl(conf1);
     this.peerZKUrl = CLUSTERS.getZkUrl2();
-    peerHaAdmin = new PhoenixHAAdmin(peerZKUrl, config, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
+    peerHaAdmin = new PhoenixHAAdmin(peerZKUrl, conf2, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
+    hdfsUrl1 = CLUSTERS.getHdfsUrl1();
+    hdfsUrl2 = CLUSTERS.getHdfsUrl2();
 
     // Clean up existing HAGroupStoreRecords
     try {
@@ -111,7 +102,8 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Insert a HAGroupStoreRecord into the system table
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(testName.getMethodName(), zkUrl,
       peerZKUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
   }
 
   // ========== Multi-Cluster & Basic Subscription Tests ==========
@@ -119,7 +111,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testDifferentTargetStatesPerCluster() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     // Track notifications
     AtomicInteger localNotifications = new AtomicInteger(0);
@@ -163,14 +155,14 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Trigger transition to STANDBY_TO_ACTIVE on LOCAL cluster
     HAGroupStoreRecord localRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.STANDBY_TO_ACTIVE, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-      this.peerZKUrl, this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.peerZKUrl, this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, localRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
     // Trigger transition to STANDBY on PEER cluster
     HAGroupStoreRecord peerRecord = new HAGroupStoreRecord("1.0", haGroupName, ACTIVE_NOT_IN_SYNC,
       0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-      TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.createHAGroupStoreRecordInZooKeeper(peerRecord);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -189,7 +181,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testUnsubscribeSpecificCluster() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     // Track notifications
     AtomicInteger totalNotifications = new AtomicInteger(0);
@@ -223,7 +215,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // First, establish ACTIVE_IN_SYNC state on PEER cluster
     HAGroupStoreRecord peerActiveRecord = new HAGroupStoreRecord("1.0", haGroupName, ACTIVE_IN_SYNC,
       0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-      TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.createHAGroupStoreRecordInZooKeeper(peerActiveRecord);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -234,7 +226,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Now trigger transition from ACTIVE_IN_SYNC to STANDBY on PEER → should call listener
     HAGroupStoreRecord peerStandbyRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, peerStandbyRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -252,7 +244,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testMultipleListenersMultipleClusters() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     // Track notifications from multiple listeners
     AtomicInteger listener1LocalNotifications = new AtomicInteger(0);
@@ -297,14 +289,14 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Trigger transition to DEGRADED_STANDBY on LOCAL
     HAGroupStoreRecord localRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.DEGRADED_STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, localRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
     // Trigger transition to DEGRADED_STANDBY on PEER
     HAGroupStoreRecord peerRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.DEGRADED_STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.createHAGroupStoreRecordInZooKeeper(peerRecord);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -321,7 +313,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testSameListenerDifferentTargetStates() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     // Track which target states were reached
     AtomicInteger stateANotifications = new AtomicInteger(0);
@@ -356,14 +348,14 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Trigger target state A on LOCAL
     HAGroupStoreRecord localRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-      this.peerZKUrl, this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.peerZKUrl, this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, localRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
     // Trigger target state B on PEER
     HAGroupStoreRecord peerRecord = new HAGroupStoreRecord("1.0", haGroupName, ACTIVE_IN_SYNC, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-      TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.createHAGroupStoreRecordInZooKeeper(peerRecord);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -381,7 +373,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testSubscriptionToNonExistentHAGroup() throws Exception {
     String nonExistentHAGroup = "nonExistentGroup_" + testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     HAGroupStateListener listener =
       (groupName, fromState, toState, modifiedTime, clusterType, lastSyncStateTimeInMs) -> {
@@ -403,7 +395,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testListenerExceptionIsolation() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     // Track notifications
     AtomicInteger goodListener1Notifications = new AtomicInteger(0);
@@ -446,7 +438,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Trigger transition to target state
     HAGroupStoreRecord transitionRecord = new HAGroupStoreRecord("1.0", haGroupName,
       ACTIVE_NOT_IN_SYNC, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, transitionRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -461,7 +453,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testConcurrentMultiClusterSubscriptions() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     final int threadCount = 10;
     final CountDownLatch startLatch = new CountDownLatch(1);
@@ -515,7 +507,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testHighFrequencyMultiClusterChanges() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     // Track notifications
     AtomicInteger localNotifications = new AtomicInteger(0);
@@ -539,7 +531,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     final int changeCount = 5;
     HAGroupStoreRecord initialPeerRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.DEGRADED_STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.createHAGroupStoreRecordInZooKeeper(initialPeerRecord);
 
     for (int i = 0; i < changeCount; i++) {
@@ -547,14 +539,14 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
       HAGroupStoreRecord localRecord = new HAGroupStoreRecord("1.0", haGroupName,
         (i % 2 == 0) ? HAGroupState.STANDBY : HAGroupState.DEGRADED_STANDBY, 0L,
         HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-        TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+        hdfsUrl1, hdfsUrl2, 0L);
       haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, localRecord, -1);
 
       // Change peer cluster
       HAGroupStoreRecord peerRecord = new HAGroupStoreRecord("1.0", haGroupName,
         (i % 2 == 0) ? HAGroupState.STANDBY : HAGroupState.STANDBY_TO_ACTIVE, 0L,
         HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-        TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+        hdfsUrl1, hdfsUrl2, 0L);
       peerHaAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, peerRecord, -1);
 
       // Small delay between changes
@@ -581,7 +573,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
   @Test
   public void testSubscriptionCleanupPerCluster() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager manager = HAGroupStoreManager.getInstance(conf1);
 
     // Track notifications to verify functionality
     AtomicInteger localActiveNotifications = new AtomicInteger(0);
@@ -642,7 +634,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Test initial functionality - trigger ACTIVE_IN_SYNC on LOCAL
     HAGroupStoreRecord localActiveRecord = new HAGroupStoreRecord("1.0", haGroupName,
       ACTIVE_NOT_IN_SYNC, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, localActiveRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -653,7 +645,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Test initial functionality - trigger STANDBY_TO_ACTIVE on PEER
     HAGroupStoreRecord peerActiveRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.STANDBY_TO_ACTIVE, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-      this.peerZKUrl, this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.peerZKUrl, this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.createHAGroupStoreRecordInZooKeeper(peerActiveRecord);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -676,13 +668,13 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // some other state.
     HAGroupStoreRecord localActiveRecord2 = new HAGroupStoreRecord("1.0", haGroupName,
       ACTIVE_IN_SYNC_TO_STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, localActiveRecord2, 1);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
     HAGroupStoreRecord localActiveRecord3 = new HAGroupStoreRecord("1.0", haGroupName,
       ACTIVE_NOT_IN_SYNC, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, localActiveRecord3, 2);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -693,13 +685,13 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Test after partial unsubscribe - trigger STANDBY_TO_ACTIVE on PEER again
     HAGroupStoreRecord peerActiveRecord2 = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, peerActiveRecord2, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
     HAGroupStoreRecord peerActiveRecord3 = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.STANDBY_TO_ACTIVE, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-      this.peerZKUrl, this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.peerZKUrl, this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, peerActiveRecord3, 1);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -722,13 +714,13 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Test after complete unsubscribe - trigger ACTIVE_NOT_IN_SYNC on both clusters
     HAGroupStoreRecord localActiveRecord4 = new HAGroupStoreRecord("1.0", haGroupName,
       ACTIVE_NOT_IN_SYNC, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, localActiveRecord4, 3);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
     HAGroupStoreRecord peerActiveRecord4 = new HAGroupStoreRecord("1.0", haGroupName,
       ACTIVE_NOT_IN_SYNC, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     peerHaAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, peerActiveRecord4, 2);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -756,7 +748,7 @@ public class HAGroupStateSubscriptionIT extends BaseTest {
     // Trigger STANDBY state and verify new subscription works
     HAGroupStoreRecord standbyRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl,
-      this.zkUrl, this.peerZKUrl, TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+      this.zkUrl, this.peerZKUrl, hdfsUrl1, hdfsUrl2, 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, standbyRecord, 4);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreClientIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreClientIT.java
@@ -21,6 +21,7 @@ import static org.apache.phoenix.jdbc.HAGroupStoreClient.ZK_CONSISTENT_HA_GROUP_
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.SYSTEM_HA_GROUP_NAME;
 import static org.apache.phoenix.jdbc.PhoenixHAAdmin.getLocalZkUrl;
 import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
+import static org.apache.phoenix.replication.reader.ReplicationLogReplayService.PHOENIX_REPLICATION_REPLAY_ENABLED;
 import static org.apache.phoenix.util.PhoenixRuntime.JDBC_PROTOCOL_SEPARATOR;
 import static org.apache.phoenix.util.PhoenixRuntime.JDBC_PROTOCOL_ZK;
 import static org.junit.Assert.assertEquals;
@@ -81,6 +82,10 @@ public class HAGroupStoreClientIT extends HABaseIT {
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
+    // some of the test scenarios don't behave correctly because of the interactions
+    // between ReplayService and HAGroupStore
+    conf1.setBoolean(PHOENIX_REPLICATION_REPLAY_ENABLED, false);
+    conf2.setBoolean(PHOENIX_REPLICATION_REPLAY_ENABLED, false);
     CLUSTERS.start();
   }
 
@@ -104,8 +109,8 @@ public class HAGroupStoreClientIT extends HABaseIT {
     this.masterUrl = CLUSTERS.getMasterAddress1();
     this.peerMasterUrl = CLUSTERS.getMasterAddress2();
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
   }
 
   @After
@@ -121,9 +126,10 @@ public class HAGroupStoreClientIT extends HABaseIT {
     String haGroupName = testName.getMethodName();
     // Clean existing record
     HAGroupStoreTestUtil.deleteHAGroupRecordInSystemTable(haGroupName, zkUrl);
-    HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, null, null,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, this.zkUrl,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+    HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, null, null, this.masterUrl,
+      this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, this.zkUrl, CLUSTERS.getHdfsUrl1(),
+      CLUSTERS.getHdfsUrl2());
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
       .getInstanceForZkUrl(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName, zkUrl);
     assertNull(haGroupStoreClient);
@@ -314,11 +320,11 @@ public class HAGroupStoreClientIT extends HABaseIT {
     String haGroupName1 = testName.getMethodName() + "1";
     String haGroupName2 = testName.getMethodName() + "2";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Setup initial HAGroupStoreRecords
     HAGroupStoreRecord record1 =
@@ -567,7 +573,9 @@ public class HAGroupStoreClientIT extends HABaseIT {
 
     // Delete the record from ZK
     haAdmin.getCurator().delete().deletingChildrenIfNeeded().forPath(toPath(haGroupName));
+    System.out.println("Going to sleep after deleting record from zk");
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
+    System.out.println("Waking up after deleting record from zk");
 
     // Delete the record from System Table
     try (
@@ -578,6 +586,7 @@ public class HAGroupStoreClientIT extends HABaseIT {
         "DELETE FROM " + SYSTEM_HA_GROUP_NAME + " WHERE HA_GROUP_NAME = '" + haGroupName + "'");
       conn.commit();
     }
+    System.out.println("Deleted record from system table");
 
     // This should fail because no record exists in either ZK or System Table
     try {
@@ -949,8 +958,8 @@ public class HAGroupStoreClientIT extends HABaseIT {
   public void testGetHAGroupNamesWithSingleGroup() throws Exception {
     String haGroupName = testName.getMethodName();
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(zkUrl);
 
@@ -976,17 +985,18 @@ public class HAGroupStoreClientIT extends HABaseIT {
 
     // Insert multiple HA group records
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.STANDBY,
+      ClusterRoleRecord.ClusterRole.ACTIVE, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName3, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName4, "bad_zk_url",
-      this.peerZKUrl, ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY,
-      this.zkUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.peerZKUrl, this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, this.zkUrl, CLUSTERS.getHdfsUrl1(),
+      CLUSTERS.getHdfsUrl2());
 
     List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(zkUrl);
 
@@ -1030,11 +1040,11 @@ public class HAGroupStoreClientIT extends HABaseIT {
 
     // Insert HA group records
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.STANDBY,
+      ClusterRoleRecord.ClusterRole.ACTIVE, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Verify both groups exist
     List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(zkUrl);
@@ -1087,8 +1097,8 @@ public class HAGroupStoreClientIT extends HABaseIT {
 
     // 1. Setup: Create initial system table record with default values
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
-      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // 2. Create ZK record with DIFFERENT values for testable fields (skip zkUrl changes)
     String updatedClusterUrl = this.masterUrl + ":updated";

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreClientIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreClientIT.java
@@ -39,7 +39,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -53,9 +52,7 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.exception.InvalidClusterRoleTransitionException;
-import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
-import org.apache.phoenix.util.ReadOnlyProps;
 import org.apache.zookeeper.data.Stat;
 import org.junit.After;
 import org.junit.Before;
@@ -65,17 +62,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
-
 /**
  * Integration tests for {@link HAGroupStoreClient}
  */
 @Category(NeedsOwnMiniClusterTest.class)
-public class HAGroupStoreClientIT extends BaseTest {
+public class HAGroupStoreClientIT extends HABaseIT {
 
   private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 5000L;
-  private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS =
-    new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
   private PhoenixHAAdmin haAdmin;
   private PhoenixHAAdmin peerHaAdmin;
   private String zkUrl;
@@ -88,8 +81,6 @@ public class HAGroupStoreClientIT extends BaseTest {
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
-    Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
-    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
     CLUSTERS.start();
   }
 
@@ -113,7 +104,8 @@ public class HAGroupStoreClientIT extends BaseTest {
     this.masterUrl = CLUSTERS.getMasterAddress1();
     this.peerMasterUrl = CLUSTERS.getMasterAddress2();
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
   }
 
   @After
@@ -130,7 +122,8 @@ public class HAGroupStoreClientIT extends BaseTest {
     // Clean existing record
     HAGroupStoreTestUtil.deleteHAGroupRecordInSystemTable(haGroupName, zkUrl);
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, null, null,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, this.zkUrl);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, this.zkUrl,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
       .getInstanceForZkUrl(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName, zkUrl);
     assertNull(haGroupStoreClient);
@@ -143,7 +136,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord record =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
       .getInstanceForZkUrl(CLUSTERS.getHBaseCluster1().getConfiguration(), haGroupName, zkUrl);
@@ -161,7 +154,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     record =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), null, this.masterUrl, null,
-        localUri.toString(), standbyUri.toString(), 0L);
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
     assertNull(peerPathChildrenCache.get(haGroupStoreClient));
@@ -170,7 +163,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     // STANDBY
     record = new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.STANDBY,
       0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
     currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
@@ -185,7 +178,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     record =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -198,7 +191,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     String invalidUrl = "invalidURL";
     record = new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.STANDBY,
       0L, HighAvailabilityPolicy.FAILOVER.toString(), invalidUrl, this.masterUrl, invalidUrl,
-      localUri.toString(), standbyUri.toString(), 0L);
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
     currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
@@ -237,7 +230,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord record =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
     HAGroupStoreRecord currentRecord = haGroupStoreClient.getHAGroupStoreRecord();
@@ -248,7 +241,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     record = new HAGroupStoreRecord("v1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
 
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -261,7 +254,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     record =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
 
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -273,7 +266,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     record = new HAGroupStoreRecord("v1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
 
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -285,7 +278,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     record =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
 
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -321,19 +314,21 @@ public class HAGroupStoreClientIT extends BaseTest {
     String haGroupName1 = testName.getMethodName() + "1";
     String haGroupName2 = testName.getMethodName() + "2";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Setup initial HAGroupStoreRecords
     HAGroupStoreRecord record1 =
       new HAGroupStoreRecord("v1.0", haGroupName1, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     HAGroupStoreRecord record2 =
       new HAGroupStoreRecord("v1.0", haGroupName2, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
@@ -356,11 +351,11 @@ public class HAGroupStoreClientIT extends BaseTest {
     record1 = new HAGroupStoreRecord("v1.0", haGroupName1,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     record2 =
       new HAGroupStoreRecord("v1.0", haGroupName2, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
@@ -378,11 +373,11 @@ public class HAGroupStoreClientIT extends BaseTest {
     record1 =
       new HAGroupStoreRecord("v1.0", haGroupName1, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     record2 =
       new HAGroupStoreRecord("v1.0", haGroupName2, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
@@ -400,11 +395,11 @@ public class HAGroupStoreClientIT extends BaseTest {
     record1 =
       new HAGroupStoreRecord("v1.0", haGroupName1, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     record2 = new HAGroupStoreRecord("v1.0", haGroupName2,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName1, record1);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName2, record2);
@@ -426,7 +421,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord record =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
@@ -455,7 +450,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     record = new HAGroupStoreRecord("v1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
 
@@ -485,7 +480,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord record1 =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record1);
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
@@ -508,7 +503,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     record1 = new HAGroupStoreRecord("v1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC_TO_STANDBY, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record1);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -526,7 +521,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord record =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, record);
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
@@ -603,7 +598,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord initialRecord =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
 
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
@@ -634,7 +629,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord initialRecord =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
 
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
@@ -666,7 +661,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord initialRecord = new HAGroupStoreRecord("v1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
     Stat initialRecordInZKStat = haAdmin.getHAGroupStoreRecordInZooKeeper(haGroupName).getRight();
     int initialRecordVersion = initialRecordInZKStat.getVersion();
@@ -697,7 +692,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord initialRecord = new HAGroupStoreRecord("v1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
 
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
@@ -725,7 +720,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord initialRecord =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
 
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
@@ -775,7 +770,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     HAGroupStoreRecord initialRecord =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, initialRecord);
 
     HAGroupStoreClient haGroupStoreClient = HAGroupStoreClient
@@ -875,20 +870,20 @@ public class HAGroupStoreClientIT extends BaseTest {
     String haGroupName = testName.getMethodName();
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, this.zkUrl, this.peerZKUrl,
       this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
-      ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HAGroupStoreRecord for local cluster
     HAGroupStoreRecord localRecord =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, localRecord);
 
     // Create HAGroupStoreRecord for peer cluster
     HAGroupStoreRecord peerRecord =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.STANDBY, 0L,
         HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.peerMasterUrl,
-        this.masterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.masterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(peerHaAdmin, haGroupName, peerRecord);
 
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -911,13 +906,13 @@ public class HAGroupStoreClientIT extends BaseTest {
     String haGroupName = testName.getMethodName();
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, this.zkUrl, this.peerZKUrl,
       this.masterUrl, this.peerMasterUrl, ClusterRoleRecord.ClusterRole.ACTIVE,
-      ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HAGroupStoreRecord for local cluster only (no peer record)
     HAGroupStoreRecord localRecord =
       new HAGroupStoreRecord("v1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-        this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+        this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, localRecord);
 
     // Explicitly ensure no peer record exists
@@ -946,7 +941,7 @@ public class HAGroupStoreClientIT extends BaseTest {
     return new HAGroupStoreRecord("v1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.masterUrl,
-      this.peerMasterUrl, localUri.toString(), standbyUri.toString(), 0L);
+      this.peerMasterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
   }
 
   // Tests for getHAGroupNames static method
@@ -954,7 +949,8 @@ public class HAGroupStoreClientIT extends BaseTest {
   public void testGetHAGroupNamesWithSingleGroup() throws Exception {
     String haGroupName = testName.getMethodName();
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(zkUrl);
 
@@ -980,14 +976,17 @@ public class HAGroupStoreClientIT extends BaseTest {
 
     // Insert multiple HA group records
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, null);
+      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName3, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName4, "bad_zk_url",
       this.peerZKUrl, ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY,
-      this.zkUrl);
+      this.zkUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(zkUrl);
 
@@ -1031,9 +1030,11 @@ public class HAGroupStoreClientIT extends BaseTest {
 
     // Insert HA group records
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, null);
+      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Verify both groups exist
     List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(zkUrl);
@@ -1086,7 +1087,8 @@ public class HAGroupStoreClientIT extends BaseTest {
 
     // 1. Setup: Create initial system table record with default values
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, this.zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // 2. Create ZK record with DIFFERENT values for testable fields (skip zkUrl changes)
     String updatedClusterUrl = this.masterUrl + ":updated";
@@ -1098,14 +1100,14 @@ public class HAGroupStoreClientIT extends BaseTest {
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, // Keep original peer ZK URL
       updatedClusterUrl, // Different cluster URL
       updatedPeerClusterUrl, // Different peer cluster URL
-      localUri.toString(), standbyUri.toString(), 5L); // Different version
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 5L); // Different version
     createOrUpdateHAGroupStoreRecordOnZookeeper(haAdmin, haGroupName, zkRecord);
 
     // Also create a peer ZK record with STANDBY_TO_ACTIVE role to test peer role sync
     HAGroupStoreRecord peerZkRecord =
       new HAGroupStoreRecord("v2.0", haGroupName, HAGroupStoreRecord.HAGroupState.STANDBY_TO_ACTIVE,
         0L, HighAvailabilityPolicy.FAILOVER.toString(), updatedClusterUrl, this.peerMasterUrl,
-        updatedClusterUrl, localUri.toString(), standbyUri.toString(), 5L);
+        updatedClusterUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 5L);
     createOrUpdateHAGroupStoreRecordOnZookeeper(peerHaAdmin, haGroupName, peerZkRecord);
 
     // 3. Create HAGroupStoreClient with short sync interval for testing

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerIT.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -41,31 +40,22 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.exception.InvalidClusterRoleTransitionException;
-import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.replication.reader.ReplicationLogReplay;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
-import org.apache.phoenix.util.ReadOnlyProps;
 import org.apache.zookeeper.data.Stat;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
-
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 
 /**
  * Integration tests for {@link HAGroupStoreManager}.
  */
 @Category(NeedsOwnMiniClusterTest.class)
-public class HAGroupStoreManagerIT extends BaseTest {
-  @ClassRule
-  public static TemporaryFolder testFolder = new TemporaryFolder();
-
+public class HAGroupStoreManagerIT extends HABaseIT {
   @Rule
   public TestName testName = new TestName();
 
@@ -73,15 +63,13 @@ public class HAGroupStoreManagerIT extends BaseTest {
   private static final Long ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS = 2000L;
   private String zkUrl;
   private String peerZKUrl;
-  private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS =
-    new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
-    Map<String, String> props = Maps.newHashMapWithExpectedSize(2);
-    props.put(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, "true");
-    props.put(ZK_SESSION_TIMEOUT, String.valueOf(30 * 1000));
-    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+    conf1.setBoolean(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, true);
+    conf1.setLong(ZK_SESSION_TIMEOUT, 30 * 1000);
+    conf2.setBoolean(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, true);
+    conf2.setLong(ZK_SESSION_TIMEOUT, 30 * 1000);
     CLUSTERS.start();
   }
 
@@ -92,8 +80,8 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
   @Before
   public void before() throws Exception {
-    haAdmin = new PhoenixHAAdmin(config, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
-    zkUrl = getLocalZkUrl(config);
+    haAdmin = new PhoenixHAAdmin(conf1, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
+    zkUrl = CLUSTERS.getZkUrl1();
     this.peerZKUrl = CLUSTERS.getZkUrl2();
 
     // Clean up existing HAGroupStoreRecords
@@ -103,21 +91,18 @@ public class HAGroupStoreManagerIT extends BaseTest {
       // Ignore cleanup errors
     }
 
-    standbyUri = testFolder.getRoot().toURI();
-    // Set the required configuration for ReplicationLogReplay
-    CLUSTERS.getHBaseCluster2().getConfiguration()
-      .set(ReplicationLogReplay.REPLICATION_LOG_REPLAY_HDFS_URL_KEY, standbyUri.toString());
-    HAGroupStoreRecord haGroupStoreRecord = new HAGroupStoreRecord(
-      HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, testName.getMethodName(),
-      HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0, HighAvailabilityPolicy.FAILOVER.toString(),
-      this.peerZKUrl, this.zkUrl, this.peerZKUrl, localUri.toString(), standbyUri.toString(), 0L);
+    HAGroupStoreRecord haGroupStoreRecord =
+      new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, testName.getMethodName(),
+        HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0,
+        HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     haAdmin.createHAGroupStoreRecordInZooKeeper(haGroupStoreRecord);
   }
 
   @Test
   public void testMutationBlockingWithSingleHAGroup() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Initially no mutation should be blocked
     assertFalse(haGroupStoreManager.isMutationBlocked(haGroupName));
@@ -125,8 +110,8 @@ public class HAGroupStoreManagerIT extends BaseTest {
     // Update to ACTIVE_TO_STANDBY role (should block mutations)
     HAGroupStoreRecord transitionRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
-      HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-      localUri.toString(), standbyUri.toString(), 0L);
+      HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+      CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, transitionRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
@@ -138,19 +123,21 @@ public class HAGroupStoreManagerIT extends BaseTest {
   public void testMutationBlockingWithMultipleHAGroups() throws Exception {
     String haGroupName1 = testName.getMethodName() + "_1";
     String haGroupName2 = testName.getMethodName() + "_2";
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Create two HA groups with ACTIVE and ACTIVE_NOT_IN_SYNC roles
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.ACTIVE, null);
-    HAGroupStoreRecord activeRecord1 =
-      new HAGroupStoreRecord("1.0", haGroupName1, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC,
-        0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-        localUri.toString(), standbyUri.toString(), 0L);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.ACTIVE, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+    HAGroupStoreRecord activeRecord1 = new HAGroupStoreRecord("1.0", haGroupName1,
+      HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0L,
+      HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+      CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     haAdmin.createHAGroupStoreRecordInZooKeeper(activeRecord1);
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.ACTIVE, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.ACTIVE, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // No mutations should be blocked
     assertFalse(haGroupStoreManager.isMutationBlocked(haGroupName1));
@@ -159,8 +146,8 @@ public class HAGroupStoreManagerIT extends BaseTest {
     // Update only second group to ACTIVE_NOT_IN_SYNC_TO_STANDBY
     HAGroupStoreRecord transitionRecord2 = new HAGroupStoreRecord("1.0", haGroupName2,
       HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC_TO_STANDBY, 0L,
-      HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-      localUri.toString(), standbyUri.toString(), 0L);
+      HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+      CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName2, transitionRecord2, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -173,7 +160,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testGetHAGroupStoreRecord() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Get record from HAGroupStoreManager
     Optional<HAGroupStoreRecord> recordOpt = haGroupStoreManager.getHAGroupStoreRecord(haGroupName);
@@ -193,7 +180,8 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
     // Create record again in System Table
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, this.peerZKUrl,
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     // Now it should be present
     Optional<HAGroupStoreRecord> retrievedOpt =
       haGroupStoreManager.getHAGroupStoreRecord(haGroupName);
@@ -217,7 +205,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testGetPeerHAGroupStoreRecord() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Initially, peer record should not be present
     Optional<HAGroupStoreRecord> peerRecordOpt =
@@ -230,9 +218,10 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
     try {
       // Create a HAGroupStoreRecord in the peer cluster
-      HAGroupStoreRecord peerRecord = new HAGroupStoreRecord("1.0", haGroupName,
-        HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        this.peerZKUrl, this.zkUrl, this.peerZKUrl, localUri.toString(), standbyUri.toString(), 0L);
+      HAGroupStoreRecord peerRecord =
+        new HAGroupStoreRecord("1.0", haGroupName, HAGroupStoreRecord.HAGroupState.STANDBY, 0L,
+          HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       peerHaAdmin.createHAGroupStoreRecordInZooKeeper(peerRecord);
       Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -260,7 +249,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
       HAGroupStoreRecord newPeerRecord =
         new HAGroupStoreRecord("1.0", haGroupName, HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY,
           0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl,
-          this.peerZKUrl, localUri.toString(), standbyUri.toString(), 0L);
+          this.peerZKUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       peerHaAdmin.createHAGroupStoreRecordInZooKeeper(newPeerRecord);
       Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -285,7 +274,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testGetPeerHAGroupStoreRecordWhenHAGroupNotInSystemTable() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Try to get peer record for an HA group that doesn't exist in system table
     Optional<HAGroupStoreRecord> peerRecordOpt =
@@ -297,13 +286,13 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testInvalidateHAGroupStoreClient() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Create a HAGroupStoreRecord first
     HAGroupStoreRecord record =
       new HAGroupStoreRecord("1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0L,
-        HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-        localUri.toString(), standbyUri.toString(), 0L);
+        HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, record, -1);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -334,7 +323,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
     // Create configuration with mutation block disabled
     Configuration conf = new Configuration();
     conf.set(CLUSTER_ROLE_BASED_MUTATION_BLOCK_ENABLED, "false");
-    conf.set(HConstants.ZOOKEEPER_QUORUM, getLocalZkUrl(config));
+    conf.set(HConstants.ZOOKEEPER_QUORUM, getLocalZkUrl(conf1));
 
     // Set the HAGroupStoreManager instance to null via reflection to force recreation
     Field field = HAGroupStoreManager.class.getDeclaredField("instances");
@@ -345,8 +334,8 @@ public class HAGroupStoreManagerIT extends BaseTest {
     // Create HAGroupStoreRecord with ACTIVE_IN_SYNC_TO_STANDBY role
     HAGroupStoreRecord transitionRecord = new HAGroupStoreRecord("1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
-      HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-      localUri.toString(), standbyUri.toString(), 0L);
+      HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+      CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, transitionRecord, -1);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -362,13 +351,13 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testSetHAGroupStatusToStoreAndForward() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Create an initial HAGroupStoreRecord with ACTIVE status
     HAGroupStoreRecord initialRecord =
       new HAGroupStoreRecord("1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0L,
-        HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-        localUri.toString(), standbyUri.toString(), 0L);
+        HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, initialRecord, -1);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -404,7 +393,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testSetHAGroupStatusToSync() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Initial record should be present in ACTIVE_IN_SYNC status
     HAGroupStoreRecord initialRecord =
@@ -441,7 +430,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
   @Test
   public void testGetHAGroupNamesFiltersCorrectlyByZkUrl() throws Exception {
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     List<String> initialHAGroupNames = haGroupStoreManager.getHAGroupNames();
 
@@ -449,20 +438,20 @@ public class HAGroupStoreManagerIT extends BaseTest {
     String haGroupWithCurrentZkUrl = testName.getMethodName() + "_current_zk";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupWithCurrentZkUrl, zkUrl,
       this.peerZKUrl, ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY,
-      null);
+      null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HA group with current zkUrl as ZK_URL_2 (swapped)
     String haGroupWithCurrentZkUrlAsPeer = testName.getMethodName() + "_current_as_peer";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupWithCurrentZkUrlAsPeer,
       this.peerZKUrl, zkUrl, ClusterRoleRecord.ClusterRole.STANDBY,
-      ClusterRoleRecord.ClusterRole.ACTIVE, zkUrl);
+      ClusterRoleRecord.ClusterRole.ACTIVE, zkUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HA group with different zkUrl (should not appear in results)
     String differentZkUrl = "localhost:2182:/different";
     String haGroupWithDifferentZkUrl = testName.getMethodName() + "_different_zk";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupWithDifferentZkUrl, differentZkUrl,
       "localhost:2183:/other", ClusterRoleRecord.ClusterRole.ACTIVE,
-      ClusterRoleRecord.ClusterRole.STANDBY, zkUrl);
+      ClusterRoleRecord.ClusterRole.STANDBY, zkUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Get HA group names - should only return groups where current zkUrl matches ZK_URL_1 or
     // ZK_URL_2
@@ -492,7 +481,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
   @Test
   public void testGetHAGroupNamesWhenNoMatchingZkUrl() throws Exception {
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Clean up existing HA group created in before()
     String testHAGroupName = testName.getMethodName();
@@ -504,7 +493,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
     String haGroupWithDifferentZkUrls = testName.getMethodName() + "_different";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupWithDifferentZkUrls,
       differentZkUrl1, differentZkUrl2, ClusterRoleRecord.ClusterRole.ACTIVE,
-      ClusterRoleRecord.ClusterRole.STANDBY, zkUrl);
+      ClusterRoleRecord.ClusterRole.STANDBY, zkUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Get HA group names - should not contain the group with different zkUrls
     List<String> filteredHAGroupNames = haGroupStoreManager.getHAGroupNames();
@@ -521,12 +510,13 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testSetReaderToDegraded() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Update the auto-created record to STANDBY state for testing
-    HAGroupStoreRecord standbyRecord = new HAGroupStoreRecord("1.0", haGroupName,
-      HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-      this.peerZKUrl, this.zkUrl, this.peerZKUrl, localUri.toString(), standbyUri.toString(), 0L);
+    HAGroupStoreRecord standbyRecord =
+      new HAGroupStoreRecord("1.0", haGroupName, HAGroupStoreRecord.HAGroupState.STANDBY, 0L,
+        HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     // Get the record to initialize ZNode from HAGroup so that we can artificially update it via
     // HAAdmin
@@ -553,7 +543,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testSetReaderToHealthy() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Get the record to initialize ZNode from HAGroup so that we can artificially update it via
     // HAAdmin
@@ -562,10 +552,10 @@ public class HAGroupStoreManagerIT extends BaseTest {
     assertTrue(currentRecord.isPresent());
 
     // Update the auto-created record to DEGRADED_STANDBY state for testing
-    HAGroupStoreRecord degradedReaderRecord =
-      new HAGroupStoreRecord("1.0", haGroupName, HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY,
-        0L, HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-        localUri.toString(), standbyUri.toString(), 0L);
+    HAGroupStoreRecord degradedReaderRecord = new HAGroupStoreRecord("1.0", haGroupName,
+      HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY, 0L,
+      HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+      CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, degradedReaderRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -585,7 +575,7 @@ public class HAGroupStoreManagerIT extends BaseTest {
   @Test
   public void testReaderStateTransitionInvalidStates() throws Exception {
     String haGroupName = testName.getMethodName();
-    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(config);
+    HAGroupStoreManager haGroupStoreManager = HAGroupStoreManager.getInstance(conf1);
 
     // Get the record to initialize ZNode from HAGroup so that we can artificially update it via
     // HAAdmin
@@ -596,8 +586,8 @@ public class HAGroupStoreManagerIT extends BaseTest {
     // Update the auto-created record to ACTIVE_IN_SYNC state (invalid for both operations)
     HAGroupStoreRecord activeRecord =
       new HAGroupStoreRecord("1.0", haGroupName, HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0L,
-        HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, this.zkUrl, this.peerZKUrl,
-        localUri.toString(), standbyUri.toString(), 0L);
+        HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, activeRecord, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
@@ -639,10 +629,12 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create separate HAAdmin instances for both clusters using try-with-resources
     // Create HAGroupStoreManager instances for both clusters using constructor
@@ -715,10 +707,12 @@ public class HAGroupStoreManagerIT extends BaseTest {
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HAGroupStoreManager instances for both clusters using constructor
     // This will automatically setup failover management and create ZNodes from system table
@@ -817,17 +811,14 @@ public class HAGroupStoreManagerIT extends BaseTest {
     String zkUrl1 = getLocalZkUrl(CLUSTERS.getHBaseCluster1().getConfiguration());
     String zkUrl2 = getLocalZkUrl(CLUSTERS.getHBaseCluster2().getConfiguration());
 
-    CLUSTERS.getHBaseCluster1().getMiniHBaseCluster().getConf().setLong(ZK_SESSION_TIMEOUT,
-      10 * 1000);
-    CLUSTERS.getHBaseCluster2().getMiniHBaseCluster().getConf().setLong(ZK_SESSION_TIMEOUT,
-      10 * 1000);
-
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HAGroupStoreManager instances for both clusters using constructor
     // This will automatically setup failover management and create ZNodes from system table
@@ -883,7 +874,10 @@ public class HAGroupStoreManagerIT extends BaseTest {
     // === STEP 3: Return to sync mode ===
     // Move cluster1 back from ACTIVE_NOT_IN_SYNC to ACTIVE_IN_SYNC
     // Wait for the required time before transitioning back to sync
-    Thread.sleep(20 * 1000);
+    long waitTimeMs = cluster1HAManager.setHAGroupStatusToSync(haGroupName);
+    if (waitTimeMs > 0) {
+      Thread.sleep(waitTimeMs);
+    }
     assertEquals(0L, cluster1HAManager.setHAGroupStatusToSync(haGroupName));
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerIT.java
@@ -127,6 +127,7 @@ public class HAGroupStoreManagerIT extends HABaseIT {
 
     // Create two HA groups with ACTIVE and ACTIVE_NOT_IN_SYNC roles
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, zkUrl, this.peerZKUrl,
+      CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
       ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.ACTIVE, null,
       CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreRecord activeRecord1 = new HAGroupStoreRecord("1.0", haGroupName1,
@@ -136,6 +137,7 @@ public class HAGroupStoreManagerIT extends HABaseIT {
     haAdmin.createHAGroupStoreRecordInZooKeeper(activeRecord1);
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, zkUrl, this.peerZKUrl,
+      CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
       ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.ACTIVE, null,
       CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
@@ -180,6 +182,7 @@ public class HAGroupStoreManagerIT extends HABaseIT {
 
     // Create record again in System Table
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, this.peerZKUrl,
+      CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
       ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
       CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     // Now it should be present
@@ -437,21 +440,24 @@ public class HAGroupStoreManagerIT extends HABaseIT {
     // Create HA groups with current zkUrl as ZK_URL_1
     String haGroupWithCurrentZkUrl = testName.getMethodName() + "_current_zk";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupWithCurrentZkUrl, zkUrl,
-      this.peerZKUrl, ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY,
-      null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.peerZKUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HA group with current zkUrl as ZK_URL_2 (swapped)
     String haGroupWithCurrentZkUrlAsPeer = testName.getMethodName() + "_current_as_peer";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupWithCurrentZkUrlAsPeer,
-      this.peerZKUrl, zkUrl, ClusterRoleRecord.ClusterRole.STANDBY,
-      ClusterRoleRecord.ClusterRole.ACTIVE, zkUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      this.peerZKUrl, zkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, zkUrl,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HA group with different zkUrl (should not appear in results)
     String differentZkUrl = "localhost:2182:/different";
     String haGroupWithDifferentZkUrl = testName.getMethodName() + "_different_zk";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupWithDifferentZkUrl, differentZkUrl,
-      "localhost:2183:/other", ClusterRoleRecord.ClusterRole.ACTIVE,
-      ClusterRoleRecord.ClusterRole.STANDBY, zkUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      "localhost:2183:/other", CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Get HA group names - should only return groups where current zkUrl matches ZK_URL_1 or
     // ZK_URL_2
@@ -492,8 +498,9 @@ public class HAGroupStoreManagerIT extends HABaseIT {
     String differentZkUrl2 = "localhost:2183:/different2";
     String haGroupWithDifferentZkUrls = testName.getMethodName() + "_different";
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupWithDifferentZkUrls,
-      differentZkUrl1, differentZkUrl2, ClusterRoleRecord.ClusterRole.ACTIVE,
-      ClusterRoleRecord.ClusterRole.STANDBY, zkUrl, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+      differentZkUrl1, differentZkUrl2, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Get HA group names - should not contain the group with different zkUrls
     List<String> filteredHAGroupNames = haGroupStoreManager.getHAGroupNames();

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
@@ -62,6 +62,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hbase.*;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.ipc.PhoenixRpcSchedulerFactory;
@@ -105,8 +106,9 @@ public class HighAvailabilityTestingUtility {
     private Admin admin2;
     @VisibleForTesting
     static final String PRINCIPAL = "USER_FOO";
-    private String hdfsUrl = "hdfs://hdfsUrl";
-    private String peerHdfsUrl = "hdfs://peerHdfsUrl";
+    private String hdfsUrl1;
+    private String hdfsUrl2;
+    private static String HA_DIR = "/phoenixHA";
 
     public HBaseTestingUtilityPair() {
       Configuration conf1 = hbaseCluster1.getConfiguration();
@@ -137,6 +139,9 @@ public class HighAvailabilityTestingUtility {
       zkUrl2 = String.format("%s\\:%d::/hbase", confAddress2,
         hbaseCluster2.getZkCluster().getClientPort());
 
+      hdfsUrl1 = hbaseCluster1.getConfiguration().get(FileSystem.FS_DEFAULT_NAME_KEY) + HA_DIR;
+      hdfsUrl2 = hbaseCluster2.getConfiguration().get(FileSystem.FS_DEFAULT_NAME_KEY) + HA_DIR;
+
       masterAddress1 =
         hbaseCluster1.getConfiguration().get(HConstants.MASTER_ADDRS_KEY).replaceAll(":", "\\\\:");
       masterAddress2 =
@@ -161,8 +166,9 @@ public class HighAvailabilityTestingUtility {
 
       LOG.info(
         "MiniHBase DR cluster pair is ready for testing.  Cluster Urls [{},{}] "
-          + "and Master Urls [{}, {}]",
-        getZkUrl1(), getZkUrl2(), getMasterAddress1(), getMasterAddress2());
+          + "and Master Urls [{}, {}] and HDFS Urls [{}, {}]",
+        getZkUrl1(), getZkUrl2(), getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(),
+        getHdfsUrl2());
       logClustersStates();
     }
 
@@ -195,11 +201,11 @@ public class HighAvailabilityTestingUtility {
       HAGroupStoreRecord activeRecord = new HAGroupStoreRecord(
         HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName, ACTIVE.getDefaultHAGroupState(),
         0L, policy != null ? policy.name() : HighAvailabilityPolicy.FAILOVER.name(), getZkUrl2(),
-        getMasterAddress1(), getMasterAddress2(), hdfsUrl, peerHdfsUrl, 1L);
+        getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(), getHdfsUrl2(), 1L);
       HAGroupStoreRecord standbyRecord = new HAGroupStoreRecord(
         HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName, STANDBY.getDefaultHAGroupState(),
         0L, policy != null ? policy.name() : HighAvailabilityPolicy.FAILOVER.name(), getZkUrl1(),
-        getMasterAddress2(), getMasterAddress1(), hdfsUrl, peerHdfsUrl, 1L);
+        getMasterAddress2(), getMasterAddress1(), getHdfsUrl2(), getHdfsUrl1(), 1L);
       upsertGroupRecordInBothSystemTable(haGroupName, ACTIVE, STANDBY, 1L, 1L, null, policy);
       addOrUpdateRoleRecordToClusters(haGroupName, activeRecord, standbyRecord);
     }
@@ -215,7 +221,7 @@ public class HighAvailabilityTestingUtility {
       HAGroupStoreRecord activeRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           ACTIVE.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(), getZkUrl2(),
-          getMasterAddress1(), getMasterAddress2(), hdfsUrl, peerHdfsUrl, 1L);
+          getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(), getHdfsUrl2(), 1L);
       upsertGroupRecordInASystemTable(haGroupName, ACTIVE, STANDBY, 1L, 1L, null, policy, 1);
       addOrUpdateRoleRecordToClusters(haGroupName, activeRecord, null);
     }
@@ -287,10 +293,10 @@ public class HighAvailabilityTestingUtility {
       HighAvailabilityPolicy policy) throws Exception {
       HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, getZkUrl1(), getZkUrl2(),
         getMasterAddress1(), getMasterAddress2(), role1, role2, version1, overrideZKUrl, policy,
-        getHATestProperties(), null, null);
+        getHATestProperties(), getHdfsUrl1(), getHdfsUrl2());
       HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, getZkUrl2(), getZkUrl1(),
         getMasterAddress2(), getMasterAddress1(), role2, role1, version2, overrideZKUrl, policy,
-        getHATestProperties(), null, null);
+        getHATestProperties(), getHdfsUrl2(), getHdfsUrl1());
     }
 
     /**
@@ -302,11 +308,11 @@ public class HighAvailabilityTestingUtility {
       if (clusterIndex == 1) {
         HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, getZkUrl1(), getZkUrl2(),
           getMasterAddress1(), getMasterAddress2(), role1, role2, version1, overrideZKUrl, policy,
-          getHATestProperties(), null, null);
+          getHATestProperties(), getHdfsUrl1(), getHdfsUrl2());
       } else {
         HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, getZkUrl2(), getZkUrl1(),
           getMasterAddress2(), getMasterAddress1(), role2, role1, version2, overrideZKUrl, policy,
-          getHATestProperties(), null, null);
+          getHATestProperties(), getHdfsUrl2(), getHdfsUrl1());
       }
     }
 
@@ -349,7 +355,7 @@ public class HighAvailabilityTestingUtility {
       if (clusterIndex == 1) {
         newRecord = new HAGroupStoreRecord(currentRecord1.getLeft().getProtocolVersion(),
           haGroupName, role1.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(),
-          getZkUrl2(), getMasterAddress1(), getMasterAddress2(), hdfsUrl, peerHdfsUrl, 1L);
+          getZkUrl2(), getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(), getHdfsUrl2(), 1L);
         refreshSystemTableInOneCluster(haGroupName, role1, role2, newRecord.getAdminCRRVersion(),
           currentRecord2.getLeft().getAdminCRRVersion(), null, haGroup.getRoleRecord().getPolicy(),
           clusterIndex);
@@ -357,7 +363,7 @@ public class HighAvailabilityTestingUtility {
       } else {
         newRecord = new HAGroupStoreRecord(currentRecord2.getLeft().getProtocolVersion(),
           haGroupName, role2.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(),
-          getZkUrl2(), getMasterAddress1(), getMasterAddress2(), hdfsUrl, peerHdfsUrl, 1L);
+          getZkUrl1(), getMasterAddress2(), getMasterAddress1(), getHdfsUrl2(), getHdfsUrl1(), 1L);
         refreshSystemTableInOneCluster(haGroupName, role1, role2,
           currentRecord1.getLeft().getAdminCRRVersion(), newRecord.getAdminCRRVersion(), null,
           haGroup.getRoleRecord().getPolicy(), clusterIndex);
@@ -487,7 +493,7 @@ public class HighAvailabilityTestingUtility {
       HAGroupStoreRecord record2 =
         new HAGroupStoreRecord(currentRecord2.getLeft().getProtocolVersion(), haGroupName,
           role2.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(), getZkUrl1(),
-          getMasterAddress2(), getMasterAddress1(), hdfsUrl, peerHdfsUrl, 1L);
+          getMasterAddress2(), getMasterAddress1(), getHdfsUrl2(), getHdfsUrl1(), 1L);
 
       refreshSystemTableInOneCluster(haGroupName, role1, role2, 1, 1, null,
         haGroup.getRoleRecord().getPolicy(), 2);
@@ -500,7 +506,7 @@ public class HighAvailabilityTestingUtility {
       HAGroupStoreRecord record1 =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           UNKNOWN.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(), getZkUrl2(),
-          getMasterAddress1(), getMasterAddress2(), hdfsUrl, peerHdfsUrl, 1L);
+          getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(), getHdfsUrl2(), 1L);
       ;
 
       // wait for the cluster roles are populated into client side from RegionServer endpoints.
@@ -519,7 +525,7 @@ public class HighAvailabilityTestingUtility {
       HAGroupStoreRecord record1 =
         new HAGroupStoreRecord(currentRecord1.getLeft().getProtocolVersion(), haGroupName,
           role1.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(), getZkUrl2(),
-          getMasterAddress1(), getMasterAddress2(), hdfsUrl, peerHdfsUrl, 1L);
+          getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(), getHdfsUrl2(), 1L);
 
       refreshSystemTableInOneCluster(haGroupName, role1, role2, 1, 1, null,
         haGroup.getRoleRecord().getPolicy(), 1);
@@ -531,8 +537,8 @@ public class HighAvailabilityTestingUtility {
       // passed in refreshSystemTableInOneCluster and OFFLINE role.
       HAGroupStoreRecord record2 =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
-          UNKNOWN.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(), getZkUrl2(),
-          getMasterAddress1(), getMasterAddress2(), hdfsUrl, peerHdfsUrl, 1L);
+          UNKNOWN.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(), getZkUrl1(),
+          getMasterAddress2(), getMasterAddress1(), getHdfsUrl2(), getHdfsUrl1(), 1L);
 
       // wait for the cluster roles are populated into client side from RegionServer endpoints.
       ClusterRoleRecord newRoleRecord =
@@ -549,11 +555,11 @@ public class HighAvailabilityTestingUtility {
       HAGroupStoreRecord record1 =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           role1.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(), getZkUrl2(),
-          getMasterAddress1(), getMasterAddress2(), hdfsUrl, peerHdfsUrl, 2L);
+          getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(), getHdfsUrl2(), 2L);
       HAGroupStoreRecord record2 =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           role2.getDefaultHAGroupState(), 0L, HighAvailabilityPolicy.FAILOVER.name(), getZkUrl1(),
-          getMasterAddress2(), getMasterAddress1(), hdfsUrl, peerHdfsUrl, 2L);
+          getMasterAddress2(), getMasterAddress1(), getHdfsUrl2(), getHdfsUrl1(), 2L);
 
       refreshSystemTableInBothClusters(haGroupName, role1, role2, 2, 2, null,
         haGroup.getRoleRecord().getPolicy());
@@ -833,6 +839,14 @@ public class HighAvailabilityTestingUtility {
 
     public PhoenixHAAdmin getHaAdmin2() {
       return haAdmin2;
+    }
+
+    public String getHdfsUrl1() {
+      return hdfsUrl1;
+    }
+
+    public String getHdfsUrl2() {
+      return hdfsUrl2;
     }
 
     private String getUrlWithoutPrincipal(HighAvailabilityGroup haGroup, String url) {

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/LoggingHAConnectionLimiterIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/LoggingHAConnectionLimiterIT.java
@@ -22,7 +22,6 @@ import static org.apache.phoenix.jdbc.HighAvailabilityPolicy.PARALLEL;
 import static org.apache.phoenix.query.QueryServices.HA_GROUP_STALE_FOR_MUTATION_CHECK_ENABLED;
 import static org.apache.phoenix.query.QueryServices.SYNCHRONOUS_REPLICATION_ENABLED;
 
-import java.net.URI;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -32,12 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.log.ConnectionLimiter;
 import org.apache.phoenix.query.ConnectionQueryServices;
 import org.apache.phoenix.query.QueryServices;
-import org.apache.phoenix.replication.ReplicationLogGroup;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -97,14 +94,8 @@ public class LoggingHAConnectionLimiterIT extends LoggingConnectionLimiterIT {
 
     Configuration conf1 = CLUSTERS.getHBaseCluster1().getConfiguration();
     Configuration conf2 = CLUSTERS.getHBaseCluster2().getConfiguration();
-    URI standbyUri = new Path(standbyFolder.getRoot().toString()).toUri();
-    URI fallbackUri = new Path(localFolder.getRoot().toString()).toUri();
     conf1.setBoolean(SYNCHRONOUS_REPLICATION_ENABLED, true);
     conf2.setBoolean(SYNCHRONOUS_REPLICATION_ENABLED, true);
-    conf1.set(ReplicationLogGroup.REPLICATION_STANDBY_HDFS_URL_KEY, standbyUri.toString());
-    conf1.set(ReplicationLogGroup.REPLICATION_FALLBACK_HDFS_URL_KEY, fallbackUri.toString());
-    conf2.set(ReplicationLogGroup.REPLICATION_STANDBY_HDFS_URL_KEY, standbyUri.toString());
-    conf2.set(ReplicationLogGroup.REPLICATION_FALLBACK_HDFS_URL_KEY, fallbackUri.toString());
     CLUSTERS.getHBaseCluster1().getConfiguration()
       .setBoolean(HA_GROUP_STALE_FOR_MUTATION_CHECK_ENABLED, false);
     CLUSTERS.getHBaseCluster2().getConfiguration()

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/PhoenixHAAdminIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/PhoenixHAAdminIT.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -35,8 +34,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.exception.StaleHAGroupStoreRecordVersionException;
-import org.apache.phoenix.query.BaseTest;
-import org.apache.phoenix.util.ReadOnlyProps;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.junit.After;
@@ -47,28 +44,20 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
-
 /**
  * Integration tests for {@link PhoenixHAAdmin} HAGroupStoreRecord operations
  */
 @Category(NeedsOwnMiniClusterTest.class)
-public class PhoenixHAAdminIT extends BaseTest {
+public class PhoenixHAAdminIT extends HABaseIT {
 
-  private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS =
-    new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
   private PhoenixHAAdmin haAdmin;
   private PhoenixHAAdmin peerHaAdmin;
-  private static final String TEST_HDFS_URL = localUri.toString();
-  private static final String TEST_PEER_HDFS_URL = standbyUri.toString();
 
   @Rule
   public TestName testName = new TestName();
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
-    Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
-    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
     CLUSTERS.start();
   }
 
@@ -129,7 +118,7 @@ public class PhoenixHAAdminIT extends BaseTest {
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
         CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-        TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     // This should throw an exception due to NodeExistsException handling
     try {
@@ -170,8 +159,8 @@ public class PhoenixHAAdminIT extends BaseTest {
     HAGroupStoreRecord updatedRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZKUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(), TEST_HDFS_URL,
-        TEST_PEER_HDFS_URL, 0L);
+        peerZKUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, currentVersion);
 
@@ -205,8 +194,8 @@ public class PhoenixHAAdminIT extends BaseTest {
     HAGroupStoreRecord updatedRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZKUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(), TEST_HDFS_URL,
-        TEST_PEER_HDFS_URL, 0L);
+        peerZKUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, currentVersion);
 
@@ -215,7 +204,7 @@ public class PhoenixHAAdminIT extends BaseTest {
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
         HighAvailabilityPolicy.FAILOVER.toString(), peerZKUrl, CLUSTERS.getMasterAddress1(),
-        CLUSTERS.getMasterAddress2(), TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     try {
       haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, anotherUpdate, currentVersion);
@@ -289,8 +278,8 @@ public class PhoenixHAAdminIT extends BaseTest {
     HAGroupStoreRecord updatedRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZKUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(), TEST_HDFS_URL,
-        TEST_PEER_HDFS_URL, 0L);
+        peerZKUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, stat.getVersion());
 
@@ -345,7 +334,7 @@ public class PhoenixHAAdminIT extends BaseTest {
             HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
             HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
             CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-            TEST_HDFS_URL, TEST_PEER_HDFS_URL, 0L);
+            CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
           // All threads use the same currentVersion, causing conflicts
           haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, currentVersion);
@@ -426,8 +415,8 @@ public class PhoenixHAAdminIT extends BaseTest {
                 ? HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC
                 : HAGroupStoreRecord.HAGroupState.STANDBY,
               0L, HighAvailabilityPolicy.FAILOVER.toString(), CLUSTERS.getZkUrl2(),
-              CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(), TEST_HDFS_URL,
-              TEST_PEER_HDFS_URL, 0L);
+              CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(),
+              CLUSTERS.getHdfsUrl2(), 0L);
 
           // Update with the current version
           haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName, updatedRecord, currentVersion);
@@ -465,7 +454,7 @@ public class PhoenixHAAdminIT extends BaseTest {
     return new HAGroupStoreRecord("v1.0", haGroupName,
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), CLUSTERS.getZkUrl2(),
-      CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(), TEST_HDFS_URL, TEST_PEER_HDFS_URL,
-      0L);
+      CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(),
+      CLUSTERS.getHdfsUrl2(), 0L);
   }
 }

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/PhoenixHAAdminToolIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/PhoenixHAAdminToolIT.java
@@ -47,8 +47,6 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
-import org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.HBaseTestingUtilityPair;
-import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.replication.reader.ReplicationLogReplay;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
 import org.apache.phoenix.util.JDBCUtil;
@@ -71,9 +69,8 @@ import org.slf4j.LoggerFactory;
  * Integration tests for {@link PhoenixHAAdminTool}.
  */
 @Category(NeedsOwnMiniClusterTest.class)
-public class PhoenixHAAdminToolIT extends BaseTest {
+public class PhoenixHAAdminToolIT extends HABaseIT {
   private static final Logger LOG = LoggerFactory.getLogger(PhoenixHAAdminToolIT.class);
-  private static final HBaseTestingUtilityPair CLUSTERS = new HBaseTestingUtilityPair();
   private static final PrintStream STDOUT = System.out;
   private static final ByteArrayOutputStream STDOUT_CAPTURE = new ByteArrayOutputStream();
   private static final Long BUFFER_TIME_IN_MS = 100L;
@@ -159,11 +156,6 @@ public class PhoenixHAAdminToolIT extends BaseTest {
       // Don't fail the test due to cleanup errors
     }
 
-    standbyUri = testFolder.getRoot().toURI();
-    // Set the required configuration for ReplicationLogReplay
-    CLUSTERS.getHBaseCluster2().getConfiguration()
-      .set(ReplicationLogReplay.REPLICATION_LOG_REPLAY_HDFS_URL_KEY, standbyUri.toString());
-
     adminTool = new PhoenixHAAdminTool();
     adminTool.setConf(CLUSTERS.getHBaseCluster1().getConfiguration());
 
@@ -177,18 +169,19 @@ public class PhoenixHAAdminToolIT extends BaseTest {
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable("prod_cluster_alpha",
       CLUSTERS.getZkUrl1(), CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress1(),
       CLUSTERS.getMasterAddress2(), ClusterRoleRecord.ClusterRole.ACTIVE,
-      ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.STANDBY, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Group 2 - Standby cluster group
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable("disaster_recovery_beta",
       CLUSTERS.getZkUrl1(), CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress1(),
       CLUSTERS.getMasterAddress2(), ClusterRoleRecord.ClusterRole.STANDBY,
-      ClusterRoleRecord.ClusterRole.ACTIVE, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, null, CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Group 3 - Test-specific group (uses test method name for uniqueness across test runs)
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, CLUSTERS.getZkUrl1(),
       CLUSTERS.getZkUrl2(), CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Clear stdout capture
     STDOUT_CAPTURE.reset();
@@ -420,7 +413,7 @@ public class PhoenixHAAdminToolIT extends BaseTest {
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
           CLUSTERS.getZkUrl1(), CLUSTERS.getMasterAddress2(), CLUSTERS.getMasterAddress1(),
-          localUri.toString(), standbyUri.toString(), 1L);
+          CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 1L);
 
       peerHaAdmin.createHAGroupStoreRecordInZooKeeper(peerRecord);
 
@@ -498,10 +491,12 @@ public class PhoenixHAAdminToolIT extends BaseTest {
     // Set up system tables for both clusters
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(failoverHaGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(failoverHaGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HAGroupStoreManager instances for both clusters
     // This will automatically setup failover management and create ZNodes from system table
@@ -594,10 +589,12 @@ public class PhoenixHAAdminToolIT extends BaseTest {
     // Set up system tables for both clusters
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(abortFailoverHaGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(abortFailoverHaGroupName, zkUrl1, zkUrl2,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HAGroupStoreManager instances for both clusters
     HAGroupStoreManager cluster1HAManager =
@@ -694,10 +691,12 @@ public class PhoenixHAAdminToolIT extends BaseTest {
     // Set up system tables for both clusters
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(timeoutFailoverHaGroupName, zkUrl1,
       zkUrl2, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(timeoutFailoverHaGroupName, zkUrl1,
       zkUrl2, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, zkUrl2,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Create HAGroupStoreManager instances for both clusters
     HAGroupStoreManager cluster1HAManager =

--- a/phoenix-core/src/it/java/org/apache/phoenix/replication/ReplicationLogGroupIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/replication/ReplicationLogGroupIT.java
@@ -49,12 +49,10 @@ import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.hbase.index.IndexRegionObserver;
 import org.apache.phoenix.jdbc.FailoverPhoenixConnection;
 import org.apache.phoenix.jdbc.HABaseIT;
-import org.apache.phoenix.jdbc.HAGroupStoreRecord;
 import org.apache.phoenix.jdbc.HighAvailabilityGroup;
 import org.apache.phoenix.jdbc.HighAvailabilityPolicy;
 import org.apache.phoenix.jdbc.HighAvailabilityTestingUtility;
 import org.apache.phoenix.jdbc.PhoenixDriver;
-import org.apache.phoenix.jdbc.PhoenixHAAdmin;
 import org.apache.phoenix.query.PhoenixTestBuilder;
 import org.apache.phoenix.query.QueryConstants;
 import org.apache.phoenix.replication.tool.LogFileAnalyzer;
@@ -77,15 +75,11 @@ import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 public class ReplicationLogGroupIT extends HABaseIT {
   private static final Logger LOG = LoggerFactory.getLogger(ReplicationLogGroupIT.class);
 
-  private static String zkUrl;
-  private static String peerZkUrl;
-
   @Rule
   public TestName name = new TestName();
 
   private Properties clientProps = new Properties();
   private String haGroupName;
-  private PhoenixHAAdmin haAdmin1;
   private HighAvailabilityGroup haGroup;
   private ReplicationLogGroup logGroup;
 
@@ -93,8 +87,6 @@ public class ReplicationLogGroupIT extends HABaseIT {
   public static void doSetup() throws Exception {
     conf1.setInt(PHOENIX_REPLICATION_ROUND_DURATION_SECONDS_KEY, 20);
     CLUSTERS.start();
-    zkUrl = CLUSTERS.getZkUrl1();
-    peerZkUrl = CLUSTERS.getZkUrl2();
     DriverManager.registerDriver(PhoenixDriver.INSTANCE);
   }
 
@@ -108,20 +100,11 @@ public class ReplicationLogGroupIT extends HABaseIT {
   public void beforeTest() throws Exception {
     LOG.info("Starting test {}", name.getMethodName());
     haGroupName = name.getMethodName();
-    haAdmin1 = CLUSTERS.getHaAdmin1();
     clientProps = HighAvailabilityTestingUtility.getHATestProperties();
     clientProps.setProperty(PHOENIX_HA_GROUP_ATTR, haGroupName);
     CLUSTERS.initClusterRole(haGroupName, HighAvailabilityPolicy.FAILOVER);
     haGroup = getHighAvailibilityGroup(CLUSTERS.getJdbcHAUrl(), clientProps);
     LOG.info("Initialized haGroup {} with URL {}", haGroup, CLUSTERS.getJdbcHAUrl());
-
-    // Update the state to ACTIVE_IN_SYNC
-    HAGroupStoreRecord haGroupStoreRecord =
-      new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
-        HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, 0L,
-        HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
-        CLUSTERS.getMasterAddress2(), fallbackUri.toString(), standbyUri.toString(), 0L);
-    haAdmin1.updateHAGroupStoreRecordInZooKeeper(haGroupName, haGroupStoreRecord, -1);
     logGroup = getReplicationLogGroup();
   }
 
@@ -139,8 +122,9 @@ public class ReplicationLogGroupIT extends HABaseIT {
 
   private Map<String, List<Mutation>> groupLogsByTable() throws Exception {
     LogFileAnalyzer analyzer = new LogFileAnalyzer();
-    analyzer.setConf(conf1);
-    Path standByLogDir = logGroup.getStandbyShardManager().getRootDirectoryPath();
+    // use peer cluster conf
+    analyzer.setConf(conf2);
+    Path standByLogDir = logGroup.getPeerShardManager().getRootDirectoryPath();
     LOG.info("Analyzing log files at {}", standByLogDir);
     String[] args = { "--check", standByLogDir.toString() };
     assertEquals(0, analyzer.run(args));

--- a/phoenix-core/src/it/java/org/apache/phoenix/replication/reader/ReplicationLogDiscoveryReplayTestIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/replication/reader/ReplicationLogDiscoveryReplayTestIT.java
@@ -17,7 +17,6 @@
  */
 package org.apache.phoenix.replication.reader;
 
-import static org.apache.phoenix.jdbc.PhoenixHAAdmin.getLocalZkUrl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -32,7 +31,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
@@ -42,77 +40,58 @@ import org.apache.hadoop.hbase.util.EnvironmentEdge;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.jdbc.ClusterRoleRecord;
+import org.apache.phoenix.jdbc.HABaseIT;
 import org.apache.phoenix.jdbc.HAGroupStoreManager;
 import org.apache.phoenix.jdbc.HAGroupStoreRecord;
 import org.apache.phoenix.jdbc.HighAvailabilityPolicy;
-import org.apache.phoenix.jdbc.HighAvailabilityTestingUtility;
-import org.apache.phoenix.query.BaseTest;
-import org.apache.phoenix.replication.ReplicationLogGroup;
 import org.apache.phoenix.replication.ReplicationLogTracker;
 import org.apache.phoenix.replication.ReplicationRound;
 import org.apache.phoenix.replication.ReplicationShardDirectoryManager;
 import org.apache.phoenix.replication.metrics.*;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
-import org.apache.phoenix.util.ReadOnlyProps;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
-
 @Category(NeedsOwnMiniClusterTest.class)
-public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
+public class ReplicationLogDiscoveryReplayTestIT extends HABaseIT {
 
   private static final Logger LOG =
     LoggerFactory.getLogger(ReplicationLogDiscoveryReplayTestIT.class);
 
-  private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS =
-    new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
   private String zkUrl;
   private String peerZkUrl;
-  private FileSystem localFs;
-  private URI standbyUri;
-  private static final String haGroupName = "testGroup";
-  private static final MetricsReplicationLogTracker METRICS_REPLICATION_LOG_TRACKER =
-    new MetricsReplicationLogTrackerReplayImpl(haGroupName);
-
-  @ClassRule
-  public static TemporaryFolder testFolder = new TemporaryFolder();
+  private FileSystem rootFs;
+  private URI rootUri;
+  private String haGroupName;
+  private MetricsReplicationLogTracker metricsReplicationLogTracker;
 
   @Rule
   public TestName testName = new TestName();
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
-    Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
-    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
     CLUSTERS.start();
   }
 
   @Before
   public void setUp() throws Exception {
-    zkUrl = getLocalZkUrl(config);
+    haGroupName = testName.getMethodName();
+    zkUrl = CLUSTERS.getZkUrl1();
     peerZkUrl = CLUSTERS.getZkUrl2();
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
-    localFs = FileSystem.getLocal(config);
-    standbyUri = testFolder.getRoot().toURI();
-    config.set(ReplicationLogGroup.REPLICATION_STANDBY_HDFS_URL_KEY, standbyUri.toString());
-  }
-
-  @After
-  public void tearDown() throws IOException {
-    localFs.delete(new Path(testFolder.getRoot().toURI()), true);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
+    rootFs = FileSystem.get(conf1);
+    rootUri = new URI(CLUSTERS.getHdfsUrl1());
+    metricsReplicationLogTracker = new MetricsReplicationLogTrackerReplayImpl(haGroupName);
   }
 
   /**
@@ -122,7 +101,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetExecutorThreadNameFormat() throws IOException {
     // Create ReplicationLogDiscoveryReplay instance
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
     ReplicationLogDiscoveryReplay discovery = new ReplicationLogDiscoveryReplay(fileTracker);
 
     // Test that it returns the expected constant value
@@ -138,7 +117,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetReplayIntervalSeconds() throws IOException {
     // Create ReplicationLogDiscoveryReplay instance
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
     ReplicationLogDiscoveryReplay discovery = new ReplicationLogDiscoveryReplay(fileTracker);
 
     // Test default value when no custom config is set
@@ -147,7 +126,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       ReplicationLogDiscoveryReplay.DEFAULT_REPLAY_INTERVAL_SECONDS, defaultResult);
 
     // Test custom value when config is set
-    config.setLong(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_INTERVAL_SECONDS_KEY, 120L);
+    conf1.setLong(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_INTERVAL_SECONDS_KEY, 120L);
     long customResult = discovery.getReplayIntervalSeconds();
     assertEquals("Should return custom value when config is set", 120L, customResult);
   }
@@ -159,7 +138,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetShutdownTimeoutSeconds() throws IOException {
     // Create ReplicationLogDiscoveryReplay instance
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
     ReplicationLogDiscoveryReplay discovery = new ReplicationLogDiscoveryReplay(fileTracker);
 
     // Test default value when no custom config is set
@@ -168,7 +147,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       ReplicationLogDiscoveryReplay.DEFAULT_SHUTDOWN_TIMEOUT_SECONDS, defaultResult);
 
     // Test custom value when config is set
-    config.setLong(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_SHUTDOWN_TIMEOUT_SECONDS_KEY,
+    conf1.setLong(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_SHUTDOWN_TIMEOUT_SECONDS_KEY,
       45L);
     long customResult = discovery.getShutdownTimeoutSeconds();
     assertEquals("Should return custom value when config is set", 45L, customResult);
@@ -181,7 +160,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetExecutorThreadCount() throws IOException {
     // Create ReplicationLogDiscoveryReplay instance
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
     ReplicationLogDiscoveryReplay discovery = new ReplicationLogDiscoveryReplay(fileTracker);
 
     // Test default value when no custom config is set
@@ -190,7 +169,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       ReplicationLogDiscoveryReplay.DEFAULT_EXECUTOR_THREAD_COUNT, defaultResult);
 
     // Test custom value when config is set
-    config.setInt(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_EXECUTOR_THREAD_COUNT_KEY, 3);
+    conf1.setInt(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_EXECUTOR_THREAD_COUNT_KEY, 3);
     int customResult = discovery.getExecutorThreadCount();
     assertEquals("Should return custom value when config is set", 3, customResult);
   }
@@ -202,7 +181,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetInProgressDirectoryProcessProbability() throws IOException {
     // Create ReplicationLogDiscoveryReplay instance
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
     ReplicationLogDiscoveryReplay discovery = new ReplicationLogDiscoveryReplay(fileTracker);
 
     // Test default value when no custom config is set
@@ -212,7 +191,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       defaultResult, 0.001);
 
     // Test custom value when config is set
-    config.setDouble(
+    conf1.setDouble(
       ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_IN_PROGRESS_DIRECTORY_PROCESSING_PROBABILITY_KEY,
       10.5);
     double customResult = discovery.getInProgressDirectoryProcessProbability();
@@ -226,7 +205,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetWaitingBufferPercentage() throws IOException {
     // Create ReplicationLogDiscoveryReplay instance
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
     ReplicationLogDiscoveryReplay discovery = new ReplicationLogDiscoveryReplay(fileTracker);
 
     // Test default value when no custom config is set
@@ -235,13 +214,13 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       ReplicationLogDiscoveryReplay.DEFAULT_WAITING_BUFFER_PERCENTAGE, defaultResult, 0.001);
 
     // Test custom value when config is set
-    config.setDouble(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_WAITING_BUFFER_PERCENTAGE_KEY,
+    conf1.setDouble(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_WAITING_BUFFER_PERCENTAGE_KEY,
       20.0);
     double customResult = discovery.getWaitingBufferPercentage();
     assertEquals("Should return custom value when config is set", 20.0, customResult, 0.001);
 
     // Clear the custom config
-    config.unset(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_WAITING_BUFFER_PERCENTAGE_KEY);
+    conf1.unset(ReplicationLogDiscoveryReplay.REPLICATION_REPLAY_WAITING_BUFFER_PERCENTAGE_KEY);
   }
 
   /**
@@ -455,7 +434,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
     long currentTime = 1704153600000L; // 2024-01-02 00:00:00
 
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
     fileTracker.init();
     long roundTimeMills =
       fileTracker.getReplicationShardDirectoryManager().getReplicationRoundDurationSeconds()
@@ -494,7 +473,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
     boolean expectedFailoverPending) throws IOException {
 
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
     fileTracker.init();
 
     try {
@@ -505,9 +484,9 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       // Create in-progress file if timestamp provided
       if (inProgressFileTimestamp != null) {
         Path inProgressDir = fileTracker.getInProgressDirPath();
-        localFs.mkdirs(inProgressDir);
+        rootFs.mkdirs(inProgressDir);
         Path inProgressFile = new Path(inProgressDir, inProgressFileTimestamp + "_rs-1_uuid.plog");
-        localFs.create(inProgressFile, true).close();
+        rootFs.create(inProgressFile, true).close();
       }
 
       // Create new file if timestamp provided
@@ -516,17 +495,17 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
           new ReplicationRound(newFileTimestamp - roundTimeMills, newFileTimestamp);
         Path shardPath = fileTracker.getReplicationShardDirectoryManager()
           .getShardDirectory(newFileRound.getStartTime());
-        localFs.mkdirs(shardPath);
+        rootFs.mkdirs(shardPath);
         Path newFile = new Path(shardPath, newFileTimestamp + "_rs-1.plog");
-        localFs.create(newFile, true).close();
+        rootFs.create(newFile, true).close();
       }
 
       // Create HAGroupStoreRecord
       long recordTime = lastSyncStateTime != null ? lastSyncStateTime : currentTime;
-      HAGroupStoreRecord mockRecord =
-        new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
-          haGroupState, recordTime, HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl,
-          peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+      HAGroupStoreRecord mockRecord = new HAGroupStoreRecord(
+        HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName, haGroupState, recordTime,
+        HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       EnvironmentEdge edge = () -> currentTime;
       EnvironmentEdgeManager.injectEdge(edge);
@@ -570,7 +549,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_SyncState_ProcessMultipleRounds() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long initialEndTime = 1704153600000L; // 2024-01-02 00:00:00
@@ -584,8 +563,8 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, initialEndTime,
-          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-          localUri.toString(), standbyUri.toString(), 0L);
+          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Set current time to allow processing 3 rounds
       long currentTime = initialEndTime + (3 * totalWaitTime);
@@ -667,7 +646,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_DegradedState_MultipleRounds() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long initialEndTime = 1704240000000L;
@@ -681,8 +660,8 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY, initialEndTime,
-          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-          localUri.toString(), standbyUri.toString(), 0L);
+          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Set current time to allow processing 3 rounds
       long currentTime = initialEndTime + (3 * totalWaitTime);
@@ -763,7 +742,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_SyncedRecoveryState_RewindToLastInSync() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long initialEndTime = 1704326400000L;
@@ -777,8 +756,8 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, initialEndTime,
-          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-          localUri.toString(), standbyUri.toString(), 0L);
+          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Set current time to allow processing multiple rounds
       long currentTime = initialEndTime + (5 * totalWaitTime);
@@ -892,7 +871,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_StateTransition_SyncToDegradedDuringProcessing() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long initialEndTime = 1704412800000L;
@@ -906,8 +885,8 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, initialEndTime,
-          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-          localUri.toString(), standbyUri.toString(), 0L);
+          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Set current time to allow processing 5 rounds
       long currentTime = initialEndTime + (5 * totalWaitTime);
@@ -1008,7 +987,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_StateTransition_DegradedToSyncedRecovery() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long initialEndTime = 1704499200000L;
@@ -1021,8 +1000,8 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY, initialEndTime,
-          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-          localUri.toString(), standbyUri.toString(), 0L);
+          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Set current time to allow processing 5 rounds
       long currentTime = initialEndTime + (5 * roundTimeMills) + bufferMillis;
@@ -1135,7 +1114,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_StateTransition_SyncToDegradedAndBackToSync() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long initialEndTime = 1704672000000L;
@@ -1148,8 +1127,8 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, initialEndTime,
-          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-          localUri.toString(), standbyUri.toString(), 0L);
+          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Set current time to allow processing enough rounds (including rewind)
       long currentTime = initialEndTime + (10 * roundTimeMills) + bufferMillis;
@@ -1293,7 +1272,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_NoRoundsToProcess() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long initialEndTime = 1704585600000L;
@@ -1305,8 +1284,8 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, initialEndTime,
-          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-          localUri.toString(), standbyUri.toString(), 0L);
+          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Set current time to NOT allow processing any rounds (not enough time has passed)
       long currentTime = initialEndTime + 1000L; // Only 1 second after
@@ -1374,7 +1353,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_LastRoundInSync_NotInitialized() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long roundTimeMills =
@@ -1397,27 +1376,28 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
 
       // Create file with minimum timestamp
       Path shardPath1 = shardManager.getShardDirectory(minFileTimestamp);
-      localFs.mkdirs(shardPath1);
+      rootFs.mkdirs(shardPath1);
       Path file1 = new Path(shardPath1, minFileTimestamp + "_rs-1.plog");
-      localFs.create(file1, true).close();
+      rootFs.create(file1, true).close();
 
       // Create file with middle timestamp
       Path shardPath2 = shardManager.getShardDirectory(middleFileTimestamp);
-      localFs.mkdirs(shardPath2);
+      rootFs.mkdirs(shardPath2);
       Path file2 = new Path(shardPath2, middleFileTimestamp + "_rs-2.plog");
-      localFs.create(file2, true).close();
+      rootFs.create(file2, true).close();
 
       // Create file with maximum timestamp
       Path shardPath3 = shardManager.getShardDirectory(maxFileTimestamp);
-      localFs.mkdirs(shardPath3);
+      rootFs.mkdirs(shardPath3);
       Path file3 = new Path(shardPath3, maxFileTimestamp + "_rs-3.plog");
-      localFs.create(file3, true).close();
+      rootFs.create(file3, true).close();
 
       // Create HAGroupStoreRecord for STANDBY state
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-          peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+          peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+          CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Calculate expected first round start time (minimum timestamp rounded down to nearest round
       // start)
@@ -1553,7 +1533,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_DegradedToSync_LastRoundInSyncStartTimeZero() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long roundTimeMills =
@@ -1574,21 +1554,22 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
 
       // Create file with minimum timestamp
       Path shardPath1 = shardManager.getShardDirectory(minFileTimestamp);
-      localFs.mkdirs(shardPath1);
+      rootFs.mkdirs(shardPath1);
       Path file1 = new Path(shardPath1, minFileTimestamp + "_rs-1.plog");
-      localFs.create(file1, true).close();
+      rootFs.create(file1, true).close();
 
       // Create file with maximum timestamp
       Path shardPath2 = shardManager.getShardDirectory(maxFileTimestamp);
-      localFs.mkdirs(shardPath2);
+      rootFs.mkdirs(shardPath2);
       Path file2 = new Path(shardPath2, maxFileTimestamp + "_rs-2.plog");
-      localFs.create(file2, true).close();
+      rootFs.create(file2, true).close();
 
       // Create HAGroupStoreRecord for STANDBY state
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-          peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+          peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+          CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Calculate expected first round start time (minimum timestamp rounded down to nearest round
       // start)
@@ -1771,7 +1752,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   @Test
   public void testReplay_TriggerFailoverAfterProcessing() throws IOException {
     TestableReplicationLogTracker fileTracker =
-      createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
     try {
       long initialEndTime = 1704153600000L; // 2024-01-02 00:00:00
@@ -1785,8 +1766,8 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       HAGroupStoreRecord mockRecord =
         new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
           HAGroupStoreRecord.HAGroupState.STANDBY, initialEndTime,
-          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-          localUri.toString(), standbyUri.toString(), 0L);
+          HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+          CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
       // Set current time to allow processing 3 rounds
       long currentTime = initialEndTime + (3 * totalWaitTime);
@@ -1880,7 +1861,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
       new ReplicationShardDirectoryManager(config, fileSystem, newFilesDirectory);
     TestableReplicationLogTracker testableReplicationLogTracker =
       new TestableReplicationLogTracker(config, haGroupName, fileSystem,
-        replicationShardDirectoryManager, METRICS_REPLICATION_LOG_TRACKER);
+        replicationShardDirectoryManager, metricsReplicationLogTracker);
     testableReplicationLogTracker.init();
     return testableReplicationLogTracker;
   }
@@ -1914,14 +1895,14 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
 
     // Initialize haGroupStoreRecord
     final ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     long initialEndTime = currentTime
       - tracker.getReplicationShardDirectoryManager().getReplicationRoundDurationSeconds() * 1000L;
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, initialEndTime,
-        HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, zkUrl, peerZkUrl,
-        localUri.toString(), standbyUri.toString(), 0L);
+        HighAvailabilityPolicy.FAILOVER.toString(), peerZkUrl, CLUSTERS.getMasterAddress1(),
+        CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     try {
       // Create test rounds
@@ -2074,11 +2055,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
       ClusterRoleRecord.ClusterRole.STANDBY_TO_ACTIVE,
-      ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY, null, CLUSTERS.getHdfsUrl1(),
+      CLUSTERS.getHdfsUrl2());
 
     TestableReplicationLogTracker fileTracker = null;
     try {
-      fileTracker = createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      fileTracker = createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
       // Create a spy of ReplicationLogDiscoveryReplay to test actual implementation
       ReplicationLogDiscoveryReplay discovery =
@@ -2094,7 +2076,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
 
       // Verify initial state is STANDBY_TO_ACTIVE
       Optional<HAGroupStoreRecord> recordBefore =
-        HAGroupStoreManager.getInstance(config).getHAGroupStoreRecord(haGroupName);
+        HAGroupStoreManager.getInstance(conf1).getHAGroupStoreRecord(haGroupName);
       assertTrue("HA group record should exist", recordBefore.isPresent());
       assertEquals("Initial state should be STANDBY_TO_ACTIVE",
         HAGroupStoreRecord.HAGroupState.STANDBY_TO_ACTIVE, recordBefore.get().getHAGroupState());
@@ -2107,7 +2089,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
 
       // Verify cluster state is updated to ACTIVE_IN_SYNC after failover
       Optional<HAGroupStoreRecord> recordAfter =
-        HAGroupStoreManager.getInstance(config).getHAGroupStoreRecord(haGroupName);
+        HAGroupStoreManager.getInstance(conf1).getHAGroupStoreRecord(haGroupName);
       assertTrue("HA group record should exist after failover", recordAfter.isPresent());
       assertEquals("Cluster state should be ACTIVE_IN_SYNC after successful failover",
         HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC, recordAfter.get().getHAGroupState());
@@ -2137,11 +2119,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetConsistencyPointSyncStateWithInProgressFiles() throws IOException {
     // Create ReplicationLogTracker
     ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+        peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     TestableReplicationLogDiscoveryReplay discovery =
       new TestableReplicationLogDiscoveryReplay(tracker, haGroupStoreRecord);
 
@@ -2175,11 +2158,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
     throws IOException {
     // Create ReplicationLogTracker
     ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+        peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     TestableReplicationLogDiscoveryReplay discovery =
       new TestableReplicationLogDiscoveryReplay(tracker, haGroupStoreRecord);
 
@@ -2211,11 +2195,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
     throws IOException {
     // Create ReplicationLogTracker
     ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+        peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     TestableReplicationLogDiscoveryReplay discovery =
       new TestableReplicationLogDiscoveryReplay(tracker, haGroupStoreRecord);
 
@@ -2257,11 +2242,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
     // because transitioning from STANDBY directly to ACTIVE_IN_SYNC is invalid
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, null);
+      ClusterRoleRecord.ClusterRole.STANDBY, ClusterRoleRecord.ClusterRole.ACTIVE, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     TestableReplicationLogTracker fileTracker = null;
     try {
-      fileTracker = createReplicationLogTracker(config, haGroupName, localFs, standbyUri);
+      fileTracker = createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri);
 
       // Create a spy of ReplicationLogDiscoveryReplay to test actual implementation
       ReplicationLogDiscoveryReplay discovery =
@@ -2277,7 +2263,7 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
 
       // Verify initial state is STANDBY (not STANDBY_TO_ACTIVE)
       Optional<HAGroupStoreRecord> recordBefore =
-        HAGroupStoreManager.getInstance(config).getHAGroupStoreRecord(haGroupName);
+        HAGroupStoreManager.getInstance(conf1).getHAGroupStoreRecord(haGroupName);
       assertTrue("HA group record should exist", recordBefore.isPresent());
       assertEquals("Initial state should be STANDBY", HAGroupStoreRecord.HAGroupState.STANDBY,
         recordBefore.get().getHAGroupState());
@@ -2316,11 +2302,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetConsistencyPointDegradedStateWithLastRoundInSync() throws IOException {
     // Create ReplicationLogTracker
     ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+        peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     TestableReplicationLogDiscoveryReplay discovery =
       new TestableReplicationLogDiscoveryReplay(tracker, haGroupStoreRecord);
 
@@ -2349,11 +2336,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetConsistencyPointDegradedStateWithoutLastRoundInSync() throws IOException {
     // Create ReplicationLogTracker
     ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+        peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     TestableReplicationLogDiscoveryReplay discovery =
       new TestableReplicationLogDiscoveryReplay(tracker, haGroupStoreRecord);
 
@@ -2382,11 +2370,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetConsistencyPointSyncedRecoveryStateWithLastRoundInSync() throws IOException {
     // Create ReplicationLogTracker
     ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+        peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     TestableReplicationLogDiscoveryReplay discovery =
       new TestableReplicationLogDiscoveryReplay(tracker, haGroupStoreRecord);
 
@@ -2416,11 +2405,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
     throws IOException {
     // Create ReplicationLogTracker
     ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+        peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     TestableReplicationLogDiscoveryReplay discovery =
       new TestableReplicationLogDiscoveryReplay(tracker, haGroupStoreRecord);
 
@@ -2448,11 +2438,12 @@ public class ReplicationLogDiscoveryReplayTestIT extends BaseTest {
   public void testGetConsistencyPointNotInitializedState() throws IOException {
     // Create ReplicationLogTracker
     ReplicationLogTracker tracker =
-      Mockito.spy(createReplicationLogTracker(config, haGroupName, localFs, standbyUri));
+      Mockito.spy(createReplicationLogTracker(conf1, haGroupName, rootFs, rootUri));
     HAGroupStoreRecord haGroupStoreRecord =
       new HAGroupStoreRecord(HAGroupStoreRecord.DEFAULT_PROTOCOL_VERSION, haGroupName,
         HAGroupStoreRecord.HAGroupState.STANDBY, 0L, HighAvailabilityPolicy.FAILOVER.toString(),
-        peerZkUrl, zkUrl, peerZkUrl, localUri.toString(), standbyUri.toString(), 0L);
+        peerZkUrl, CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
+        CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
     TestableReplicationLogDiscoveryReplay discovery =
       new TestableReplicationLogDiscoveryReplay(tracker, haGroupStoreRecord);
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/replication/reader/ReplicationLogReplayServiceTestIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/replication/reader/ReplicationLogReplayServiceTestIT.java
@@ -24,10 +24,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.net.URI;
 import java.sql.SQLException;
 import java.util.List;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hbase.util.EnvironmentEdge;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
@@ -38,24 +36,17 @@ import org.apache.phoenix.jdbc.PhoenixHAAdmin;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.mockito.Mockito;
 
 @Category(NeedsOwnMiniClusterTest.class)
 public class ReplicationLogReplayServiceTestIT extends HABaseIT {
 
-  @ClassRule
-  public static TemporaryFolder testFolder = new TemporaryFolder();
-
   private String zkUrl;
   private String peerZkUrl;
-  private FileSystem localFs;
-  private URI standbyUri;
   private PhoenixHAAdmin haAdmin;
   private PhoenixHAAdmin peerHaAdmin;
 
@@ -71,17 +62,9 @@ public class ReplicationLogReplayServiceTestIT extends HABaseIT {
   public void setUp() throws Exception {
     zkUrl = getLocalZkUrl(conf1);
     peerZkUrl = CLUSTERS.getZkUrl2();
-    localFs = FileSystem.getLocal(conf1);
-    standbyUri = testFolder.getRoot().toURI();
     haAdmin = new PhoenixHAAdmin(zkUrl, conf1, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
     peerHaAdmin = new PhoenixHAAdmin(peerZkUrl, conf2, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
     cleanupHAGroupState();
-
-    // Set the required configuration for ReplicationLogReplay
-    conf1.set(ReplicationLogReplay.REPLICATION_LOG_REPLAY_HDFS_URL_KEY, standbyUri.toString());
-    // Enable replication replay service
-    conf1.setBoolean(ReplicationLogReplayService.PHOENIX_REPLICATION_REPLAY_ENABLED, true);
-
   }
 
   /**
@@ -96,11 +79,13 @@ public class ReplicationLogReplayServiceTestIT extends HABaseIT {
     // Insert HAGroupStoreRecords into the system table
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Set up consistency points for both groups
     long consistencyPoint1 = 1704153600000L; // 2024-01-02 00:00:00
@@ -142,7 +127,8 @@ public class ReplicationLogReplayServiceTestIT extends HABaseIT {
     // Insert HAGroupStoreRecord into the system table
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Set up consistency point for the group
     long consistencyPoint = 1704153600000L; // 2024-01-02 00:00:00

--- a/phoenix-core/src/it/java/org/apache/phoenix/replication/reader/ReplicationLogReplayTestIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/replication/reader/ReplicationLogReplayTestIT.java
@@ -17,95 +17,56 @@
  */
 package org.apache.phoenix.replication.reader;
 
-import static org.apache.phoenix.jdbc.HAGroupStoreClient.ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE;
-import static org.apache.phoenix.jdbc.PhoenixHAAdmin.getLocalZkUrl;
-import static org.apache.phoenix.jdbc.PhoenixHAAdmin.toPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.net.URI;
 import java.sql.SQLException;
-import java.util.List;
-import java.util.Map;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.jdbc.ClusterRoleRecord;
-import org.apache.phoenix.jdbc.HAGroupStoreClient;
-import org.apache.phoenix.jdbc.HighAvailabilityTestingUtility;
-import org.apache.phoenix.jdbc.PhoenixHAAdmin;
-import org.apache.phoenix.query.BaseTest;
+import org.apache.phoenix.jdbc.HABaseIT;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
-import org.apache.phoenix.util.ReadOnlyProps;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
-
 @Category(NeedsOwnMiniClusterTest.class)
-public class ReplicationLogReplayTestIT extends BaseTest {
-
-  @ClassRule
-  public static TemporaryFolder testFolder = new TemporaryFolder();
-
-  private static final HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS =
-    new HighAvailabilityTestingUtility.HBaseTestingUtilityPair();
+public class ReplicationLogReplayTestIT extends HABaseIT {
   private String zkUrl;
-  private String peerZkUrl;;
-  private FileSystem localFs;
-  private URI rootURI;
-  private PhoenixHAAdmin haAdmin;
-  private PhoenixHAAdmin peerHaAdmin;
+  private String peerZkUrl;
 
   @Rule
   public TestName testName = new TestName();
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
-    Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
-    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
     CLUSTERS.start();
   }
 
   @Before
   public void setUp() throws Exception {
-    zkUrl = getLocalZkUrl(config);
+    zkUrl = CLUSTERS.getZkUrl1();
     peerZkUrl = CLUSTERS.getZkUrl2();
-    localFs = FileSystem.getLocal(config);
-    standbyUri = testFolder.getRoot().toURI();
-    rootURI = new URI(standbyUri.toString());
-    zkUrl = getLocalZkUrl(config);
-    peerZkUrl = CLUSTERS.getZkUrl2();
-    peerHaAdmin = new PhoenixHAAdmin(peerZkUrl, config, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
-    cleanupHAGroupState();
-
-    // Set the required configuration for ReplicationLogReplay
-    config.set(ReplicationLogReplay.REPLICATION_LOG_REPLAY_HDFS_URL_KEY, standbyUri.toString());
-  }
-
-  @After
-  public void tearDown() throws IOException {
-    localFs.delete(new Path(testFolder.getRoot().toURI()), true);
   }
 
   @Test
-  public void testInit() throws IOException, SQLException {
-    final String haGroupName = "testGroup";
+  public void testInit() throws Exception {
+    final String haGroupName = testName.getMethodName();
 
     // Create TestableReplicationReplay instance
-    ReplicationLogReplay replicationLogReplay = new ReplicationLogReplay(config, haGroupName);
+    ReplicationLogReplay replicationLogReplay = new ReplicationLogReplay(conf1, haGroupName);
 
     // Insert a HAGroupStoreRecord into the system table
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
+    URI rootURI = new URI(CLUSTERS.getHdfsUrl1());
     // Call init method
     replicationLogReplay.init();
 
@@ -132,15 +93,17 @@ public class ReplicationLogReplayTestIT extends BaseTest {
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName1, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName2, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Get instances for the first HA group
-    ReplicationLogReplay group1Instance1 = ReplicationLogReplay.get(config, haGroupName1);
-    ReplicationLogReplay group1Instance2 = ReplicationLogReplay.get(config, haGroupName1);
+    ReplicationLogReplay group1Instance1 = ReplicationLogReplay.get(conf1, haGroupName1);
+    ReplicationLogReplay group1Instance2 = ReplicationLogReplay.get(conf1, haGroupName1);
 
     // Verify same instance is returned for same haGroupName
     assertNotNull("ReplicationLogReplay should not be null", group1Instance1);
@@ -149,60 +112,45 @@ public class ReplicationLogReplayTestIT extends BaseTest {
       group1Instance2);
 
     // Get instance for a different HA group
-    ReplicationLogReplay group2Instance1 = ReplicationLogReplay.get(config, haGroupName2);
+    ReplicationLogReplay group2Instance1 = ReplicationLogReplay.get(conf1, haGroupName2);
     assertNotNull("ReplicationLogReplay should not be null", group2Instance1);
     assertNotSame("Different instance should be returned for different haGroup", group2Instance1,
       group1Instance1);
 
     // Verify multiple calls still return cached instances
-    ReplicationLogReplay group1Instance3 = ReplicationLogReplay.get(config, haGroupName1);
-    ReplicationLogReplay group2Instance2 = ReplicationLogReplay.get(config, haGroupName2);
+    ReplicationLogReplay group1Instance3 = ReplicationLogReplay.get(conf1, haGroupName1);
+    ReplicationLogReplay group2Instance2 = ReplicationLogReplay.get(conf1, haGroupName2);
     assertSame("Cached instance should be returned", group1Instance3, group1Instance1);
     assertSame("Cached instance should be returned", group2Instance2, group2Instance1);
   }
 
   @Test
   public void testReplicationReplayCacheRemovalOnClose() throws SQLException {
-    final String haGroupName = "testHAGroup";
+    final String haGroupName = testName.getMethodName();
 
     HAGroupStoreTestUtil.upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZkUrl,
       CLUSTERS.getMasterAddress1(), CLUSTERS.getMasterAddress2(),
-      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null);
+      ClusterRoleRecord.ClusterRole.ACTIVE, ClusterRoleRecord.ClusterRole.STANDBY, null,
+      CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2());
 
     // Get initial instance
-    ReplicationLogReplay group1Instance1 = ReplicationLogReplay.get(config, haGroupName);
+    ReplicationLogReplay group1Instance1 = ReplicationLogReplay.get(conf1, haGroupName);
     assertNotNull("ReplicationLogReplay should not be null", group1Instance1);
 
     // Verify cached instance is returned
-    ReplicationLogReplay group1Instance2 = ReplicationLogReplay.get(config, haGroupName);
+    ReplicationLogReplay group1Instance2 = ReplicationLogReplay.get(conf1, haGroupName);
     assertSame("Same instance should be returned before close", group1Instance2, group1Instance1);
 
     // Close the replay instance
     group1Instance1.close();
 
     // Get instance after close - should be a new instance
-    ReplicationLogReplay group1Instance3 = ReplicationLogReplay.get(config, haGroupName);
+    ReplicationLogReplay group1Instance3 = ReplicationLogReplay.get(conf1, haGroupName);
     assertNotNull("ReplicationLogReplay should not be null after close", group1Instance3);
     assertNotSame("New instance should be created after close", group1Instance1, group1Instance3);
     assertEquals("HA Group ID should match", haGroupName, group1Instance3.getHaGroupName());
 
     // Clean up
     group1Instance3.close();
-  }
-
-  private void cleanupHAGroupState() throws SQLException {
-    // Clean up existing HAGroupStoreRecords
-    try {
-      List<String> haGroupNames = HAGroupStoreClient.getHAGroupNames(zkUrl);
-      for (String haGroupName : haGroupNames) {
-        haAdmin.getCurator().delete().quietly().forPath(toPath(haGroupName));
-        peerHaAdmin.getCurator().delete().quietly().forPath(toPath(haGroupName));
-      }
-
-    } catch (Exception e) {
-      // Ignore cleanup errors
-    }
-    // Remove any existing entries in the system table
-    HAGroupStoreTestUtil.deleteAllHAGroupRecordsInSystemTable(zkUrl);
   }
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
@@ -85,7 +85,6 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
-import java.net.URI;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Date;
@@ -118,7 +117,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
@@ -154,7 +152,6 @@ import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
 import org.apache.phoenix.jdbc.PhoenixEmbeddedDriver;
 import org.apache.phoenix.jdbc.PhoenixTestDriver;
-import org.apache.phoenix.replication.ReplicationLogGroup;
 import org.apache.phoenix.schema.NewerTableAlreadyExistsException;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.schema.PTableType;
@@ -345,9 +342,6 @@ public abstract class BaseTest {
   protected static boolean clusterInitialized = false;
   protected static HBaseTestingUtility utility;
   protected static final Configuration config = HBaseConfiguration.create();
-  protected static final String logDir = "/PHOENIX_REPLICATION";
-  protected static URI standbyUri = new Path(logDir).toUri();
-  protected static URI localUri = new Path(logDir).toUri();
 
   protected static String getUrl() {
     if (!clusterInitialized) {
@@ -591,9 +585,6 @@ public abstract class BaseTest {
       conf.setLong(QueryServices.PHOENIX_SERVER_PAGE_SIZE_MS, 0);
     }
     setPhoenixRegionServerEndpoint(conf);
-    // setup up synchronous replication
-    conf.set(ReplicationLogGroup.REPLICATION_STANDBY_HDFS_URL_KEY, standbyUri.toString());
-    conf.set(ReplicationLogGroup.REPLICATION_FALLBACK_HDFS_URL_KEY, localUri.toString());
     return conf;
   }
 

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/ReplicationLogBaseTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/ReplicationLogBaseTest.java
@@ -63,8 +63,8 @@ public class ReplicationLogBaseTest {
   protected Configuration conf;
   protected ServerName serverName;
   protected FileSystem localFs;
-  protected URI standbyUri;
-  protected URI fallbackUri;
+  protected URI peerUri;
+  protected URI localUri;
   @Mock
   protected HAGroupStoreManager haGroupStoreManager;
   protected HAGroupStoreRecord storeRecord;
@@ -91,11 +91,9 @@ public class ReplicationLogBaseTest {
     haGroupName = name.getMethodName();
     conf = HBaseConfiguration.create();
     localFs = FileSystem.getLocal(conf);
-    standbyUri = new Path(standbyFolder.getRoot().toString()).toUri();
-    fallbackUri = new Path(localFolder.getRoot().toString()).toUri();
+    peerUri = new Path(standbyFolder.getRoot().toString()).toUri();
+    localUri = new Path(localFolder.getRoot().toString()).toUri();
     serverName = ServerName.valueOf("test", 60010, EnvironmentEdgeManager.currentTimeMillis());
-    conf.set(ReplicationLogGroup.REPLICATION_STANDBY_HDFS_URL_KEY, standbyUri.toString());
-    conf.set(ReplicationLogGroup.REPLICATION_FALLBACK_HDFS_URL_KEY, fallbackUri.toString());
     // Small ring buffer size for testing
     conf.setInt(ReplicationLogGroup.REPLICATION_LOG_RINGBUFFER_SIZE_KEY, TEST_RINGBUFFER_SIZE);
     // Set a short sync timeout for testing
@@ -128,7 +126,7 @@ public class ReplicationLogBaseTest {
   private HAGroupStoreRecord initHAGroupStoreRecord() {
     return new HAGroupStoreRecord(null, haGroupName, initialState, 0,
       HighAvailabilityPolicy.FAILOVER.toString(), "peerZKUrl", "clusterUrl", "peerClusterUrl",
-      "hdfsUrl", "peerHdfsUrl", 0L);
+      localUri.toString(), peerUri.toString(), 0L);
   }
 
   static class TestableLogGroup extends ReplicationLogGroup {
@@ -140,12 +138,12 @@ public class ReplicationLogBaseTest {
 
     @Override
     protected ReplicationLog createStandbyLog() throws IOException {
-      return spy(new TestableLog(this, standbyShardManager));
+      return spy(new TestableLog(this, peerShardManager));
     }
 
     @Override
     protected ReplicationLog createFallbackLog() throws IOException {
-      return spy(new TestableLog(this, fallbackShardManager));
+      return spy(new TestableLog(this, localShardManager));
     }
 
   }

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/ReplicationLogDiscoveryForwarderTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/ReplicationLogDiscoveryForwarderTest.java
@@ -69,8 +69,7 @@ public class ReplicationLogDiscoveryForwarderTest extends ReplicationLogBaseTest
   public void testLogForwardingAndTransitionBackToSyncMode() throws Exception {
     final String tableName = "TESTTBL";
     final long count = 100L;
-    int roundDurationSeconds =
-      logGroup.getFallbackShardManager().getReplicationRoundDurationSeconds();
+    int roundDurationSeconds = logGroup.getLocalShardManager().getReplicationRoundDurationSeconds();
 
     doAnswer(new Answer<Object>() {
       @Override
@@ -144,8 +143,7 @@ public class ReplicationLogDiscoveryForwarderTest extends ReplicationLogBaseTest
   @Test
   public void testSyncModeUpdateWaitTime() throws Exception {
     final long[] waitTime = { 8L };
-    int roundDurationSeconds =
-      logGroup.getFallbackShardManager().getReplicationRoundDurationSeconds();
+    int roundDurationSeconds = logGroup.getLocalShardManager().getReplicationRoundDurationSeconds();
 
     doAnswer(new Answer<Object>() {
       @Override

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/ReplicationLogDiscoveryForwarderTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/ReplicationLogDiscoveryForwarderTest.java
@@ -165,7 +165,8 @@ public class ReplicationLogDiscoveryForwarderTest extends ReplicationLogBaseTest
         return ret;
       }
     }).when(haGroupStoreManager).setHAGroupStatusToSync(haGroupName);
-    Thread.sleep(roundDurationSeconds * 4 * 1000);
+    Thread.sleep(roundDurationSeconds * 3 * 1000);
+    LOG.info("Coming out of sleep");
     // we should have switched back to the SYNC mode
     assertEquals(SYNC, logGroup.getMode());
   }

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/ReplicationShardDirectoryManagerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/ReplicationShardDirectoryManagerTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
@@ -44,16 +43,12 @@ public class ReplicationShardDirectoryManagerTest {
 
   private Configuration conf;
   private FileSystem localFs;
-  private URI standbyUri;
   private ReplicationShardDirectoryManager manager;
 
   @Before
   public void setUp() throws IOException {
     conf = HBaseConfiguration.create();
     localFs = FileSystem.getLocal(conf);
-    standbyUri = new Path(testFolder.toString()).toUri();
-    conf.set(ReplicationLogGroup.REPLICATION_STANDBY_HDFS_URL_KEY, standbyUri.toString());
-
     // Create manager with default configuration
     Path rootPath = new Path(testFolder.getRoot().getAbsolutePath());
     manager = new ReplicationShardDirectoryManager(conf, localFs, rootPath);

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/HAGroupStoreTestUtil.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/HAGroupStoreTestUtil.java
@@ -42,23 +42,26 @@ public class HAGroupStoreTestUtil {
    * @param localClusterRole  the role of the local cluster
    * @param peerClusterRole   the role of the peer cluster
    * @param overrideConnZkUrl optional override for the connection ZK URL
+   * @param hdfsUrl1          the local cluster HDFS URI
+   * @param hdfsUrl2          the peer cluster HDFS URI
    * @throws SQLException if the database operation fails
    */
   public static void upsertHAGroupRecordInSystemTable(String haGroupName, String zkUrl,
     String peerZKUrl, ClusterRoleRecord.ClusterRole localClusterRole,
-    ClusterRoleRecord.ClusterRole peerClusterRole, String overrideConnZkUrl) throws SQLException {
+    ClusterRoleRecord.ClusterRole peerClusterRole, String overrideConnZkUrl, String hdfsUrl1,
+    String hdfsUrl2) throws SQLException {
     upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZKUrl, zkUrl, peerZKUrl,
       localClusterRole, peerClusterRole, 1L, overrideConnZkUrl, HighAvailabilityPolicy.FAILOVER,
-      new Properties(), null, null);
+      new Properties(), hdfsUrl1, hdfsUrl2);
   }
 
   public static void upsertHAGroupRecordInSystemTable(String haGroupName, String zkUrl,
     String peerZKUrl, String clusterUrl1, String clusterUrl2,
     ClusterRoleRecord.ClusterRole localClusterRole, ClusterRoleRecord.ClusterRole peerClusterRole,
-    String overrideConnZkUrl) throws SQLException {
+    String overrideConnZkUrl, String hdfsUrl1, String hdfsUrl2) throws SQLException {
     upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZKUrl, clusterUrl1, clusterUrl2,
       localClusterRole, peerClusterRole, 1L, overrideConnZkUrl, HighAvailabilityPolicy.FAILOVER,
-      new Properties(), null, null);
+      new Properties(), hdfsUrl1, hdfsUrl2);
   }
 
   /**
@@ -69,6 +72,10 @@ public class HAGroupStoreTestUtil {
    * @param clusterRole1      the role of the local cluster
    * @param clusterRole2      the role of the peer cluster
    * @param overrideConnZkUrl optional override for the connection ZK URL
+   * @param policy            HA policy
+   * @param props             JDBC connection properties
+   * @param hdfsUrl1          Local cluster HDFS URI
+   * @param hdfsUrl2          Peer cluster HDFS URI
    * @throws SQLException if the database operation fails
    */
   public static void upsertHAGroupRecordInSystemTable(String haGroupName, String zkUrl,

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/HAGroupStoreTestUtil.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/HAGroupStoreTestUtil.java
@@ -39,6 +39,8 @@ public class HAGroupStoreTestUtil {
    * @param haGroupName       the HA group name
    * @param zkUrl             the ZooKeeper URL for the local cluster
    * @param peerZKUrl         the ZooKeeper URL for the peer cluster
+   * @param clusterUrl1       the HMaster address of the local cluster
+   * @param clusterUrl2       the HMaster address of the peer cluster
    * @param localClusterRole  the role of the local cluster
    * @param peerClusterRole   the role of the peer cluster
    * @param overrideConnZkUrl optional override for the connection ZK URL
@@ -46,15 +48,6 @@ public class HAGroupStoreTestUtil {
    * @param hdfsUrl2          the peer cluster HDFS URI
    * @throws SQLException if the database operation fails
    */
-  public static void upsertHAGroupRecordInSystemTable(String haGroupName, String zkUrl,
-    String peerZKUrl, ClusterRoleRecord.ClusterRole localClusterRole,
-    ClusterRoleRecord.ClusterRole peerClusterRole, String overrideConnZkUrl, String hdfsUrl1,
-    String hdfsUrl2) throws SQLException {
-    upsertHAGroupRecordInSystemTable(haGroupName, zkUrl, peerZKUrl, zkUrl, peerZKUrl,
-      localClusterRole, peerClusterRole, 1L, overrideConnZkUrl, HighAvailabilityPolicy.FAILOVER,
-      new Properties(), hdfsUrl1, hdfsUrl2);
-  }
-
   public static void upsertHAGroupRecordInSystemTable(String haGroupName, String zkUrl,
     String peerZKUrl, String clusterUrl1, String clusterUrl2,
     ClusterRoleRecord.ClusterRole localClusterRole, ClusterRoleRecord.ClusterRole peerClusterRole,


### PR DESCRIPTION
1. Consume the hdfs urls from HAGroupStoreRecord both on the writer and replay path.
2. Enhance HighAvailabilityTestingUtility to create and get the HDFS urls
3. Refactored HA ITs to only use dual clusters than spinning up both Dual cluster and a standalone mini cluster.
4. Fixed ITs where zk urls were being passed instead of cluster urls.