### PR TITLE
PHOENIX-7855 Fix for flapper root cause: java.lang.IllegalArgumentException: bound must be positive

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
@@ -703,7 +703,7 @@ public class CDCQueryIT extends CDCBaseIT {
         }
       }
       Random rand = new Random();
-      int randMinTSpos = rand.nextInt(lastDeletionTSpos - 1);
+      int randMinTSpos = rand.nextInt(Math.max(1, lastDeletionTSpos - 1));
       int randMaxTSpos =
         randMinTSpos + 1 + rand.nextInt(uniqueTimestamps.size() - (randMinTSpos + 1));
       verifyChangesViaSCN(tenantId, conn, cdcFullName, pkColumns, datatableName, dataColumns,


### PR DESCRIPTION
[PHOENIX-7855](https://issues.apache.org/jira/browse/PHOENIX-7855)

Tested by applying this along with #2450 and #2451 on my local workspace and ran for up to 50 iterations in a loop and didn't encounter any failure.

Generated-by: Claude Code 2.1.128 with Model: us.anthropic.claude-opus-4-6-v1[1m]