### PR TITLE
PHOENIX-7828 De-flake UCFWithDisabledIndexIT

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/UCFWithDisabledIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/UCFWithDisabledIndexIT.java
@@ -27,9 +27,12 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.compile.ExplainPlan;
 import org.apache.phoenix.compile.ExplainPlanAttributes;
@@ -102,6 +105,23 @@ public class UCFWithDisabledIndexIT extends BaseTest {
 
   }
 
+  private static void waitForCoprocessorOnSystemCatalog(Class<?> coprocessorClass) throws Exception {
+    final TableName sysCatalog = TableName.valueOf("SYSTEM.CATALOG");
+    utility.waitFor(10000, 100, () -> {
+      List<HRegion> regions = utility.getHBaseCluster().getRegions(sysCatalog);
+      if (regions.isEmpty()) {
+        return false;
+      }
+      for (HRegion region : regions) {
+        if (region.getCoprocessorHost()
+            .findCoprocessor(coprocessorClass.getName()) == null) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+
   @Test
   public void testUcfWithNoGetTableCalls() throws Throwable {
     final String tableName = generateUniqueName();
@@ -118,7 +138,7 @@ public class UCFWithDisabledIndexIT extends BaseTest {
 
       stmt.execute("CREATE TABLE " + tableName
         + " (COL1 CHAR(10) NOT NULL, COL2 CHAR(5) NOT NULL, COL3 VARCHAR,"
-        + " COL4 VARCHAR CONSTRAINT pk PRIMARY KEY(COL1, COL2))" + " UPDATE_CACHE_FREQUENCY=20000");
+        + " COL4 VARCHAR CONSTRAINT pk PRIMARY KEY(COL1, COL2))" + " UPDATE_CACHE_FREQUENCY=NEVER");
       stmt.execute("CREATE INDEX " + indexName + " ON " + tableName + " (COL3) INCLUDE (COL4)");
       stmt.execute("CREATE VIEW " + view01 + " (VCOL1 CHAR(8), COL5 VARCHAR) AS SELECT * FROM "
         + tableName + " WHERE COL1 = 'col1'");
@@ -203,6 +223,7 @@ public class UCFWithDisabledIndexIT extends BaseTest {
       updateIndexToRebuild(conn, tableName, indexName);
       TestUtil.removeCoprocessor(conn, "SYSTEM.CATALOG", TestMetaDataEndpointImpl.class);
       TestUtil.addCoprocessor(conn, "SYSTEM.CATALOG", MetaDataEndpointImpl.class);
+      waitForCoprocessorOnSystemCatalog(MetaDataEndpointImpl.class);
       verifyTableAndIndexRows(conn, tableName, indexName, false);
       conn.close();
     }
@@ -266,6 +287,7 @@ public class UCFWithDisabledIndexIT extends BaseTest {
     // re-attach original coproc
     TestUtil.removeCoprocessor(conn, "SYSTEM.CATALOG", TestMetaDataEndpointImpl.class);
     TestUtil.addCoprocessor(conn, "SYSTEM.CATALOG", MetaDataEndpointImpl.class);
+    waitForCoprocessorOnSystemCatalog(MetaDataEndpointImpl.class);
 
     final Statement stmt = conn.createStatement();
     stmt.execute("UPSERT INTO " + tableName + " (col1, col2, col3, col4) values ('c011', "
@@ -334,6 +356,7 @@ public class UCFWithDisabledIndexIT extends BaseTest {
     // attach coproc that does not allow getTable RPC call
     TestUtil.removeCoprocessor(conn, "SYSTEM.CATALOG", MetaDataEndpointImpl.class);
     TestUtil.addCoprocessor(conn, "SYSTEM.CATALOG", TestMetaDataEndpointImpl.class);
+    waitForCoprocessorOnSystemCatalog(TestMetaDataEndpointImpl.class);
     return stmt;
   }
 
@@ -356,6 +379,7 @@ public class UCFWithDisabledIndexIT extends BaseTest {
       updateIndexToRebuild(conn, tableName, indexName);
       TestUtil.removeCoprocessor(conn, "SYSTEM.CATALOG", TestMetaDataEndpointImpl.class);
       TestUtil.addCoprocessor(conn, "SYSTEM.CATALOG", MetaDataEndpointImpl.class);
+      waitForCoprocessorOnSystemCatalog(MetaDataEndpointImpl.class);
       verifyTableAndIndexRows(conn, tableName, indexName, false);
       conn.close();
     }
@@ -385,6 +409,7 @@ public class UCFWithDisabledIndexIT extends BaseTest {
       updateIndexToRebuild(conn, tableName, indexName);
       TestUtil.removeCoprocessor(conn, "SYSTEM.CATALOG", TestMetaDataEndpointImpl.class);
       TestUtil.addCoprocessor(conn, "SYSTEM.CATALOG", MetaDataEndpointImpl.class);
+      waitForCoprocessorOnSystemCatalog(MetaDataEndpointImpl.class);
       verifyTableAndIndexRows(conn, tableName, indexName, true);
       conn.close();
     }


### PR DESCRIPTION
`UCFWithDisabledIndexIT` was flaky due to two independent races.

First, the tests swap `MetaDataEndpointImpl` on `SYSTEM.CATALOG` with a `TestMetaDataEndpointImpl` that throws `DoNotRetryIOException("Not allowed")` on every getTable RPC, but `TestUtil.addCoprocessor()` only polls until the master `TableDescriptor` is updated and does not wait for region servers to reopen `SYSTEM.CATALOG` with the new coprocessor. This creates five race sites where client work runs before the swap is visible.

Second, `testUcfWithNoGetTableCalls` created its data table with `UPDATE_CACHE_FREQUENCY=20000`, then performed 7 DDLs and 7 UPSERTs before a final `SELECT` that is expected to be served entirely from the client metadata cache. Whenever wall-clock delay between `CREATE TABLE` and the `SELECT` exceeded 20 s the cache expired, a getTable RPC was issued, and the stub rejected it.

Add a `waitForCoprocessorOnSystemCatalog(Class)` helper that polls `region.getCoprocessorHost().findCoprocessor(className)` on every `SYSTEM.CATALOG` region (up to 10 s) and call it after each of the five swaps.

Change `testUcfWithNoGetTableCalls`'s `CREATE TABLE` from `UPDATE_CACHE_FREQUENCY=20000` to `UPDATE_CACHE_FREQUENCY=NEVER`, which decouples the assertion from wall-clock time.