### PR TITLE
PHOENIX-7832 TenantViewOperationWorkloadIT add missing break in WEIGHTED switch case

### DIFF
--- a/phoenix-pherf/src/it/java/org/apache/phoenix/pherf/workload/mt/TenantViewOperationWorkloadIT.java
+++ b/phoenix-pherf/src/it/java/org/apache/phoenix/pherf/workload/mt/TenantViewOperationWorkloadIT.java
@@ -145,6 +145,7 @@ public class TenantViewOperationWorkloadIT extends ParallelStatsDisabledIT {
         settings.tenantGroups = scenario.getLoadProfile().getTenantDistribution();
         settings.expectedOpGroups = scenario.getLoadProfile().getOpDistribution().size();
         settings.expectedTenantGroups = scenario.getLoadProfile().getTenantDistribution().size();
+        break;
       default:
         List<TenantGroup> tenantGroups = new ArrayList<>();
         TenantGroup tg1 = new TenantGroup();


### PR DESCRIPTION
The switch on `generatorType` in `TenantViewOperationWorkloadIT` is missing a `break` after the `WEIGHTED` case. Execution falls through into `default` which overwrites all the carefully-set `WEIGHTED` fields with the default (single tenant group, 10 tenants), so when `generatorType == WEIGHTED` the settings are corrupt and the tenant-distribution assertions fail intermittently.