### PR TITLE
PHOENIX-7833 CDCBaseIT/CDCQueryIT keep manual edge installed after applyMutations

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
@@ -396,15 +396,25 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
     String datatableName, String tid, List<Set<ChangeRow>> batches, String cdcName)
     throws Exception {
     EnvironmentEdgeManager.injectEdge(injectEdge);
+    long latestChangeTS = injectEdge.currentTime();
     try (Connection conn = committer.getConnection(tid)) {
       for (Set<ChangeRow> batch : batches) {
         for (ChangeRow changeRow : batch) {
           addChange(conn, tableName, changeRow);
+          if (changeRow.changeTS > latestChangeTS) {
+            latestChangeTS = changeRow.changeTS;
+          }
         }
         committer.commit(conn);
       }
     }
-    committer.reset();
+    // Keep the manual edge installed for the remainder of the test so
+    // EnvironmentEdgeManager.currentTimeMillis() does not silently revert
+    // to the wall clock and trip QueryCompiler.verifySCN against the
+    // configured max-lookback age. Pin to the latest changeTS so SCN-bounded
+    // reads of the just-applied mutations remain in-window. Per-test
+    // cleanup is the responsibility of the suite's @After hook.
+    injectEdge.setValue(latestChangeTS);
 
     // For debug: uncomment to see the exact HBase cells.
     dumpCells(schemaName, tableName, datatableName, cdcName);
@@ -950,6 +960,13 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
       EnvironmentEdgeManager.injectEdge(injectEdge);
     }
 
+    /**
+     * Uninstall the manual time edge. Callers should NOT invoke this from inside test bodies that
+     * still need to issue SCN-bounded reads of the just-applied mutations: doing so reverts
+     * {@link EnvironmentEdgeManager#currentTimeMillis()} to the wall clock and may push the SCN
+     * outside the configured max-lookback window. Per-test cleanup belongs in an {@code @After}
+     * hook instead (see {@code CDCQueryIT#afterTest}).
+     */
     public void reset() {
       EnvironmentEdgeManager.reset();
     }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
@@ -70,6 +70,7 @@ import org.apache.phoenix.util.QueryUtil;
 import org.apache.phoenix.util.ReadOnlyProps;
 import org.apache.phoenix.util.SchemaUtil;
 import org.apache.phoenix.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -143,6 +144,14 @@ public class CDCQueryIT extends CDCBaseIT {
     EnvironmentEdgeManager.reset();
     injectEdge = new ManualEnvironmentEdge();
     injectEdge.setValue(EnvironmentEdgeManager.currentTimeMillis());
+  }
+
+  @After
+  public void afterTest() {
+    // CDCBaseIT.applyMutations intentionally leaves the manual edge installed so
+    // SCN-bounded reads in the test body remain inside the max-lookback window.
+    // Restore the real clock here so per-test isolation is preserved.
+    EnvironmentEdgeManager.reset();
   }
 
   private void cdcIndexShouldNotBeUsedForDataTableQueries(Connection conn, String dataTableName,


### PR DESCRIPTION
`CDCBaseIT.applyMutations` installs a `ManualEnvironmentEdge` so each `addChange` pins `EnvironmentEdgeManager.currentTimeMillis()` to the row's `changeTS`, then calls `committer.reset()` whose default implementation is `EnvironmentEdgeManager.reset()`, reverting `currentTimeMillis()` to the wall clock. The rest of the CDC test body easily takes longer than `CDCQueryIT.MAX_LOOKBACK_AGE = 10s`, so any SCN-bounded read whose smallest SCN is the earliest `changeTS` trips `QueryCompiler.verifySCN` with `ERROR 538 "Cannot use SCN to look further back in the past beyond the configured max lookback age"`. The `IndexTool` mapper shares the same `EnvironmentEdgeManager` static state in the in-process mini-cluster and `PhoenixServerBuildIndexInputFormat` hits the same `ERROR 538` while compiling its SCN-bounded plan. The fix stops calling `committer.reset()` at the end of `applyMutations`, instead pinning `injectEdge` the highest `changeTS` seen across all batches so subsequent SCN-bounded reads of the just-applied mutations stay inside the max-lookback window, and adds a `CDCQueryIT.afterTest()` that calls `EnvironmentEdgeManager.reset()` to preserve per-test isolation.