### PR TITLE
PHOENIX-7834 CDCBaseIT do not force-delete a never-upserted row

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
@@ -332,8 +332,12 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
       for (int j = 0; j < nRows; ++j) {
         if (rand.nextInt(nRows) % 2 == 0) {
           boolean isDelete;
-          if (i > nBatches / 2 && !gotDelete) {
-            // Force a delete if there was none so far.
+          // Only force a delete on rows that have already been upserted in this run; deleting a
+          // never-inserted row produces a no-op tombstone on the data table while CDC still
+          // surfaces a later upsert for the same key, deterministically tripping the
+          // delete-vs-upsert assertion in verifyChangesViaSCN. If no candidate exists yet, defer
+          // the forced delete to a later batch (the loop will reconsider on the next iteration).
+          if (i > nBatches / 2 && !gotDelete && mutatedRows.contains(rows.get(j))) {
             isDelete = true;
           } else {
             isDelete = mutatedRows.contains(rows.get(j)) && rand.nextInt(5) == 0;


### PR DESCRIPTION
`CDCBaseIT.generateMutations` has a second-half "force a delete if there was none so far" branch that flips `isDelete=true` without checking whether the candidate row was ever upserted in this run, so when random batch participation has skipped a key in every prior batch the forced `DELETE` lands on a non-existent row and produces an HBase tombstone with no matching put. The data table view sees no change, and a later legitimate upsert for the same key surfaces as the next CDC change event on a `forView=true` CDC while the expected change list still has the tombstone marked as a delete, tripping `CDCBaseIT.verifyChangesViaSCN` with `ComparisonFailure expected:<delete> but was:<upsert> in CDCQueryIT.testSelectGeneric[forView=true, encodingScheme=TWO_BYTE_QUALIFIERS, multitenant=false, tableSaltBuckets=null, withSchemaName=false, caseSensitiveNames=false]`. The fix gates the forced-delete branch on `mutatedRows.contains(rows.get(j))` so a delete is only ever forced on a row that has already been upserted.