### PR TITLE
PHOENIX-7848. Use ZK TLS properties from HBase config if present

### DIFF
--- a/bin/phoenix_utils.py
+++ b/bin/phoenix_utils.py
@@ -129,20 +129,27 @@ def setPath():
             # Try to provide something valid
             hbase_conf_dir = '.'
 
-    global zk_tls_args
-    root = ET.parse(os.path.join(hbase_conf_dir, "hbase-site.xml")).getroot()
-    zk_hbase_prefix = "hbase.zookeeper.property."
-    zkcfg = {
-        prop.find("name").text[len(zk_hbase_prefix):]: prop.find("value").text
-        for prop in root.findall("property")
-        if prop.find("name").text.startswith(zk_hbase_prefix)
-    }
-    if zkcfg.get('client.secure').lower() == 'true':
-        zk_tls_args = '-Dzookeeper.client.secure=true ' + \
-            '-Dzookeeper.clientCnxnSocket=' + zkcfg['clientCnxnSocket'] + ' ' + \
-            '-Dzookeeper.ssl.trustStore.location=' + zkcfg['ssl.trustStore.location'] + ' ' + \
-            '-Dzookeeper.ssl.trustStore.type=' + zkcfg['ssl.trustStore.type'] + ' ' + \
-            '-Dzookeeper.ssl.trustStore.password=' + zkcfg['ssl.trustStore.password'] + ' '
+    hbase_site_file = os.path.join(hbase_conf_dir, "hbase-site.xml")
+    try:
+        global zk_tls_args
+        root = ET.parse(hbase_site_file).getroot()
+        zk_hbase_prefix = "hbase.zookeeper.property."
+        zkcfg = {
+            prop.find("name").text[len(zk_hbase_prefix):]: prop.find("value").text
+            for prop in root.findall("property")
+            if prop.find("name").text.startswith(zk_hbase_prefix)
+        }
+        if 'client.secure' in zkcfg and zkcfg.get('client.secure').lower() == 'true':
+            zk_tls_args = '-Dzookeeper.client.secure=true ' + \
+                '-Dzookeeper.clientCnxnSocket=' + zkcfg['clientCnxnSocket'] + ' ' + \
+                '-Dzookeeper.ssl.trustStore.location=' + zkcfg['ssl.trustStore.location'] + ' ' + \
+                '-Dzookeeper.ssl.trustStore.type=' + zkcfg['ssl.trustStore.type'] + ' ' + \
+                '-Dzookeeper.ssl.trustStore.password=' + zkcfg['ssl.trustStore.password'] + ' '
+    except Exception as e:
+        sys.exit(
+            "ERROR: Failed to parse ZooKeeper TLS properties from '%s': %s"
+            % (hbase_site_file, repr(e))
+        )
 
     global current_dir
     current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/bin/phoenix_utils.py
+++ b/bin/phoenix_utils.py
@@ -25,6 +25,7 @@ import fnmatch
 import re
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 
 def find(pattern, classPaths):
     paths = classPaths.split(os.pathsep)
@@ -125,6 +126,21 @@ def setPath():
         else:
             # Try to provide something valid
             hbase_conf_dir = '.'
+
+    global zk_tls_args
+    root = ET.parse(os.path.join(hbase_conf_dir, "hbase-site.xml")).getroot()
+    zk_hbase_prefix = "hbase.zookeeper.property."
+    zkcfg = {
+        prop.find("name").text[len(zk_hbase_prefix):]: prop.find("value").text
+        for prop in root.findall("property")
+        if prop.find("name").text.startswith(zk_hbase_prefix)
+    }
+    if zkcfg.get('client.secure').lower() == 'true':
+        zk_tls_args = '-Dzookeeper.client.secure=true ' + \
+            '-Dzookeeper.clientCnxnSocket=' + zkcfg['clientCnxnSocket'] + ' ' + \
+            '-Dzookeeper.ssl.trustStore.location=' + zkcfg['ssl.trustStore.location'] + ' ' + \
+            '-Dzookeeper.ssl.trustStore.type=' + zkcfg['ssl.trustStore.type'] + ' ' + \
+            '-Dzookeeper.ssl.trustStore.password=' + zkcfg['ssl.trustStore.password'] + ' '
 
     global current_dir
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -316,6 +332,7 @@ if __name__ == "__main__":
     setPath()
     print("phoenix_class_path:", phoenix_class_path)
     print("hbase_conf_dir:", hbase_conf_dir)
+    print("zk_tls_args:", zk_tls_args)
     print("current_dir:", current_dir)
     print("phoenix_embedded_jar_path:", phoenix_embedded_jar_path)
     print("phoenix_client_embedded_jar:", phoenix_client_embedded_jar)

--- a/bin/phoenix_utils.py
+++ b/bin/phoenix_utils.py
@@ -27,6 +27,8 @@ import subprocess
 import sys
 import xml.etree.ElementTree as ET
 
+zk_tls_args = ""
+
 def find(pattern, classPaths):
     paths = classPaths.split(os.pathsep)
 

--- a/bin/sqlline.py
+++ b/bin/sqlline.py
@@ -94,6 +94,7 @@ opts = os.getenv('PHOENIX_OPTS') or os.getenv('HBASE_OPTS') or ''
 
 java_cmd = phoenix_utils.java + ' ' + phoenix_utils.jvm_module_flags + \
     ' ' + opts + \
+    ' ' + getattr(phoenix_utils, "zk_tls_args", "") + \
     ' -cp "' + phoenix_utils.hbase_conf_dir + os.pathsep + \
     phoenix_utils.hadoop_conf + os.pathsep + \
     phoenix_utils.sqlline_with_deps_jar + os.pathsep + \

--- a/bin/sqlline.py
+++ b/bin/sqlline.py
@@ -94,7 +94,7 @@ opts = os.getenv('PHOENIX_OPTS') or os.getenv('HBASE_OPTS') or ''
 
 java_cmd = phoenix_utils.java + ' ' + phoenix_utils.jvm_module_flags + \
     ' ' + opts + \
-    ' ' + getattr(phoenix_utils, "zk_tls_args", "") + \
+    ' ' + phoenix_utils.zk_tls_args + \
     ' -cp "' + phoenix_utils.hbase_conf_dir + os.pathsep + \
     phoenix_utils.hadoop_conf + os.pathsep + \
     phoenix_utils.sqlline_with_deps_jar + os.pathsep + \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Parse ZooKeeper TLS properties from `hbase-site.xml` and add them to `sqlline` command line args.


### Why are the changes needed?

Phoenix `sqlline` thick client is unable to connect to TLS-only ZooKeeper ensemble.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Locally.

### Was this patch authored or co-authored using generative AI tooling?

No.