### PR TITLE
PHOENIX-7856 User defined time zone doesn't work for timestamp filed …

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/DateUtil.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/DateUtil.java
@@ -220,25 +220,51 @@ public class DateUtil {
   }
 
   /**
-   * Parses the timestsamp string in the UTC time zone.
+   * Parses the timestamp string in the UTC time zone.
    * @param timestampValue timestamp string in UTC
    * @return Timestamp parsed in UTC
    */
   public static Timestamp parseTimestamp(String timestampValue) {
-    Timestamp timestamp = new Timestamp(parseDateTime(timestampValue));
+    return parseTimestamp(timestampValue, null);
+  }
+
+  /**
+   * Parses the timestamp string with the given parser.
+   * @param timestampValue timestamp string
+   * @param parser Parser with user defined time zone.
+   * @return Timestamp parsed by the given parser, or parsed in UTC if parser is null.
+   */
+  public static Timestamp parseTimestamp(String timestampValue, DateTimeParser parser) {
+    Timestamp timestamp;
+    if (parser == null) {
+      timestamp = new Timestamp(parseDateTime(timestampValue));
+    } else {
+      timestamp = new Timestamp(parser.parseDateTime(timestampValue));
+    }
+    int nanos = getNanosFromTimestamp(timestampValue);
+    if (nanos > -1) {
+      // First clear existing nanos (default is 0), then set the new nanos value
+      // to avoid accumulating nanos from previous operations
+      timestamp.setNanos(0);
+      timestamp.setNanos(nanos);
+    }
+    return timestamp;
+  }
+
+  private static int getNanosFromTimestamp(String timestampValue) {
+    int nanos = -1;
     int period = timestampValue.indexOf('.');
     if (period > 0) {
       String nanosStr = timestampValue.substring(period + 1);
       if (nanosStr.length() > 9) throw new IllegalDataException("nanos > 999999999 or < 0");
       if (nanosStr.length() > 3) {
-        int nanos = Integer.parseInt(nanosStr);
+        nanos = Integer.parseInt(nanosStr);
         for (int i = 0; i < 9 - nanosStr.length(); i++) {
           nanos *= 10;
         }
-        timestamp.setNanos(nanos);
       }
     }
-    return timestamp;
+    return nanos;
   }
 
   /**

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/csv/CsvUpsertExecutor.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/csv/CsvUpsertExecutor.java
@@ -162,7 +162,7 @@ public class CsvUpsertExecutor extends UpsertExecutor<CSVRecord, String> {
         return null;
       }
       if (dataType == PTimestamp.INSTANCE) {
-        return DateUtil.parseTimestamp(input);
+        return DateUtil.parseTimestamp(input, dateTimeParser);
       }
       if (dateTimeParser != null) {
         long epochTime = dateTimeParser.parseDateTime(input);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/json/JsonUpsertExecutor.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/json/JsonUpsertExecutor.java
@@ -187,7 +187,7 @@ public class JsonUpsertExecutor extends UpsertExecutor<Map<?, ?>, Object> {
         return null;
       }
       if (dataType == PTimestamp.INSTANCE) {
-        return DateUtil.parseTimestamp(input.toString());
+        return DateUtil.parseTimestamp(input.toString(), dateTimeParser);
       }
       if (dateTimeParser != null && input instanceof String) {
         final String s = (String) input;

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/DateUtilTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/DateUtilTest.java
@@ -17,42 +17,26 @@
  */
 package org.apache.phoenix.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
+import org.apache.phoenix.schema.IllegalDataException;
+import org.apache.phoenix.schema.types.PDate;
+import org.apache.phoenix.schema.types.PTime;
+import org.apache.phoenix.schema.types.PTimestamp;
+import org.junit.Test;
 
-import java.io.IOException;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
 import java.util.TimeZone;
 
-import org.apache.phoenix.query.QueryServices;
-import org.apache.phoenix.util.ColumnInfo;
-import org.apache.phoenix.util.DateUtil;
-import org.apache.phoenix.schema.IllegalDataException;
-import org.apache.phoenix.schema.types.PDate;
-import org.apache.phoenix.schema.types.PInteger;
-import org.apache.phoenix.schema.types.PIntegerArray;
-import org.apache.phoenix.schema.types.PTime;
-import org.apache.phoenix.schema.types.PTimestamp;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-
-import org.apache.phoenix.thirdparty.com.google.common.base.Joiner;
-import org.apache.phoenix.thirdparty.com.google.common.collect.Iterables;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test class for {@link DateUtil}

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/DateUtilTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/DateUtilTest.java
@@ -21,21 +21,38 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
+import java.io.IOException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
 import java.util.TimeZone;
+
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.util.ColumnInfo;
+import org.apache.phoenix.util.DateUtil;
 import org.apache.phoenix.schema.IllegalDataException;
 import org.apache.phoenix.schema.types.PDate;
