### PR TITLE
PHOENIX-7873: Incorporate HBASE-29974 filter seek hints (compat-2.6.6 module)

### DIFF
--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -289,6 +289,11 @@
           <artifactId>phoenix-hbase-compat-2.6.4</artifactId>
           <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.apache.phoenix</groupId>
+          <artifactId>phoenix-hbase-compat-2.6.6</artifactId>
+          <version>${project.version}</version>
+        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/phoenix-core-client/pom.xml
+++ b/phoenix-core-client/pom.xml
@@ -299,6 +299,9 @@
                     || ("${hbase.compat.version}".equals("2.6.4")
                       &amp;&amp; hbaseMinor == 6
                       &amp;&amp; hbasePatch &gt;=4)
+                    || ("${hbase.compat.version}".equals("2.6.6")
+                      &amp;&amp; hbaseMinor == 6
+                      &amp;&amp; hbasePatch &gt;=6)
                   )</condition>
             </evaluateBeanshell>
           </rules>

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/filter/DelegateFilter.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/filter/DelegateFilter.java
@@ -21,14 +21,12 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.filter.Filter;
-import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.phoenix.compat.hbase.CompatDelegateFilter;
 
-public class DelegateFilter extends FilterBase {
-
-  protected Filter delegate = null;
+public class DelegateFilter extends CompatDelegateFilter {
 
   public DelegateFilter(Filter delegate) {
-    this.delegate = delegate;
+    super(delegate);
   }
 
   @Override

--- a/phoenix-core/src/test/java/org/apache/phoenix/filter/DelegateFilterStructureTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/filter/DelegateFilterStructureTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.filter;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compat.hbase.CompatDelegateFilter;
+import org.junit.Test;
+
+/**
+ * Locks in that Phoenix's delegating filters extend the compat base class, so that the
+ * version-gated getSkipHint / getHintForRejectedRow forwarding added in the 2.6.6 compat module is
+ * inherited. Intentionally structural only (no calls to the new Filter methods) so it compiles
+ * under every hbase.profile, including profiles whose HBase lacks those methods.
+ */
+public class DelegateFilterStructureTest {
+
+  @Test
+  public void delegateFilterExtendsCompatDelegateFilter() {
+    DelegateFilter f = new DelegateFilter(null);
+    assertTrue(f instanceof CompatDelegateFilter);
+  }
+
+  @Test
+  public void allVersionsIndexRebuildFilterInheritsCompatDelegateFilter() {
+    // AllVersionsIndexRebuildFilter(Filter originalFilter) — single-arg ctor.
+    AllVersionsIndexRebuildFilter f = new AllVersionsIndexRebuildFilter(null);
+    assertTrue(f instanceof CompatDelegateFilter);
+  }
+
+  @Test
+  public void unverifiedRowFilterInheritsCompatDelegateFilter() {
+    // UnverifiedRowFilter(Filter delegate, byte[] emptyCF, byte[] emptyCQ) — the ctor
+    // Preconditions-checks the two byte[] args are non-null, so pass real (empty) arrays.
+    // A null delegate is fine: it is only stored, not dereferenced, by the constructor.
+    UnverifiedRowFilter f = new UnverifiedRowFilter(null, Bytes.toBytes("cf"), Bytes.toBytes("cq"));
+    assertTrue(f instanceof CompatDelegateFilter);
+  }
+}

--- a/phoenix-hbase-compat-2.6.6/pom.xml
+++ b/phoenix-hbase-compat-2.6.6/pom.xml
@@ -28,7 +28,12 @@
   <description>Compatibility module for HBase 2.6.6+</description>
 
   <properties>
-    <!-- TODO(PHOENIX-7873): flip to 2.6.6-hadoop3 when HBase 2.6.6 GA is on Maven Central -->
+    <!--
+      TODO(PHOENIX-7873): HBase 2.6.6 is not yet GA on Maven Central. This compat module is
+      built against a locally-installed 2.6.6-SNAPSHOT until then. At GA: flip this value to
+      2.6.6-hadoop3 in lockstep with <hbase-2.6.runtime.version> in the root pom.xml, then
+      remove both TODO comments. Find them with: grep -rn 'TODO(PHOENIX-7873)'.
+    -->
     <hbase26.compat.version>2.6.6-SNAPSHOT</hbase26.compat.version>
   </properties>
 

--- a/phoenix-hbase-compat-2.6.6/pom.xml
+++ b/phoenix-hbase-compat-2.6.6/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.phoenix</groupId>
+    <artifactId>phoenix</artifactId>
+    <version>5.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>phoenix-hbase-compat-2.6.6</artifactId>
+  <name>Phoenix Hbase 2.6.6 compatibility</name>
+  <description>Compatibility module for HBase 2.6.6+</description>
+
+  <properties>
+    <!-- TODO(PHOENIX-7873): flip to 2.6.6-hadoop3 when HBase 2.6.6 GA is on Maven Central -->
+    <hbase26.compat.version>2.6.6-SNAPSHOT</hbase26.compat.version>
+  </properties>
+
+  <dependencies>
+    <!-- HBase dependencies -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Override parent dependencyManagement for transitive HBase dependencies -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-hadoop-compat</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-hadoop2-compat</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-protocol</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-protocol-shaded</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-zookeeper</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-metrics</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-metrics-api</artifactId>
+      <version>${hbase26.compat.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Build with -Dwithout.tephra fails without this -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/ByteStringer.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/ByteStringer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import com.google.protobuf.ByteString;
+
+// This has different signature in the HBase 2 and 3 modules
+// This only comes together after the maven-replacer plugin relocates all protobuf code.
+public class ByteStringer {
+
+  private ByteStringer() {
+  }
+
+  public static ByteString wrap(final byte[] array) {
+    return org.apache.hadoop.hbase.util.ByteStringer.wrap(array);
+  }
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatDelegateFilter.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatDelegateFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+
+public class CompatDelegateFilter extends FilterBase {
+  protected Filter delegate = null;
+
+  public CompatDelegateFilter(Filter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ReturnCode filterKeyValue(Cell v) throws IOException {
+    return delegate.filterKeyValue(v);
+  }
+
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatDelegateFilter.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatDelegateFilter.java
@@ -34,4 +34,14 @@ public class CompatDelegateFilter extends FilterBase {
     return delegate.filterKeyValue(v);
   }
 
+  @Override
+  public Cell getHintForRejectedRow(Cell firstRowCell) throws IOException {
+    return delegate.getHintForRejectedRow(firstRowCell);
+  }
+
+  @Override
+  public Cell getSkipHint(Cell skippedCell) throws IOException {
+    return delegate.getSkipHint(skippedCell);
+  }
+
 }

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatDelegateHTable.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatDelegateHTable.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.hbase.CompareOperator;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RowMutations;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+
+public abstract class CompatDelegateHTable implements Table {
+
+  protected final Table delegate;
+
+  public CompatDelegateHTable(Table delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public HTableDescriptor getTableDescriptor() throws IOException {
+    return delegate.getTableDescriptor();
+  }
+
+  @Override
+  public boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, CompareOp compareOp,
+    byte[] value, Put put) throws IOException {
+    return delegate.checkAndPut(row, family, qualifier, compareOp, value, put);
+  }
+
+  @Override
+  public boolean checkAndDelete(byte[] row, byte[] family, byte[] qualifier, CompareOp compareOp,
+    byte[] value, Delete delete) throws IOException {
+    return delegate.checkAndDelete(row, family, qualifier, compareOp, value, delete);
+  }
+
+  @Override
+  public boolean checkAndMutate(byte[] row, byte[] family, byte[] qualifier, CompareOp compareOp,
+    byte[] value, RowMutations mutation) throws IOException {
+    return delegate.checkAndMutate(row, family, qualifier, compareOp, value, mutation);
+  }
+
+  @Override
+  public boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, byte[] value, Put put)
+    throws IOException {
+    return delegate.checkAndPut(row, family, qualifier, value, put);
+  }
+
+  @Override
+  public boolean checkAndDelete(byte[] row, byte[] family, byte[] qualifier, byte[] value,
+    Delete delete) throws IOException {
+    return delegate.checkAndDelete(row, family, qualifier, value, delete);
+  }
+
+  @Override
+  public boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, CompareOperator op,
+    byte[] value, Put put) throws IOException {
+    return delegate.checkAndPut(row, family, qualifier, op, value, put);
+  }
+
+  @Override
+  public boolean checkAndDelete(byte[] row, byte[] family, byte[] qualifier, CompareOperator op,
+    byte[] value, Delete delete) throws IOException {
+    return delegate.checkAndDelete(row, family, qualifier, op, value, delete);
+  }
+
+  @Override
+  public boolean checkAndMutate(byte[] row, byte[] family, byte[] qualifier, CompareOperator op,
+    byte[] value, RowMutations mutation) throws IOException {
+    return delegate.checkAndMutate(row, family, qualifier, op, value, mutation);
+  }
+
+  @Override
+  public CheckAndMutateBuilder checkAndMutate(byte[] row, byte[] family) {
+    return delegate.checkAndMutate(row, family);
+  }
+
+  @Override
+  public void setOperationTimeout(int operationTimeout) {
+    delegate.setOperationTimeout(operationTimeout);
+  }
+
+  @Override
+  public int getOperationTimeout() {
+    return delegate.getOperationTimeout();
+  }
+
+  @Override
+  public int getRpcTimeout() {
+    return delegate.getRpcTimeout();
+  }
+
+  @Override
+  public void setRpcTimeout(int rpcTimeout) {
+    delegate.setRpcTimeout(rpcTimeout);
+  }
+
+  @Override
+  public int getReadRpcTimeout() {
+    return delegate.getReadRpcTimeout();
+  }
+
+  @Override
+  public void setReadRpcTimeout(int readRpcTimeout) {
+    delegate.setReadRpcTimeout(readRpcTimeout);
+  }
+
+  @Override
+  public int getWriteRpcTimeout() {
+    return delegate.getWriteRpcTimeout();
+  }
+
+  @Override
+  public void setWriteRpcTimeout(int writeRpcTimeout) {
+    delegate.setWriteRpcTimeout(writeRpcTimeout);
+  }
+
+  @Override
+  public boolean[] existsAll(List<Get> gets) throws IOException {
+    return delegate.existsAll(gets);
+  }
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatIndexHalfStoreFileReader.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatIndexHalfStoreFileReader.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.io.Reference;
+import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
+import org.apache.hadoop.hbase.io.hfile.ReaderContext;
+import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.regionserver.StoreFileReader;
+
+public class CompatIndexHalfStoreFileReader extends StoreFileReader {
+
+  public CompatIndexHalfStoreFileReader(final FileSystem fs, final CacheConfig cacheConf,
+    final Configuration conf, final ReaderContext readerContext, final HFileInfo hFileInfo, Path p,
+    Reference r) throws IOException {
+    super(readerContext, hFileInfo, cacheConf, new StoreFileInfo(conf, fs, fs.getFileStatus(p), r),
+      conf);
+  }
+
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatIndexedHLogReader.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatIndexedHLogReader.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import org.apache.hadoop.hbase.regionserver.wal.ProtobufWALStreamReader;
+
+public abstract class CompatIndexedHLogReader extends ProtobufWALStreamReader {
+
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatLocalIndexStoreFileScanner.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatLocalIndexStoreFileScanner.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.regionserver.StoreFileScanner;
+
+public class CompatLocalIndexStoreFileScanner extends StoreFileScanner {
+
+  public CompatLocalIndexStoreFileScanner(CompatIndexHalfStoreFileReader reader,
+    boolean cacheBlocks, boolean pread, boolean isCompaction, long readPt, long scannerOrder,
+    boolean canOptimizeForNonNullColumn) {
+    super(reader, reader.getScanner(cacheBlocks, pread, isCompaction), !isCompaction,
+      reader.getHFileReader().hasMVCCInfo(), readPt, scannerOrder, canOptimizeForNonNullColumn,
+      reader.getHFileReader().getDataBlockEncoding() == DataBlockEncoding.ROW_INDEX_V1);
+  }
+
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatOmidTransactionTable.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatOmidTransactionTable.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RowMutations;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+
+public abstract class CompatOmidTransactionTable implements Table {
+
+  @Override
+  public boolean checkAndPut(byte[] row, byte[] family, byte[] qualifier, CompareOp compareOp,
+    byte[] value, Put put) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean checkAndDelete(byte[] row, byte[] family, byte[] qualifier, CompareOp compareOp,
+    byte[] value, Delete delete) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean checkAndMutate(byte[] row, byte[] family, byte[] qualifier, CompareOp compareOp,
+    byte[] value, RowMutations mutation) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CheckAndMutateBuilder checkAndMutate(byte[] row, byte[] family) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatPagingFilter.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatPagingFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+
+public abstract class CompatPagingFilter extends FilterBase {
+  protected Filter delegate = null;
+
+  public CompatPagingFilter(Filter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ReturnCode filterKeyValue(Cell v) throws IOException {
+
+    if (delegate != null) {
+      return delegate.filterKeyValue(v);
+    }
+    return super.filterKeyValue(v);
+  }
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatPagingFilter.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatPagingFilter.java
@@ -37,4 +37,20 @@ public abstract class CompatPagingFilter extends FilterBase {
     }
     return super.filterKeyValue(v);
   }
+
+  @Override
+  public Cell getHintForRejectedRow(Cell firstRowCell) throws IOException {
+    if (delegate != null) {
+      return delegate.getHintForRejectedRow(firstRowCell);
+    }
+    return super.getHintForRejectedRow(firstRowCell);
+  }
+
+  @Override
+  public Cell getSkipHint(Cell skippedCell) throws IOException {
+    if (delegate != null) {
+      return delegate.getSkipHint(skippedCell);
+    }
+    return super.getSkipHint(skippedCell);
+  }
 }

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatPhoenixRpcScheduler.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatPhoenixRpcScheduler.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.ipc.CallRunner;
+import org.apache.hadoop.hbase.ipc.RpcScheduler;
+
+/**
+ * {@link RpcScheduler} that first checks to see if this is an index or metadata update before
+ * passing off the call to the delegate {@link RpcScheduler}.
+ */
+public abstract class CompatPhoenixRpcScheduler extends RpcScheduler {
+  protected RpcScheduler delegate;
+
+  @Override
+  public boolean dispatch(CallRunner task) {
+    try {
+      return compatDispatch(task);
+    } catch (Exception e) {
+      // This never happens with Hbase 2.5
+      throw new RuntimeException(e);
+    }
+  }
+
+  public int getActiveRpcHandlerCount() {
+    return delegate.getActiveRpcHandlerCount();
+  }
+
+  @Override
+  public int getActiveBulkLoadRpcHandlerCount() {
+    return delegate.getActiveBulkLoadRpcHandlerCount();
+  }
+
+  @Override
+  public int getBulkLoadQueueLength() {
+    return delegate.getBulkLoadQueueLength();
+  }
+
+  public abstract boolean compatDispatch(CallRunner task) throws IOException, InterruptedException;
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatScanMetrics.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatScanMetrics.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+import org.apache.hadoop.hbase.client.metrics.ScanMetricsRegionInfo;
+import org.apache.hadoop.hbase.client.metrics.ServerSideScanMetrics;
+
+public class CompatScanMetrics {
+
+  public static class RegionMetricsInfo {
+    private final String encodedRegionName;
+    private final String serverName;
+    private final Map<String, Long> metrics;
+
+    public RegionMetricsInfo(String encodedRegionName, String serverName,
+      Map<String, Long> metrics) {
+      this.encodedRegionName = encodedRegionName;
+      this.serverName = serverName;
+      this.metrics = metrics;
+    }
+
+    public String getEncodedRegionName() {
+      return encodedRegionName;
+    }
+
+    public String getServerName() {
+      return serverName;
+    }
+
+    public Map<String, Long> getMetrics() {
+      return metrics;
+    }
+  }
+
+  public static final String FS_READ_TIME_METRIC_NAME =
+    ServerSideScanMetrics.FS_READ_TIME_METRIC_NAME;
+  public static final String BYTES_READ_FROM_FS_METRIC_NAME =
+    ServerSideScanMetrics.BYTES_READ_FROM_FS_METRIC_NAME;
+  public static final String BYTES_READ_FROM_MEMSTORE_METRIC_NAME =
+    ServerSideScanMetrics.BYTES_READ_FROM_MEMSTORE_METRIC_NAME;
+  public static final String BYTES_READ_FROM_BLOCK_CACHE_METRIC_NAME =
+    ServerSideScanMetrics.BYTES_READ_FROM_BLOCK_CACHE_METRIC_NAME;
+  public static final String BLOCK_READ_OPS_COUNT_METRIC_NAME =
+    ServerSideScanMetrics.BLOCK_READ_OPS_COUNT_METRIC_NAME;
+  public static final String RPC_SCAN_PROCESSING_TIME_METRIC_NAME =
+    ServerSideScanMetrics.RPC_SCAN_PROCESSING_TIME_METRIC_NAME;
+  public static final String RPC_SCAN_QUEUE_WAIT_TIME_METRIC_NAME =
+    ServerSideScanMetrics.RPC_SCAN_QUEUE_WAIT_TIME_METRIC_NAME;
+
+  private CompatScanMetrics() {
+    // Not to be instantiated
+  }
+
+  public static boolean supportsFineGrainedReadMetrics() {
+    return true;
+  }
+
+  public static Long getFsReadTime(ScanMetrics scanMetrics) {
+    return getCounterValue(scanMetrics, ServerSideScanMetrics.FS_READ_TIME_METRIC_NAME);
+  }
+
+  public static Long getBytesReadFromFs(ScanMetrics scanMetrics) {
+    return getCounterValue(scanMetrics, ServerSideScanMetrics.BYTES_READ_FROM_FS_METRIC_NAME);
+  }
+
+  public static Long getBytesReadFromMemstore(ScanMetrics scanMetrics) {
+    return getCounterValue(scanMetrics, ServerSideScanMetrics.BYTES_READ_FROM_MEMSTORE_METRIC_NAME);
+  }
+
+  public static Long getBytesReadFromBlockCache(ScanMetrics scanMetrics) {
+    return getCounterValue(scanMetrics,
+      ServerSideScanMetrics.BYTES_READ_FROM_BLOCK_CACHE_METRIC_NAME);
+  }
+
+  public static Long getBlockReadOpsCount(ScanMetrics scanMetrics) {
+    return getCounterValue(scanMetrics, ServerSideScanMetrics.BLOCK_READ_OPS_COUNT_METRIC_NAME);
+  }
+
+  private static Long getCounterValue(ScanMetrics scanMetrics, String metricName) {
+    AtomicLong counter = scanMetrics.getCounter(metricName);
+    return counter != null ? counter.get() : 0L;
+  }
+
+  public static boolean supportsScanMetricsByRegion() {
+    return true;
+  }
+
+  public static void enableScanMetricsByRegion(Scan scan, boolean enabled) {
+    scan.setEnableScanMetricsByRegion(enabled);
+  }
+
+  public static List<RegionMetricsInfo> collectRegionMetrics(ScanMetrics scanMetrics) {
+    Map<ScanMetricsRegionInfo, Map<String, Long>> byRegion = scanMetrics.collectMetricsByRegion();
+    if (byRegion == null || byRegion.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<RegionMetricsInfo> result = new ArrayList<>();
+    for (Map.Entry<ScanMetricsRegionInfo, Map<String, Long>> entry : byRegion.entrySet()) {
+      ScanMetricsRegionInfo regionInfo = entry.getKey();
+      result.add(new RegionMetricsInfo(regionInfo.getEncodedRegionName(),
+        regionInfo.getServerName().toString(), entry.getValue()));
+    }
+    return result;
+  }
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatThreadLocalServerSideScanMetrics.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatThreadLocalServerSideScanMetrics.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import org.apache.hadoop.hbase.monitoring.ThreadLocalServerSideScanMetrics;
+
+public class CompatThreadLocalServerSideScanMetrics {
+  private CompatThreadLocalServerSideScanMetrics() {
+    // Not to be instantiated
+  }
+
+  public static void addFsReadTime(long fsReadTimeInMs) {
+    ThreadLocalServerSideScanMetrics.addFsReadTime(fsReadTimeInMs);
+  }
+
+  public static void addBytesReadFromFs(long bytesReadFromFS) {
+    ThreadLocalServerSideScanMetrics.addBytesReadFromFs(bytesReadFromFS);
+  }
+
+  public static void addBytesReadFromMemstore(long bytesReadFromMemstore) {
+    ThreadLocalServerSideScanMetrics.addBytesReadFromMemstore(bytesReadFromMemstore);
+  }
+
+  public static void addBytesReadFromBlockCache(long bytesReadFromBlockCache) {
+    ThreadLocalServerSideScanMetrics.addBytesReadFromBlockCache(bytesReadFromBlockCache);
+  }
+
+  public static void addBlockReadOpsCount(long blockReadOpsCount) {
+    ThreadLocalServerSideScanMetrics.addBlockReadOpsCount(blockReadOpsCount);
+  }
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatUtil.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/CompatUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.hbase.MetaTableAccessor;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CompatUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CompatUtil.class);
+
+  private CompatUtil() {
+    // Not to be instantiated
+  }
+
+  public static List<RegionInfo> getMergeRegions(Connection conn, RegionInfo regionInfo)
+    throws IOException {
+    return MetaTableAccessor.getMergeRegions(conn, regionInfo);
+  }
+
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/HbaseCompatCapabilities.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/HbaseCompatCapabilities.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+public class HbaseCompatCapabilities {
+  // Currently every supported HBase version has the same capabilities, so there is
+  // nothing in here.
+}

--- a/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/package-info.java
+++ b/phoenix-hbase-compat-2.6.6/src/main/java/org/apache/phoenix/compat/hbase/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains compatibility classes for bridging differences
+ * between different versions of HBase.
+ */
+package org.apache.phoenix.compat.hbase;

--- a/phoenix-hbase-compat-2.6.6/src/test/java/org/apache/phoenix/compat/hbase/CompatDelegateFilterTest.java
+++ b/phoenix-hbase-compat-2.6.6/src/test/java/org/apache/phoenix/compat/hbase/CompatDelegateFilterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import static org.junit.Assert.assertSame;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Test;
+
+public class CompatDelegateFilterTest {
+
+  /** A delegate that returns distinct sentinel cells from each hint method. */
+  private static class HintingDelegate extends FilterBase {
+    final Cell rejectedRowHint = new KeyValue(Bytes.toBytes("rejected"), Bytes.toBytes("f"),
+      Bytes.toBytes("q"), Bytes.toBytes("v"));
+    final Cell skipHint = new KeyValue(Bytes.toBytes("skip"), Bytes.toBytes("f"),
+      Bytes.toBytes("q"), Bytes.toBytes("v"));
+
+    @Override
+    public Cell getHintForRejectedRow(Cell firstRowCell) throws IOException {
+      return rejectedRowHint;
+    }
+
+    @Override
+    public Cell getSkipHint(Cell skippedCell) throws IOException {
+      return skipHint;
+    }
+  }
+
+  @Test
+  public void forwardsGetHintForRejectedRowToDelegate() throws IOException {
+    HintingDelegate delegate = new HintingDelegate();
+    CompatDelegateFilter filter = new CompatDelegateFilter(delegate);
+    assertSame(delegate.rejectedRowHint, filter.getHintForRejectedRow(null));
+  }
+
+  @Test
+  public void forwardsGetSkipHintToDelegate() throws IOException {
+    HintingDelegate delegate = new HintingDelegate();
+    CompatDelegateFilter filter = new CompatDelegateFilter(delegate);
+    assertSame(delegate.skipHint, filter.getSkipHint(null));
+  }
+}

--- a/phoenix-hbase-compat-2.6.6/src/test/java/org/apache/phoenix/compat/hbase/CompatPagingFilterTest.java
+++ b/phoenix-hbase-compat-2.6.6/src/test/java/org/apache/phoenix/compat/hbase/CompatPagingFilterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.compat.hbase;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Test;
+
+public class CompatPagingFilterTest {
+
+  /** Minimal concrete subclass so the abstract compat base can be instantiated. */
+  private static class TestPagingFilter extends CompatPagingFilter {
+    TestPagingFilter(Filter delegate) {
+      super(delegate);
+    }
+  }
+
+  private static class HintingDelegate extends FilterBase {
+    final Cell rejectedRowHint = new KeyValue(Bytes.toBytes("rejected"), Bytes.toBytes("f"),
+      Bytes.toBytes("q"), Bytes.toBytes("v"));
+    final Cell skipHint = new KeyValue(Bytes.toBytes("skip"), Bytes.toBytes("f"),
+      Bytes.toBytes("q"), Bytes.toBytes("v"));
+
+    @Override
+    public Cell getHintForRejectedRow(Cell firstRowCell) throws IOException {
+      return rejectedRowHint;
+    }
+
+    @Override
+    public Cell getSkipHint(Cell skippedCell) throws IOException {
+      return skipHint;
+    }
+  }
+
+  @Test
+  public void forwardsToDelegateWhenPresent() throws IOException {
+    HintingDelegate delegate = new HintingDelegate();
+    TestPagingFilter filter = new TestPagingFilter(delegate);
+    assertSame(delegate.rejectedRowHint, filter.getHintForRejectedRow(null));
+    assertSame(delegate.skipHint, filter.getSkipHint(null));
+  }
+
+  @Test
+  public void returnsNullWhenDelegateAbsent() throws IOException {
+    TestPagingFilter filter = new TestPagingFilter(null);
+    assertNull(filter.getHintForRejectedRow(null));
+    assertNull(filter.getSkipHint(null));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
   </licenses>
 
   <modules>
+    <module>phoenix-hbase-compat-2.6.6</module>
     <module>phoenix-hbase-compat-2.6.4</module>
     <module>phoenix-hbase-compat-2.6.0</module>
     <module>phoenix-hbase-compat-2.5.4</module>
@@ -80,7 +81,9 @@
     <hbase-2.5.runtime.version>2.5.14-hadoop3</hbase-2.5.runtime.version>
     <hbase-2.6.0.runtime.version>2.6.1-hadoop3</hbase-2.6.0.runtime.version>
     <hbase-2.6.3.runtime.version>2.6.3-hadoop3</hbase-2.6.3.runtime.version>
-    <hbase-2.6.runtime.version>2.6.5-hadoop3</hbase-2.6.runtime.version>
+    <hbase-2.6.5.runtime.version>2.6.5-hadoop3</hbase-2.6.5.runtime.version>
+    <!-- TODO(PHOENIX-7873): flip to 2.6.6-hadoop3 when HBase 2.6.6 GA is on Maven Central -->
+    <hbase-2.6.runtime.version>2.6.6-SNAPSHOT</hbase-2.6.runtime.version>
 
     <compileSource>1.8</compileSource>
     <maven.compiler.source>${compileSource}</maven.compiler.source>
@@ -272,6 +275,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-client-embedded-hbase-2.6.5</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
         <artifactId>phoenix-client-embedded-hbase-2.6.0</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -312,6 +320,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-client-lite-hbase-2.6.5</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
         <artifactId>phoenix-server-hbase-2.5.0</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -342,6 +355,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-server-hbase-2.6.5</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
         <artifactId>phoenix-mapreduce-byo-shaded-hbase-hbase-2.5.0</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -363,6 +381,11 @@
       <dependency>
         <groupId>org.apache.phoenix</groupId>
         <artifactId>phoenix-mapreduce-byo-shaded-hbase-hbase-2.6</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-mapreduce-byo-shaded-hbase-hbase-2.6.5</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -403,6 +426,11 @@
       <dependency>
         <groupId>org.apache.phoenix</groupId>
         <artifactId>phoenix-hbase-compat-2.6.4</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-hbase-compat-2.6.6</artifactId>
         <version>${project.version}</version>
       </dependency>
       <!-- Intra-project test dependencies -->
@@ -2231,8 +2259,10 @@
       </properties>
     </profile>
     <profile>
-      <!-- This WILL work with the public -hadoop3 artifacts -->
-      <id>phoenix-hbase-compat-2.6.4</id>
+      <!-- Default 2.6 family profile. SNAPSHOT-backed until HBase 2.6.6 GA; see
+           TODO(PHOENIX-7873) on hbase-2.6.runtime.version. Will resolve the public
+           -hadoop3 artifacts once that property is flipped to 2.6.6-hadoop3. -->
+      <id>phoenix-hbase-compat-2.6.6</id>
       <activation>
         <property>
           <name>hbase.profile</name>
@@ -2241,8 +2271,24 @@
       </activation>
       <properties>
         <hbase.profile>2.6</hbase.profile>
-        <hbase.compat.version>2.6.4</hbase.compat.version>
+        <hbase.compat.version>2.6.6</hbase.compat.version>
         <hbase.version>${hbase-2.6.runtime.version}</hbase.version>
+      </properties>
+    </profile>
+    <profile>
+      <!-- Pinned/displaced profile for the previous 2.6.5 line; intentionally reuses the
+           2.6.4 compat module. Works with the public -hadoop3 artifacts. -->
+      <id>phoenix-hbase-compat-2.6.5</id>
+      <activation>
+        <property>
+          <name>hbase.profile</name>
+          <value>2.6.5</value>
+        </property>
+      </activation>
+      <properties>
+        <hbase.profile>2.6.5</hbase.profile>
+        <hbase.compat.version>2.6.4</hbase.compat.version>
+        <hbase.version>${hbase-2.6.5.runtime.version}</hbase.version>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,13 @@
     <hbase-2.6.0.runtime.version>2.6.1-hadoop3</hbase-2.6.0.runtime.version>
     <hbase-2.6.3.runtime.version>2.6.3-hadoop3</hbase-2.6.3.runtime.version>
     <hbase-2.6.5.runtime.version>2.6.5-hadoop3</hbase-2.6.5.runtime.version>
-    <!-- TODO(PHOENIX-7873): flip to 2.6.6-hadoop3 when HBase 2.6.6 GA is on Maven Central -->
+    <!--
+      TODO(PHOENIX-7873): HBase 2.6.6 is not yet GA on Maven Central, so the 2.6 profile
+      builds against a locally-installed 2.6.6-SNAPSHOT. At GA: (1) flip this value to
+      2.6.6-hadoop3, (2) flip the matching <hbase26.compat.version> in
+      phoenix-hbase-compat-2.6.6/pom.xml, then (3) remove both TODO comments. The two markers
+      must change together; find them with: grep -rn 'TODO(PHOENIX-7873)'.
+    -->
     <hbase-2.6.runtime.version>2.6.6-SNAPSHOT</hbase-2.6.runtime.version>
 
     <compileSource>1.8</compileSource>


### PR DESCRIPTION
  ### What changes were proposed in this pull request?

  Incorporates the new HBase filter seek-hint methods — `getSkipHint` / `getHintForRejectedRow`, added to `Filter` by
  [HBASE-29974](https://issues.apache.org/jira/browse/HBASE-29974) and propagated through composite filters by
  [HBASE-30150](https://issues.apache.org/jira/browse/HBASE-30150) — into Phoenix's wrapper filters, so a wrapped delegate's seek hint is no longer
  swallowed.

  Because these `Filter` methods exist only in HBase 2.6.6+, this follows the PHOENIX-7731 precedent (commit `0d71499104`) and adds a new version-gated
  compat module **`phoenix-hbase-compat-2.6.6`** (a copy of `phoenix-hbase-compat-2.6.4`) where the gated `@Override`s live. Older compat modules are
  untouched.

  - **New module `phoenix-hbase-compat-2.6.6`** — verbatim copy of `2.6.4`, plus the two seek-hint forwarding overrides:
    - `CompatDelegateFilter` — unconditional forwarding to the delegate.
    - `CompatPagingFilter` — null-guarded forwarding (falls back to `super` when there is no delegate).
  - **`DelegateFilter` re-parented** from `FilterBase` to `CompatDelegateFilter`, so it and its subclasses (`AllVersionsIndexRebuildFilter`,
  `UnverifiedRowFilter`) inherit the forwarding. `PagingFilter` already extends `CompatPagingFilter` (unchanged).
  - **Build wiring** (root `pom.xml`): new module in `<modules>`; `hbase-2.6.5.runtime.version` split out; the `2.6` family profile repointed to the `2.6.6`
  module; a new pinned `hbase.profile=2.6.5` profile for the displaced `2.6.5` line; 5 `dependencyManagement` entries; enforcer beanshell clause; assembly
  coverage dependency.

  Class hierarchy after this change:

  ```
  FilterBase (HBase)
    └─ CompatDelegateFilter   (phoenix-hbase-compat-2.6.6: forwards getSkipHint/getHintForRejectedRow)
         └─ DelegateFilter    (phoenix-core-client)
              ├─ AllVersionsIndexRebuildFilter
              └─ UnverifiedRowFilter

  FilterBase (HBase)
    └─ CompatPagingFilter     (phoenix-hbase-compat-2.6.6: null-guarded forwarding)
         └─ PagingFilter       (phoenix-core-client)
  ```

  > ⚠️ **Draft — blocked on HBase 2.6.6 GA.** HBase 2.6.6 is not yet GA on Maven Central (the JIRAs are merged and present in tag `2.6.6RC0`, but no
  `2.6.6-hadoop3` artifact is published). This branch pins `2.6.6-SNAPSHOT`, which only resolves against a locally-installed HBase build. Two
  `2.6.6-SNAPSHOT` markers (root `pom.xml` `<hbase-2.6.runtime.version>` and `phoenix-hbase-compat-2.6.6/pom.xml` `<hbase26.compat.version>`, both carrying
  `TODO(PHOENIX-7873)` comments) must flip to `2.6.6-hadoop3` at GA before merge.

  ### Why are the changes needed?

  HBASE-29974 lets a `Filter` return a seek hint when it skips/rejects a row so the scanner can jump ahead instead of scanning cell-by-cell, and HBASE-30150
  makes composite filters propagate that hint. Phoenix's wrapper filters (`DelegateFilter`, `PagingFilter`) extend `FilterBase`, whose default
  implementations of these methods return no hint. As a result, when one of these wrappers wraps a delegate that *does* produce a seek hint, the hint is
  swallowed and the scan loses the skip optimization. Forwarding the hint from the delegate restores that optimization for wrapped filters on HBase 2.6.6+.

  ### Does this PR introduce _any_ user-facing change?

  No functional/result change. This is a scan-performance behavior change that only takes effect on HBase 2.6.6+: wrapped delegate filters can now
  contribute seek hints instead of having them swallowed. Query results are unchanged; only how efficiently the scanner skips rows/cells differs. Against
  all currently released Phoenix/HBase versions there is no observable change, since the methods do not exist before HBase 2.6.6.

  ### How was this patch tested?

  Verified locally (JDK 8) against a locally-installed HBase `2.6.6-SNAPSHOT`:

  - **`-Dhbase.profile=2.6` build** — `phoenix-hbase-compat-2.6.6` + `phoenix-core-client` + `phoenix-core` compile; new forwarding unit tests pass
  (`CompatDelegateFilterTest`, `CompatPagingFilterTest`) plus the structural test.
  - **Default profile (HBase 2.5.x) build** — no regression; the profile-safe structural test (`DelegateFilterStructureTest`, `instanceof`-only) compiles
  and passes where the new `Filter` methods are absent, proving the version gating.
  - **Pinned `-Dhbase.profile=2.6.5` build** — the displaced `2.6.4` module still compiles against `2.6.5-hadoop3`; enforcer passes.
  - **Spotless** clean on all changed files.

  ### Was this patch authored or co-authored using generative AI tooling?

  Generated-by: Claude Code (Anthropic Claude Opus 4.8)