### PR TITLE
PHOENIX-7818 OmidTransactionContext.getVisibilityLevel missing break in switch

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/transaction/OmidTransactionContext.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/transaction/OmidTransactionContext.java
@@ -224,6 +224,7 @@ public class OmidTransactionContext implements PhoenixTransactionContext {
         break;
       case SNAPSHOT_ALL:
         phoenixVisibilityLevel = PhoenixVisibilityLevel.SNAPSHOT_ALL;
+        break;
       default:
         phoenixVisibilityLevel = null;
     }


### PR DESCRIPTION
`OmidTransactionContext.getVisibilityLevel()` translates the OMID `VisibilityLevel` into Phoenix's `PhoenixVisibilityLevel`. A switch statement is missing a break statement. Execution falls through into the default arm, which unconditionally overwrites `phoenixVisibilityLevel` with `null`. Any caller that asks for the visibility level of a `SNAPSHOT_ALL` transaction always sees `null`.