### PR TITLE
PHOENIX-7826 MetadataGetTableReadLockIT wait for coprocessor swap to land

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/MetadataGetTableReadLockIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/MetadataGetTableReadLockIT.java
@@ -23,6 +23,8 @@ import java.sql.DriverManager;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.coprocessor.MetaDataEndpointImpl;
@@ -72,6 +74,7 @@ public class MetadataGetTableReadLockIT extends BaseTest {
       BlockingMetaDataEndpointImpl.setSleepSignal(sleepSignal);
       BlockingMetaDataEndpointImpl.setSleepDuration(SLEEP_DURATION);
       TestUtil.addCoprocessor(conn, "SYSTEM.CATALOG", BlockingMetaDataEndpointImpl.class);
+      waitForCoprocessorOnSystemCatalog(BlockingMetaDataEndpointImpl.class);
 
       // start thread-1 and wait for signal before it starts sleeping
       Thread t1 = getQueryThread(tableName);
@@ -92,6 +95,23 @@ public class MetadataGetTableReadLockIT extends BaseTest {
       Assert.assertTrue("Second thread should not have been blocked by the first thread.",
         end - start < SLEEP_DURATION);
     }
+  }
+
+  private static void waitForCoprocessorOnSystemCatalog(Class<?> coprocessorClass) throws Exception {
+    final TableName sysCatalog = TableName.valueOf("SYSTEM.CATALOG");
+    utility.waitFor(10000, 100, () -> {
+      List<HRegion> regions = utility.getHBaseCluster().getRegions(sysCatalog);
+      if (regions.isEmpty()) {
+        return false;
+      }
+      for (HRegion region : regions) {
+        if (region.getCoprocessorHost()
+            .findCoprocessor(coprocessorClass.getName()) == null) {
+          return false;
+        }
+      }
+      return true;
+    });
   }
 
   private static Thread getQueryThread(String tableName) {


### PR DESCRIPTION
The `testBlockedReadDoesNotBlockAnotherRead` test installs a `BlockingMetaDataEndpointImpl` coprocessor on `SYSTEM.CATALOG` and expects a worker thread's query to hit it and signal a latch the main thread is waiting on, but `TestUtil.addCoprocessor()` only updates the master `TableDescriptor` and doesn't wait for region servers to reopen the region with the new coprocessor, so if the query reaches the old `MetaDataEndpointImpl` first the latch is never signaled and the main thread hangs until the Surefire/Failsafe fork times out. The fix is to add a helper that polls each `SYSTEM.CATALOG` region's coprocessor host (via `findCoprocessor` for up to 10 seconds and call it after `addCoprocessor` so the coprocessor swap is guaranteed visible before the worker thread starts.