### PR TITLE
PHOENIX-7836 UncoveredGlobalIndexRegionScanner2IT relax per-test query timeout

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/UncoveredGlobalIndexRegionScanner2IT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/UncoveredGlobalIndexRegionScanner2IT.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -930,7 +931,14 @@ public class UncoveredGlobalIndexRegionScanner2IT extends BaseTest {
 
   @Test
   public void testCount() throws Exception {
-    try (Connection conn = DriverManager.getConnection(getUrl())) {
+    // testCount upserts 100k rows and then runs an aggregate count whose region scans are
+    // forced to go through the post-dummy region-move callback. On slower CI/dev hardware the
+    // 5-minute default phoenix.query.timeoutMs from QueryServicesTestImpl is not enough to
+    // complete the scan, especially for the uncovered=false,salted=true parameterization.
+    // Allow a longer timeout for this individual test connection.
+    Properties props = new Properties();
+    props.setProperty(QueryServices.THREAD_TIMEOUT_MS_ATTRIB, Long.toString(20L * 60L * 1000L));
+    try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
       String dataTableName = generateUniqueName();
       conn.createStatement().execute(
         "CREATE TABLE " + dataTableName + "(k1 BIGINT NOT NULL, k2 BIGINT NOT NULL, v1 INTEGER, "


### PR DESCRIPTION
`testCount` upserts 100,000 rows, builds an uncovered global index, sets `phoenix.scanner.disable.uncovered.regions.move=false`, and runs an aggregate count that forces every region scan through the post-dummy region-move callback. For the `uncovered=false, salted=true` parameterization the per-region work is heavier and the global `phoenix.query.timeoutMs` set by `QueryServicesTestImpl` to `DEFAULT_THREAD_TIMEOUT_MS` (5 minutes) can be exhausted. The fix overrides the timeout only for this test's connection by passing a `Properties` with `phoenix.query.timeoutMs = 20 * 60 * 1000`.