### PR TITLE
PHOENIX-7817 Resolve Omid transaction manager via provider singleton view

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/transaction/OmidTransactionContext.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/transaction/OmidTransactionContext.java
@@ -44,19 +44,24 @@ public class OmidTransactionContext implements PhoenixTransactionContext {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OmidTransactionContext.class);
 
-  private HBaseTransactionManager tm;
+  // The client is a thin view onto the OmidTransactionProvider singleton's
+  // current HBaseTransactionManager. Do not cache the manager itself here so that
+  // tests which swap the singleton's manager (via OmidTransactionProvider.injectTestService)
+  // do not leave this context holding a reference to a closed manager. In production the
+  // singleton's manager is set exactly once and never replaced, so resolving on each call
+  // is functionally identical to caching.
+  private OmidTransactionProvider.OmidTransactionClient client;
   private HBaseTransaction tx;
 
   public OmidTransactionContext() {
     this.tx = null;
-    this.tm = null;
+    this.client = null;
   }
 
   public OmidTransactionContext(PhoenixConnection connection) throws SQLException {
-    PhoenixTransactionClient client =
-      connection.getQueryServices().initTransactionClient(getProvider());
-    assert (client instanceof OmidTransactionProvider.OmidTransactionClient);
-    this.tm = ((OmidTransactionProvider.OmidTransactionClient) client).getTransactionClient();
+    PhoenixTransactionClient c = connection.getQueryServices().initTransactionClient(getProvider());
+    assert (c instanceof OmidTransactionProvider.OmidTransactionClient);
+    this.client = (OmidTransactionProvider.OmidTransactionClient) c;
     this.tx = null;
   }
 
@@ -64,8 +69,10 @@ public class OmidTransactionContext implements PhoenixTransactionContext {
     this();
     if (txnBytes != null && txnBytes.length > 0) {
       TSOProto.Transaction transaction = TSOProto.Transaction.parseFrom(txnBytes);
+      HBaseTransactionManager m = tm();
       tx = new HBaseTransaction(transaction.getTimestamp(), transaction.getEpoch(),
-        new HashSet<HBaseCellId>(), new HashSet<HBaseCellId>(), null, tm.isLowLatency());
+        new HashSet<HBaseCellId>(), new HashSet<HBaseCellId>(), null,
+        m != null && m.isLowLatency());
     } else {
       tx = null;
     }
@@ -75,33 +82,40 @@ public class OmidTransactionContext implements PhoenixTransactionContext {
     assert (ctx instanceof OmidTransactionContext);
     OmidTransactionContext omidTransactionContext = (OmidTransactionContext) ctx;
 
-    this.tm = omidTransactionContext.tm;
+    this.client = omidTransactionContext.client;
 
     if (subTask) {
       if (omidTransactionContext.isTransactionRunning()) {
         Transaction transaction = omidTransactionContext.getTransaction();
+        HBaseTransactionManager m = tm();
         this.tx = new HBaseTransaction(transaction.getTransactionId(), transaction.getEpoch(),
-          new HashSet<HBaseCellId>(), new HashSet<HBaseCellId>(), this.tm,
-          transaction.getReadTimestamp(), transaction.getWriteTimestamp(), tm.isLowLatency());
+          new HashSet<HBaseCellId>(), new HashSet<HBaseCellId>(), m,
+          transaction.getReadTimestamp(), transaction.getWriteTimestamp(),
+          m != null && m.isLowLatency());
       } else {
         this.tx = null;
       }
 
-      this.tm = null;
+      this.client = null;
     } else {
       this.tx = omidTransactionContext.getTransaction();
     }
   }
 
