### PR TITLE
PHOENIX-7823 AuditLoggingIT replace hardcoded table names with generateUniqueName()

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/AuditLoggingIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/AuditLoggingIT.java
@@ -35,17 +35,19 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
 
   @Test
   public void testEmptyLogging() throws Exception {
-    String createqQery =
-      "create table test1 (mykey integer not null primary key," + " mycolumn varchar)";
-    String upsertQuery = "upsert into test1 values (1,'Hello')";
-    String selectQuery = "select * from test1";
-    String getLogsQuery = "select * from SYSTEM.LOG WHERE TABLE_NAME='TEST1' order by start_time";
+    String tableName = generateUniqueName();
+    String createQuery =
+      "create table " + tableName + " (mykey integer not null primary key, mycolumn varchar)";
+    String upsertQuery = "upsert into " + tableName + " values (1,'Hello')";
+    String selectQuery = "select * from " + tableName;
+    String getLogsQuery =
+      "select * from SYSTEM.LOG WHERE TABLE_NAME='" + tableName + "' order by start_time";
     Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
     Connection conn = DriverManager.getConnection(getUrl(), props);
     conn.setAutoCommit(true);
     try {
       Statement stmt = conn.createStatement();
-      stmt.execute(createqQery);
+      stmt.execute(createQuery);
       stmt.execute(upsertQuery);
       stmt.executeQuery(selectQuery);
       conn.commit();
@@ -60,17 +62,19 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
 
   @Test
   public void testLoggingSelect() throws Exception {
-    String createqQery =
-      "create table test2 (mykey integer not null primary key," + " mycolumn varchar)";
-    String upsertQuery = "upsert into test2 values (1,'Hello')";
-    String selectQuery = "select * from test2";
-    String getLogsQuery = "select * from SYSTEM.LOG WHERE TABLE_NAME='TEST2' order by start_time";
+    String tableName = generateUniqueName();
+    String createQuery =
+      "create table " + tableName + " (mykey integer not null primary key, mycolumn varchar)";
+    String upsertQuery = "upsert into " + tableName + " values (1,'Hello')";
+    String selectQuery = "select * from " + tableName;
+    String getLogsQuery =
+      "select * from SYSTEM.LOG WHERE TABLE_NAME='" + tableName + "' order by start_time";
     Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
     props.setProperty(QueryServices.LOG_LEVEL, LogLevel.TRACE.name());
     try (Connection conn = DriverManager.getConnection(getUrl(), props);
       Statement stmt = conn.createStatement();) {
       conn.setAutoCommit(true);
-      stmt.execute(createqQery);
+      stmt.execute(createQuery);
       stmt.execute(upsertQuery);
       ResultSet rs = stmt.executeQuery(selectQuery);
       assertTrue(rs.next());
@@ -97,18 +101,20 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
 
   @Test
   public void testLoggingDMLAndDDL() throws Exception {
-    String createqQery =
-      "create table test3 (mykey integer not null primary key," + " mycolumn varchar)";
-    String upsertQuery = "upsert into test3 values (1,'Hello')";
-    String selectQuery = "select * from test3";
-    String getLogsQuery = "select * from SYSTEM.LOG WHERE TABLE_NAME='TEST3' order by start_time";
+    String tableName = generateUniqueName();
+    String createQuery =
+      "create table " + tableName + " (mykey integer not null primary key, mycolumn varchar)";
+    String upsertQuery = "upsert into " + tableName + " values (1,'Hello')";
+    String selectQuery = "select * from " + tableName;
+    String getLogsQuery =
+      "select * from SYSTEM.LOG WHERE TABLE_NAME='" + tableName + "' order by start_time";
     Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
     props.setProperty(QueryServices.AUDIT_LOG_LEVEL, LogLevel.INFO.name());
     try (Connection conn = DriverManager.getConnection(getUrl(), props);
       Statement stmt = conn.createStatement();) {
       conn.setAutoCommit(true);
 
-      stmt.execute(createqQery);
+      stmt.execute(createQuery);
       stmt.execute(upsertQuery);
       ResultSet rs = conn.createStatement().executeQuery(selectQuery);
       assertTrue(rs.next());
@@ -120,7 +126,7 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
         try {
           ResultSet rs2 = stmt.executeQuery(getLogsQuery);
           assertTrue(rs2.next());
-          assertEquals(rs2.getString(7), createqQery);
+          assertEquals(rs2.getString(7), createQuery);
           assertTrue(rs2.next());
           assertEquals(rs2.getString(7), upsertQuery);
           assertFalse(rs2.next());
@@ -137,18 +143,20 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
 
   @Test
   public void testLoggingDMLAandDDLandSelect() throws Exception {
-    String createqQuery =
-      "create table test4 (mykey integer not null primary key," + " mycolumn varchar)";
-    String upsertQuery = "upsert into test4 values (1,'Hello')";
-    String selectQuery = "select * from test4";
-    String getLogsQuery = "select * from SYSTEM.LOG WHERE TABLE_NAME='TEST4' order by start_time";
+    String tableName = generateUniqueName();
+    String createQuery =
+      "create table " + tableName + " (mykey integer not null primary key, mycolumn varchar)";
+    String upsertQuery = "upsert into " + tableName + " values (1,'Hello')";
+    String selectQuery = "select * from " + tableName;
+    String getLogsQuery =
+      "select * from SYSTEM.LOG WHERE TABLE_NAME='" + tableName + "' order by start_time";
     Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
     props.setProperty(QueryServices.AUDIT_LOG_LEVEL, LogLevel.INFO.name());
     props.setProperty(QueryServices.LOG_LEVEL, LogLevel.TRACE.name());
     try (Connection conn = DriverManager.getConnection(getUrl(), props);
       Statement stmt = conn.createStatement();) {
       conn.setAutoCommit(true);
-      stmt.execute(createqQuery);
+      stmt.execute(createQuery);
       stmt.execute(upsertQuery);
       ResultSet rs = stmt.executeQuery(selectQuery);
       assertTrue(rs.next());
@@ -160,7 +168,7 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
         try {
           ResultSet rs2 = conn.createStatement().executeQuery(getLogsQuery);
           assertTrue(rs2.next());
-          assertEquals(rs2.getString(7), createqQuery);
+          assertEquals(rs2.getString(7), createQuery);
           assertTrue(rs2.next());
           assertEquals(rs2.getString(7), upsertQuery);
           assertTrue(rs2.next());
@@ -180,11 +188,13 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
 
   @Test
   public void testLogginParameterizedUpsert() throws Exception {
-    String createqQery =
-      "create table test5 (mykey integer not null primary key," + " mycolumn varchar)";
-    String upsertQuery = "upsert into test5 values (?, ?)";
-    String selectQuery = "select * from test5";
-    String getLogsQuery = "select * from SYSTEM.LOG WHERE TABLE_NAME='TEST5' order by start_time";
+    String tableName = generateUniqueName();
+    String createQuery =
+      "create table " + tableName + " (mykey integer not null primary key, mycolumn varchar)";
+    String upsertQuery = "upsert into " + tableName + " values (?, ?)";
+    String selectQuery = "select * from " + tableName;
+    String getLogsQuery =
+      "select * from SYSTEM.LOG WHERE TABLE_NAME='" + tableName + "' order by start_time";
     Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
     props.setProperty(QueryServices.AUDIT_LOG_LEVEL, LogLevel.INFO.name());
     props.setProperty(QueryServices.LOG_LEVEL, LogLevel.TRACE.name());
@@ -192,7 +202,7 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
       Statement stmt = conn.createStatement();
       PreparedStatement p = conn.prepareStatement(upsertQuery);) {
       conn.setAutoCommit(true);
-      stmt.execute(createqQery);
+      stmt.execute(createQuery);
 
       p.setInt(1, 1);
       p.setString(2, "foo");
@@ -232,11 +242,12 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
 
   @Test
   public void testlogSamplingRate() throws Exception {
-    String createqQery =
-      "create table test6 (mykey integer not null primary key," + " mycolumn varchar)";
-
-    String selectQuery = "select * from test6";
-    String getLogsQuery = "select * from SYSTEM.LOG WHERE TABLE_NAME='TEST6' order by start_time";
+    String tableName = generateUniqueName();
+    String createQuery =
+      "create table " + tableName + " (mykey integer not null primary key, mycolumn varchar)";
+    String selectQuery = "select * from " + tableName;
+    String getLogsQuery =
+      "select * from SYSTEM.LOG WHERE TABLE_NAME='" + tableName + "' order by start_time";
     Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
     props.setProperty(QueryServices.AUDIT_LOG_LEVEL, LogLevel.INFO.name());
     props.setProperty(QueryServices.LOG_LEVEL, LogLevel.TRACE.name());
@@ -245,10 +256,10 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
     conn.setAutoCommit(true);
     try {
       Statement stat = conn.createStatement();
-      stat.execute(createqQery);
+      stat.execute(createQuery);
       String upsertQuery;
       for (int i = 0; i < 100; i++) {
-        upsertQuery = "upsert into test6 values (" + i + ",'asd')";
+        upsertQuery = "upsert into " + tableName + " values (" + i + ",'asd')";
         stat.execute(upsertQuery);
         ResultSet rs = stat.executeQuery(selectQuery);
         assertTrue(rs.next());
@@ -262,13 +273,12 @@ public class AuditLoggingIT extends ParallelStatsDisabledIT {
         String query = rs2.getString(7);
         if (query.equals(selectQuery)) {
           numOfSelects++;
-        } else if (query.contains("upsert into test6 values (")) {
+        } else if (query.contains("upsert into " + tableName + " values (")) {
           numOfUpserts++;
         }
       }
       assertEquals(numOfUpserts, 100);
       assertTrue(numOfSelects > 0 && numOfSelects < 100);
-      System.out.println(numOfSelects);
 
     } finally {
       conn.close();


### PR DESCRIPTION
`AuditLoggingIT` uses hardcoded table names `test1`..`test6` a shared mini-cluster, causing `CREATE TABLE` collisions on CI retries and allowing `SYSTEM.LOG` queries to match stale entries from prior runs. The fix is to replace those names with `generateUniqueName()`everywhere they appear in SQL, and while in the file also rename the misspelled local `createqQery` -> `createQuery` and drop a stray `System.out.println` debug print.