### PR TITLE
PHOENIX-7824 ConcurrentMutationsExtendedIT fix wrong TimeUnit on doneSignal.await

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ConcurrentMutationsExtendedIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ConcurrentMutationsExtendedIT.java
@@ -377,7 +377,7 @@ public class ConcurrentMutationsExtendedIT extends ParallelStatsDisabledIT {
     Thread t2 = new Thread(r2);
     t2.start();
 
-    doneSignal.await(ROW_LOCK_WAIT_TIME + 5000, TimeUnit.SECONDS);
+    assertTrue("Ran out of time", doneSignal.await(60, TimeUnit.SECONDS));
     assertNull(failedMsg[0], failedMsg[0]);
     if (eventual) {
       Thread.sleep(35000);
@@ -439,7 +439,7 @@ public class ConcurrentMutationsExtendedIT extends ParallelStatsDisabledIT {
     Thread t2 = new Thread(r2);
     t2.start();
 
-    doneSignal.await(ROW_LOCK_WAIT_TIME + 5000, TimeUnit.SECONDS);
+    assertTrue("Ran out of time", doneSignal.await(60, TimeUnit.SECONDS));
     if (eventual) {
       Thread.sleep(35000);
     }


### PR DESCRIPTION
Two call sites in `ConcurrentMutationsExtendedIT` calls `doneSignal.await(ROW_LOCK_WAIT_TIME + 5000, TimeUnit.SECONDS)`, but `ROW_LOCK_WAIT_TIME` is the HBase row-lock-wait constant in milliseconds (default 10000). Passing `TimeUnit.SECONDS` turned the intended 15-second wait into a 4+ hour timeout. Additionally, the return value of await was unchecked, allowing silent under-completion to bypass the verification phase and let the test "pass" by accident.