### PR TITLE
PHOENIX-7830 De-flake MutableIndexFailureIT

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/MutableIndexFailureIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/MutableIndexFailureIT.java
@@ -103,7 +103,6 @@ public class MutableIndexFailureIT extends BaseTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MutableIndexFailureIT.class);
 
-  public static volatile boolean FAIL_WRITE = false;
   public static volatile String fullTableName;
 
   private String tableName;
@@ -415,7 +414,7 @@ public class MutableIndexFailureIT extends BaseTest {
 
       }
     } finally {
-      FAIL_WRITE = false;
+      FailingRegionObserver.FAIL_WRITE = false;
     }
   }
 
@@ -611,7 +610,7 @@ public class MutableIndexFailureIT extends BaseTest {
   }
 
   public static class FailingRegionObserver extends SimpleRegionObserver {
-    public static boolean TOGGLE_FAIL_WRITE_FOR_RETRY = false;
+    public static volatile boolean TOGGLE_FAIL_WRITE_FOR_RETRY = false;
     public static volatile boolean FAIL_WRITE = false;
     public static volatile boolean FAIL_NEXT_WRITE = false;
     public static final String FAIL_INDEX_NAME = "FAIL_IDX";


### PR DESCRIPTION
`MutableIndexFailureIT` has two independent bugs that cause flaky and cascading test failures. First, the outer class declares its own static volatile `FAIL_WRITE` field that shadows `FailingRegionObserver.FAIL_WRITE`, so the finally block in `testIndexWriteFailure` resets the dead outer field and leaves `FailingRegionObserver.FAIL_WRITE` stuck at true when the test fails mid-way, breaking subsequent tests in the same fork. Second, `FailingRegionObserver.TOGGLE_FAIL_WRITE_FOR_RETRY` is not declared volatile even though it is written by app threads in `addRowsInTableDuringRetry` and read by region server handler threads in `preBatchMutate`, so the RS thread can observe a stale false, miss the retry toggle, and surface a `CommitException` that fails the assertion. The fix removes the shadowed outer `FAIL_WRITE` field, retargets the finally block to reset `FailingRegionObserver.FAIL_WRITE`, and marks `FailingRegionObserver.TOGGLE_FAIL_WRITE_FOR_RETRY` volatile to guarantee cross-thread visibility.