### PR TITLE
PHOENIX-5236 Multiple dynamic columns in WHERE clause is not working

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/WhereCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/WhereCompiler.java
@@ -595,6 +595,7 @@ public class WhereCompiler {
           break;
         case MULTIPLE:
           filter = isPossibleToUseEncodedCQFilter(encodingScheme, storageScheme)
+              && !ScanUtil.hasDynamicColumns(table)
             ? new MultiEncodedCQKeyValueComparisonFilter(whereClause, encodingScheme, allCFs,
               essentialCF)
             : (disambiguateWithFamily

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/DynamicColumnIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/DynamicColumnIT.java
@@ -273,4 +273,138 @@ public class DynamicColumnIT extends ParallelStatsDisabledIT {
     }
   }
 
+  /**
+   * Test that multiple dynamic columns in a WHERE clause work correctly on a table
+   * with column encoding enabled (the default). Regression test for PHOENIX-5236.
+   */
+  @Test
+  public void testMultipleDynamicColumnsInWhere() throws Exception {
+    String tableName = generateUniqueName();
+    String ddl = "create table " + tableName
+      + " (id VARCHAR PRIMARY KEY, name VARCHAR)";
+    try (Connection conn = DriverManager.getConnection(getUrl())) {
+      conn.createStatement().execute(ddl);
+
+      // Upsert rows with dynamic columns
+      String dml = "UPSERT INTO " + tableName
+        + "(id, name, city VARCHAR, department VARCHAR, age INTEGER)"
+        + " VALUES (?, ?, ?, ?, ?)";
+      try (PreparedStatement stmt = conn.prepareStatement(dml)) {
+        stmt.setString(1, "1");
+        stmt.setString(2, "John");
+        stmt.setString(3, "Chennai");
+        stmt.setString(4, "Engineering");
+        stmt.setInt(5, 30);
+        stmt.executeUpdate();
+
+        stmt.setString(1, "2");
+        stmt.setString(2, "Jane");
+        stmt.setString(3, "Mumbai");
+        stmt.setString(4, "Marketing");
+        stmt.setInt(5, 28);
+        stmt.executeUpdate();
+
+        stmt.setString(1, "3");
+        stmt.setString(2, "Bob");
+        stmt.setString(3, "Chennai");
+        stmt.setString(4, "Marketing");
+        stmt.setInt(5, 35);
+        stmt.executeUpdate();
+
+        conn.commit();
+      }
+
+      // Single dynamic column in WHERE - baseline
+      String query = "SELECT id, name FROM " + tableName
+        + " (city VARCHAR) WHERE city = ?";
+      try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        stmt.setString(1, "Chennai");
+        ResultSet rs = stmt.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("1", rs.getString(1));
+        assertEquals("John", rs.getString(2));
+        assertTrue(rs.next());
+        assertEquals("3", rs.getString(1));
+        assertEquals("Bob", rs.getString(2));
+        assertFalse(rs.next());
+      }
+
+      // Multiple dynamic columns in WHERE - PHOENIX-5236 bug
+      query = "SELECT id, name FROM " + tableName
+        + " (city VARCHAR, department VARCHAR, age INTEGER)"
+        + " WHERE city = ? AND department = ?";
+      try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        stmt.setString(1, "Chennai");
+        stmt.setString(2, "Engineering");
+        ResultSet rs = stmt.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("1", rs.getString(1));
+        assertEquals("John", rs.getString(2));
+        assertFalse(rs.next());
+      }
+
+      // Dynamic columns compared to each other
+      query = "SELECT id, name FROM " + tableName
+        + " (city VARCHAR, department VARCHAR)"
+        + " WHERE city = department";
+      try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        ResultSet rs = stmt.executeQuery();
+        assertFalse(rs.next());
+      }
+
+      // 3 dynamic columns in WHERE
+      query = "SELECT id, name FROM " + tableName
+        + " (city VARCHAR, department VARCHAR, age INTEGER)"
+        + " WHERE city = ? AND department = ? AND age > ?";
+      try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        stmt.setString(1, "Chennai");
+        stmt.setString(2, "Engineering");
+        stmt.setInt(3, 25);
+        ResultSet rs = stmt.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("1", rs.getString(1));
+        assertEquals("John", rs.getString(2));
+        assertFalse(rs.next());
+      }
+
+      // 1 schema column + 2 dynamic columns in WHERE (mixed)
+      query = "SELECT id FROM " + tableName
+        + " (city VARCHAR, department VARCHAR)"
+        + " WHERE name = ? AND city = ? AND department = ?";
+      try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        stmt.setString(1, "John");
+        stmt.setString(2, "Chennai");
+        stmt.setString(3, "Engineering");
+        ResultSet rs = stmt.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("1", rs.getString(1));
+        assertFalse(rs.next());
+      }
+
+      // 2 dynamic + 1 schema column in WHERE (mixed, different order)
+      query = "SELECT id FROM " + tableName
+        + " (city VARCHAR, age INTEGER)"
+        + " WHERE city = ? AND age > ? AND name = ?";
+      try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        stmt.setString(1, "Chennai");
+        stmt.setInt(2, 30);
+        stmt.setString(3, "Bob");
+        ResultSet rs = stmt.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("3", rs.getString(1));
+        assertFalse(rs.next());
+      }
+
+      // No dynamic columns in WHERE (schema-only, baseline - no regression)
+      query = "SELECT id FROM " + tableName + " WHERE name = ?";
+      try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        stmt.setString(1, "Jane");
+        ResultSet rs = stmt.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("2", rs.getString(1));
+        assertFalse(rs.next());
+      }
+    }
+  }
+
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/compile/WhereCompilerTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/compile/WhereCompilerTest.java
@@ -59,7 +59,10 @@ import org.apache.phoenix.expression.KeyValueColumnExpression;
 import org.apache.phoenix.expression.LiteralExpression;
 import org.apache.phoenix.expression.RowKeyColumnExpression;
 import org.apache.phoenix.expression.function.SubstrFunction;
