### PR TITLE
PHOENIX-7837 SecureUserConnectionsIT install permissive auth_to_local rules

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/SecureUserConnectionsIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/SecureUserConnectionsIT.java
@@ -103,7 +103,17 @@ public class SecureUserConnectionsIT {
     conf.setBoolean(User.HBASE_SECURITY_AUTHORIZATION_CONF_KEY, true);
     conf.set(HConstants.CLIENT_CONNECTION_REGISTRY_IMPL_CONF_KEY,
       ZKConnectionInfo.ZK_REGISTRY_NAME);
+    // Install permissive auth_to_local rules so that this test can run on a developer
+    // workstation that has an active Kerberos TGT for an unrelated realm. Without this,
+    // ConnectionInfo.create -> User.getCurrent -> UGI.getLoginUser will commit the OS-level
+    // Kerberos principal through HadoopLoginModule, and KerberosName.getShortName will throw
+    // NoMatchingRule because the test's default realm ("EXAMPLE.COM", set by
+    // updateDefaultRealm) does not match the developer's real-world principal.
+    conf.set("hadoop.security.auth_to_local", "RULE:[1:$1] RULE:[2:$1] DEFAULT");
     UserGroupInformation.setConfiguration(conf);
+    // Belt-and-suspenders: KerberosName caches its rules statically across tests, so make
+    // sure our permissive rules are the ones in effect.
+    KerberosName.setRules("RULE:[1:$1] RULE:[2:$1] DEFAULT");
 
     // Clear the cached singletons so we can inject our own.
     InstanceResolver.clearSingletons();


### PR DESCRIPTION
`SecureUserConnectionsIT` brings up an embedded MiniKDC, sets `hadoop.security.authentication=kerberos` and the default realm to `EXAMPLE.COM`, but never installs any `hadoop.security.auth_to_local` rules. On a developer workstation holding an active TGT for an unrelated realm `KerberosName.getShortName` has no matching rule to the unrelated realm and the test fails with `KerberosAuthException`. The fix installs permissive rules `RULE:[1:$1] RULE:[2:$1] DEFAULT` in the test's `Configuration` and also sets them statically on `KerberosName`.