+import org.apache.phoenix.schema.types.PInteger;
+import org.apache.phoenix.schema.types.PIntegerArray;
 import org.apache.phoenix.schema.types.PTime;
 import org.apache.phoenix.schema.types.PTimestamp;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.phoenix.thirdparty.com.google.common.base.Joiner;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Iterables;
 
 /**
  * Test class for {@link DateUtil}
@@ -351,5 +368,50 @@ public class DateUtilTest {
       java.sql.Timestamp.from(startOfWinter.atZone(ZoneOffset.UTC).toInstant());
     assertEquals(DateUtil.applyInputDisplacement(startOfWinterLocal, tz), startOfWinterDisplaced);
     assertEquals(DateUtil.applyOutputDisplacement(startOfWinterDisplaced, tz), startOfWinterLocal);
+  }
+
+  /**
+   * parseTimestamp should use the configured timezone from parser instead of hardcoded UTC.
+   * Test logic:
+   * 1. Create a DateTimeParser with Asia/Shanghai timezone
+   * 2. Parse timestamp string "2020-01-01 00:00:00.000" using the parser
+   * 3. Verify parsed epoch millis is 8 hours less than UTC parsed result
+   */
+  @Test
+  public void testParseTimestampWithCustomTimeZone() throws ParseException {
+    String tsStr = "2020-01-01 00:00:00.000";
+    java.util.TimeZone shanghaiZone = java.util.TimeZone.getTimeZone("Asia/Shanghai");
+
+    java.sql.Timestamp parsedTs = DateUtil.parseTimestamp(tsStr,
+      DateUtil.getDateTimeParser("yyyy-MM-dd HH:mm:ss.SSS", PTimestamp.INSTANCE, shanghaiZone.getID()));
+
+    // DateUtil.parseTimestamp() parses using UTC by default when no parser is provided
+    java.sql.Timestamp utcTs = DateUtil.parseTimestamp(tsStr);
+
+    // Asia/Shanghai is UTC+8, so the parsed epoch time should be 8 hours less than UTC result
+    long expectedMillis = utcTs.getTime() - (8L * 60 * 60 * 1000);
+
+    assertEquals("Timestamp should be parsed using configured timezone Asia/Shanghai", expectedMillis, parsedTs.getTime());
+  }
+
+  /**
+   * Verifies that nanosecond precision is correctly preserved under a custom timezone
+   */
+  @Test
+  public void testParseTimestampWithCustomTimeZoneAndNanos() throws ParseException {
+    String tsStr = "2020-01-01 00:00:00.123"; // Only 3 nanoseconds
+    java.util.TimeZone shanghaiZone = java.util.TimeZone.getTimeZone("Asia/Shanghai");
+
+    java.sql.Timestamp parsedTs = DateUtil.parseTimestamp(tsStr,
+      DateUtil.getDateTimeParser("yyyy-MM-dd HH:mm:ss.SSS", PTimestamp.INSTANCE, shanghaiZone.getID()));
+
+    // DateUtil.parseTimestamp() parses using UTC by default when no parser is provided
+    java.sql.Timestamp utcTs = DateUtil.parseTimestamp(tsStr);
+
+    // Asia/Shanghai is UTC+8, so the parsed epoch time should be 8 hours less than UTC result
+    long expectedMillis = utcTs.getTime() - (8L * 60 * 60 * 1000);
+
+    assertEquals("Epoch millis should reflect Asia/Shanghai timezone", expectedMillis, parsedTs.getTime());
+    assertEquals("Nanos should be preserved correctly", 123000000, parsedTs.getNanos());
   }
 }


### PR DESCRIPTION
…in CSVBulkload

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://phoenix.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] PHOENIX-XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes, and prefix it with the JIRA id, e.g. 'PHOENIX-XXXX Your PR title ...'.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
 a) Refactor DateUtil.parseTimestamp to accept an optional DateTimeParser parameter,
     enabling custom timezone-aware timestamp parsing. The nanoseconds extraction logic
     was isolated into a separate private method to avoid duplication across code paths.
  b) Update CsvUpsertExecutor and JsonUpsertExecutor to pass the user-defined
     DateTimeParser into DateUtil.parseTimestamp, so CSV/JSON upsert operations respect
     configured timezone settings for timestamp columns.
  c) Add unit tests for custom timezone (GMT+8), and nanoseconds preservation.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The original parseTimestamp always forced UTC timezone, ignoring any user-defined timezone parser configuration. This caused incorrect timestamp values when importing data via CSV/JSON from non-UTC timezones. The refactored method now respects the DateTimeParser's timezone when provided, while maintaining backward compatibility by falling back to UTC when the parser is null.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Phoenix versions or within the unreleased branches such as master.
If no, write 'No'.
-->
After this change, CSV and JSON upsert operations will correctly interpret timestamp values according to the configured timezone parser instead of always  treating them as UTC. Users who previously relied on the UTC-only behavior may need to adjust their input data or explicitly set the timezone configuration.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1.  Added unit tests in DateUtilTest to test timestamp parsing with GMT+8
2. Functional test on local

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: OpenCode 1.15.5 + GLM-4.7 