+import org.apache.phoenix.filter.MultiCQKeyValueComparisonFilter;
+import org.apache.phoenix.filter.MultiEncodedCQKeyValueComparisonFilter;
 import org.apache.phoenix.filter.RowKeyComparisonFilter;
+import org.apache.phoenix.filter.SingleCQKeyValueComparisonFilter;
 import org.apache.phoenix.filter.SkipScanFilter;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
@@ -1179,6 +1182,132 @@ public class WhereCompilerTest extends BaseConnectionlessQueryTest {
         WhereCompiler.contains(getDNF(pconn, containedQueries[i]),
           getDNF(pconn, containingQueries[i])));
     }
+  }
+
+  // ===== PHOENIX-5236: Filter selection tests for dynamic columns =====
+
+  /**
+   * Test that a single dynamic column in WHERE uses SingleCQKeyValueComparisonFilter.
+   */
+  @Test
+  public void testSingleDynamicColumnFilterSelection() throws SQLException {
+    PhoenixConnection pconn =
+      DriverManager.getConnection(getUrl(), PropertiesUtil.deepCopy(TEST_PROPERTIES))
+        .unwrap(PhoenixConnection.class);
+    String tableName = "T_" + generateUniqueName();
+    pconn.createStatement().execute(
+      "CREATE TABLE " + tableName + " (id VARCHAR PRIMARY KEY, name VARCHAR)");
+
+    String query = "SELECT id FROM " + tableName
+      + " (city VARCHAR) WHERE city = 'Chennai'";
+    PhoenixPreparedStatement pstmt = new PhoenixPreparedStatement(pconn, query);
+    QueryPlan plan = pstmt.optimizeQuery();
+    Scan scan = plan.getContext().getScan();
+    Filter filter = scan.getFilter();
+    assertTrue("Expected SingleCQKeyValueComparisonFilter for single dynamic column in WHERE, got: "
+      + (filter == null ? "null" : filter.getClass().getSimpleName()),
+      filter instanceof SingleCQKeyValueComparisonFilter);
+  }
+
+  /**
+   * Test that multiple dynamic columns in WHERE uses MultiCQKeyValueComparisonFilter
+   * (not MultiEncodedCQKeyValueComparisonFilter) on a table with encoding enabled.
+   * This is the regression test for PHOENIX-5236.
+   */
+  @Test
+  public void testMultipleDynamicColumnsFilterSelection() throws SQLException {
+    PhoenixConnection pconn =
+      DriverManager.getConnection(getUrl(), PropertiesUtil.deepCopy(TEST_PROPERTIES))
+        .unwrap(PhoenixConnection.class);
+    String tableName = "T_" + generateUniqueName();
+    pconn.createStatement().execute(
+      "CREATE TABLE " + tableName + " (id VARCHAR PRIMARY KEY, name VARCHAR)");
+
+    String query = "SELECT id FROM " + tableName
+      + " (city VARCHAR, department VARCHAR) WHERE city = 'Chennai' AND department = 'Engineering'";
+    PhoenixPreparedStatement pstmt = new PhoenixPreparedStatement(pconn, query);
+    QueryPlan plan = pstmt.optimizeQuery();
+    Scan scan = plan.getContext().getScan();
+    Filter filter = scan.getFilter();
+    assertTrue(
+      "Expected MultiCQKeyValueComparisonFilter for multiple dynamic columns in WHERE, got: "
+        + (filter == null ? "null" : filter.getClass().getSimpleName()),
+      filter instanceof MultiCQKeyValueComparisonFilter);
+  }
+
+  /**
+   * Test that multiple schema-defined columns in WHERE still uses
+   * MultiEncodedCQKeyValueComparisonFilter on a table with encoding enabled.
+   */
+  @Test
+  public void testMultipleSchemaColumnsStillUsesEncodedFilter() throws SQLException {
+    PhoenixConnection pconn =
+      DriverManager.getConnection(getUrl(), PropertiesUtil.deepCopy(TEST_PROPERTIES))
+        .unwrap(PhoenixConnection.class);
+    String tableName = "T_" + generateUniqueName();
+    pconn.createStatement().execute(
+      "CREATE TABLE " + tableName
+        + " (id VARCHAR PRIMARY KEY, city VARCHAR, department VARCHAR)");
+
+    String query = "SELECT id FROM " + tableName
+      + " WHERE city = 'Chennai' AND department = 'Engineering'";
+    PhoenixPreparedStatement pstmt = newPreparedStatement(pconn, query);
+    QueryPlan plan = pstmt.optimizeQuery();
+    Scan scan = plan.getContext().getScan();
+    Filter filter = scan.getFilter();
+    assertTrue(
+      "Expected MultiEncodedCQKeyValueComparisonFilter for schema columns in WHERE, got: "
+        + (filter == null ? "null" : filter.getClass().getSimpleName()),
+      filter instanceof MultiEncodedCQKeyValueComparisonFilter);
+  }
+
+  /**
+   * Test that a table with COLUMN_ENCODED_BYTES=NONE uses MultiCQKeyValueComparisonFilter
+   * for multiple columns (regardless of whether they are dynamic).
+   */
+  @Test
+  public void testNonEncodedTableUsesMultiCQFilter() throws SQLException {
+    PhoenixConnection pconn =
+      DriverManager.getConnection(getUrl(), PropertiesUtil.deepCopy(TEST_PROPERTIES))
+        .unwrap(PhoenixConnection.class);
+    String tableName = "T_" + generateUniqueName();
+    pconn.createStatement().execute(
+      "CREATE TABLE " + tableName
+        + " (id VARCHAR PRIMARY KEY, city VARCHAR, department VARCHAR) COLUMN_ENCODED_BYTES=NONE");
+
+    String query = "SELECT id FROM " + tableName
+      + " WHERE city = 'Chennai' AND department = 'Engineering'";
+    PhoenixPreparedStatement pstmt = newPreparedStatement(pconn, query);
+    QueryPlan plan = pstmt.optimizeQuery();
+    Scan scan = plan.getContext().getScan();
+    Filter filter = scan.getFilter();
+    assertTrue(
+      "Expected MultiCQKeyValueComparisonFilter for non-encoded table, got: "
+        + (filter == null ? "null" : filter.getClass().getSimpleName()),
+      filter instanceof MultiCQKeyValueComparisonFilter);
+  }
+
+  /**
+   * Test that a single schema column in WHERE uses SingleCQKeyValueComparisonFilter
+   * (baseline behavior unchanged).
+   */
+  @Test
+  public void testSingleSchemaColumnFilterSelection() throws SQLException {
+    PhoenixConnection pconn =
+      DriverManager.getConnection(getUrl(), PropertiesUtil.deepCopy(TEST_PROPERTIES))
+        .unwrap(PhoenixConnection.class);
+    String tableName = "T_" + generateUniqueName();
+    pconn.createStatement().execute(
+      "CREATE TABLE " + tableName + " (id VARCHAR PRIMARY KEY, city VARCHAR)");
+
+    String query = "SELECT id FROM " + tableName + " WHERE city = 'Chennai'";
+    PhoenixPreparedStatement pstmt = newPreparedStatement(pconn, query);
+    QueryPlan plan = pstmt.optimizeQuery();
+    Scan scan = plan.getContext().getScan();
+    Filter filter = scan.getFilter();
+    assertTrue("Expected SingleCQKeyValueComparisonFilter for single schema column in WHERE, got: "
+      + (filter == null ? "null" : filter.getClass().getSimpleName()),
+      filter instanceof SingleCQKeyValueComparisonFilter);
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://phoenix.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] PHOENIX-XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes, and prefix it with the JIRA id, e.g. 'PHOENIX-XXXX Your PR title ...'.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Added a ScanUtil.hasDynamicColumns(table) check in WhereCompiler.setScanFilter() so that when the WHERE clause references multiple columns and the table has dynamic columns, Phoenix falls back to MultiCQKeyValueComparisonFilter (HashMap-based, raw byte comparison) instead of MultiEncodedCQKeyValueComparisonFilter (array-based, expects encoded integer qualifiers).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When a table uses column encoding (the default) and the WHERE clause filters on multiple dynamic columns, Phoenix selects MultiEncodedCQKeyValueComparisonFilter. This filter calls encodingScheme.decode() on each column qualifier, expecting a 2-4 byte encoded integer. 
Dynamic columns use the actual column name as the qualifier (e.g., "POPULATION" = 10 bytes), causing InvalidQualifierBytesException: Expected length: 2. Actual: 10. 
Single dynamic column in WHERE works fine because SingleCQKeyValueComparisonFilter uses raw byte comparison. The workaround was COLUMN_ENCODED_BYTES=NONE on table creation, which defeats the purpose of encoding.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Phoenix versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Queries with multiple dynamic columns in the WHERE clause now work correctly on tables with column encoding enabled (the default). Previously these queries threw InvalidQualifierBytesException. No workaround (COLUMN_ENCODED_BYTES=NONE) is needed anymore

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


5 new unit tests in WhereCompilerTest verifying correct filter selection:

1. Single dynamic column → SingleCQKeyValueComparisonFilter
2. Multiple dynamic columns → MultiCQKeyValueComparisonFilter (not Encoded)
3. Multiple schema columns → MultiEncodedCQKeyValueComparisonFilter (no regression)
4. Non-encoded table → MultiCQKeyValueComparisonFilter
5. Single schema column → SingleCQKeyValueComparisonFilter

1 new integration test in DynamicColumnIT covering 7 scenarios:
1. No dynamic columns (baseline)
2. 1 dynamic column in WHERE
3. 2 dynamic columns in WHERE
4. 3 dynamic columns in WHERE
5. 1 schema + 2 dynamic (mixed)
6. 2 dynamic + 1 schema (mixed)
7. Dynamic columns compared to each other


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes. This patch was co-authored with Claude Code opus-4.6.