### PR TITLE
PHOENIX-7825 ConcurrentMutationsIT make MyClock.shouldAdvance volatile

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ConcurrentMutationsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ConcurrentMutationsIT.java
@@ -44,7 +44,7 @@ public class ConcurrentMutationsIT extends ParallelStatsDisabledIT {
 
   private static class MyClock extends EnvironmentEdge {
     public volatile long time;
-    boolean shouldAdvance = true;
+    volatile boolean shouldAdvance = true;
 
     public MyClock(long time) {
       this.time = time;


### PR DESCRIPTION
`ConcurrentMutationsIT` installs a custom `EnvironmentEdge`, and the test thread calls `setAdvance(false)` to freeze time so two mutations share a timestamp. However, `MyClock.shouldAdvance` is not volatile, so the JMM does not require regionserver handler threads in the same JVM to observe the freeze, and in practice they keep advancing time, causing mutations expected to share a timestamp to diverge and producing non-deterministic index-scrutiny results, with the shared `ParallelStatsDisabled` mini-cluster amplifying the race.