### PR TITLE
Fix 'occured' -> 'occurred' typos in 2 files

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/UpgradeUtil.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/UpgradeUtil.java
@@ -2788,7 +2788,7 @@ public class UpgradeUtil {
         conn.commit();
       } else {
         throw new RuntimeException(
-          "Error: problem occured during upgrade. " + "Table is not upgraded successfully");
+          "Error: problem occurred during upgrade. " + "Table is not upgraded successfully");
       }
       if (table.getType() == PTableType.VIEW) {
         LOGGER

--- a/phoenix-pherf/src/test/java/org/apache/phoenix/pherf/ConfigurationParserTest.java
+++ b/phoenix-pherf/src/test/java/org/apache/phoenix/pherf/ConfigurationParserTest.java
@@ -326,7 +326,7 @@ public class ConfigurationParserTest extends ResultBaseTest {
       // Writing to console
       jaxbMarshaller.marshal(data, System.out);
     } catch (JAXBException e) {
-      // some exception occured
+      // some exception occurred
       e.printStackTrace();
     }
     return data.toString();


### PR DESCRIPTION
Trivial spelling fix — `occured` → `occurred`.

One occurrence is in a user-visible `RuntimeException` message emitted when an upgrade fails:

- `phoenix-core-client/.../UpgradeUtil.java` — `"Error: problem occurred during upgrade. Table is not upgraded successfully"`

The other is a test code comment:

- `phoenix-pherf/.../ConfigurationParserTest.java`

No functional changes.