### PR TITLE
PHOENIX-7819 HighAvailabilityGroup.URLS inner Set must be thread-safe

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
@@ -25,7 +25,6 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -279,7 +278,8 @@ public class HighAvailabilityGroup {
     }
     HAURLInfo haurlInfo = new HAURLInfo(name, principal, additionalJDBCParams);
     HAGroupInfo info = getHAGroupInfo(url, properties);
-    URLS.computeIfAbsent(info, haGroupInfo -> new HashSet<>()).add(haurlInfo);
+    // Multiple threads can concurrently call this code path with the same HAGroupInfo.
+    URLS.computeIfAbsent(info, haGroupInfo -> ConcurrentHashMap.newKeySet()).add(haurlInfo);
     return haurlInfo;
   }
 


### PR DESCRIPTION
When multiple threads register HA URL infos for the same `HAGroupInfo`, `computeIfAbsent()` returns the same HashSet instance to every thread, which then concurrently call `add()` on it. `java.util.HashSet` is not thread-safe. Concurrent `add()` is undefined behavior and can lose entries.