+  private HBaseTransactionManager tm() {
+    return client == null ? null : client.getTransactionClient();
+  }
+
   @Override
   public void begin() throws SQLException {
-    if (tm == null) {
+    HBaseTransactionManager m = tm();
+    if (m == null) {
       throw new SQLExceptionInfo.Builder(SQLExceptionCode.NULL_TRANSACTION_CONTEXT).build()
         .buildException();
     }
 
     try {
-      tx = (HBaseTransaction) tm.begin();
+      tx = (HBaseTransaction) m.begin();
     } catch (TransactionException e) {
       throw new SQLExceptionInfo.Builder(SQLExceptionCode.TRANSACTION_FAILED)
         .setMessage(e.getMessage()).setRootCause(e).build().buildException();
@@ -110,10 +124,11 @@ public class OmidTransactionContext implements PhoenixTransactionContext {
 
   @Override
   public void commit() throws SQLException {
-    if (tx == null || tm == null) return;
+    HBaseTransactionManager m = tm();
+    if (tx == null || m == null) return;
 
     try {
-      tm.commit(tx);
+      m.commit(tx);
     } catch (TransactionException e) {
       throw new SQLExceptionInfo.Builder(SQLExceptionCode.TRANSACTION_FAILED)
         .setMessage(e.getMessage()).setRootCause(e).build().buildException();
@@ -125,12 +140,13 @@ public class OmidTransactionContext implements PhoenixTransactionContext {
 
   @Override
   public void abort() throws SQLException {
-    if (tx == null || tm == null || tx.getStatus() != Status.RUNNING) {
+    HBaseTransactionManager m = tm();
+    if (tx == null || m == null || tx.getStatus() != Status.RUNNING) {
       return;
     }
 
     try {
-      tm.rollback(tx);
+      m.rollback(tx);
     } catch (TransactionException e) {
       throw new SQLExceptionInfo.Builder(SQLExceptionCode.TRANSACTION_FAILED)
         .setMessage(e.getMessage()).setRootCause(e).build().buildException();
@@ -149,9 +165,14 @@ public class OmidTransactionContext implements PhoenixTransactionContext {
 
   @Override
   public void commitDDLFence(PTable dataTable) throws SQLException {
+    HBaseTransactionManager m = tm();
+    if (m == null) {
+      throw new SQLExceptionInfo.Builder(SQLExceptionCode.NULL_TRANSACTION_CONTEXT).build()
+        .buildException();
+    }
 
     try {
-      tx = (HBaseTransaction) tm.fence(dataTable.getName().getBytes());
+      tx = (HBaseTransaction) m.fence(dataTable.getName().getBytes());
       if (LOGGER.isInfoEnabled()) {
         LOGGER.info("Added write fence at ~" + tx.getReadTimestamp());
       }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/transaction/OmidTransactionProvider.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/transaction/OmidTransactionProvider.java
@@ -36,7 +36,9 @@ import org.apache.phoenix.transaction.TransactionFactory.Provider;
 public class OmidTransactionProvider implements PhoenixTransactionProvider {
   private static final OmidTransactionProvider INSTANCE = new OmidTransactionProvider();
 
-  private HBaseTransactionManager transactionManager = null;
+  // volatile so that test-framework injection (injectTestService) is published to other
+  // threads without requiring all readers to synchronize on the singleton.
+  private volatile HBaseTransactionManager transactionManager = null;
   private volatile CommitTable.Client commitTableClient = null;
 
   public static final OmidTransactionProvider getInstance() {
@@ -78,18 +80,22 @@ public class OmidTransactionProvider implements PhoenixTransactionProvider {
       }
     }
 
-    return new OmidTransactionClient(transactionManager);
+    return new OmidTransactionClient(this);
   }
 
+  /**
+   * A thin view onto the {@link OmidTransactionProvider} singleton's current
+   * {@link HBaseTransactionManager}.
+   */
   static class OmidTransactionClient implements PhoenixTransactionClient {
-    private final HBaseTransactionManager transactionManager;
+    private final OmidTransactionProvider provider;
 
-    public OmidTransactionClient(HBaseTransactionManager transactionManager) {
-      this.transactionManager = transactionManager;
+    public OmidTransactionClient(OmidTransactionProvider provider) {
+      this.provider = provider;
     }
 
     public HBaseTransactionManager getTransactionClient() {
-      return transactionManager;
+      return provider.transactionManager;
     }
 
     @Override


### PR DESCRIPTION
`OmidTransactionClient` captures the provider's `HBaseTransactionManager` at construction time. `OmidTransactionContext` in turn caches that same reference in a private field. When a prior test class shuts down OMID's TSO together with its mini-cluster, the next test class reuses the stale wrapper and is dispatched to the dead executor. The symptom is a `RejectedExecutionException` originating from the OMID TSOClient state-machine executor.
 
In production the singleton's manager is set exactly once and never replaced, but the test framework exercises the swap path between classes within a single Surefire/Failsafe fork.
 
Fix:
 
`OmidTransactionClient` becomes a thin view onto the singleton's current `HBaseTransactionManager`. It resolves
`provider.transactionManager` on every call to `getTransactionClient()`. `transactionManager` is marked volatile so test-framework injection is published to other threads without synchronization.

In production the dynamic lookup is functionally identical to caching.