### PR TITLE
[WIP] PHOENIX-7623: Add a profile which runs ITs with phoenix ha client

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HighAvailabilityGroup.java
@@ -763,7 +763,7 @@ public class HighAvailabilityGroup {
    * lifecycle management is confined to this class because an HA group is a shared resource.
    * Someone calling close on this would make it unusable, since the state would become closed.
    */
-  void close() {
+  public void close() {
     state = State.CLOSED;
   }
 

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/util/ReadOnlyProps.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/util/ReadOnlyProps.java
@@ -58,7 +58,7 @@ public class ReadOnlyProps implements Iterable<Entry<String, String>> {
     this(EMPTY_PROPS, iterator);
   }
 
-  private ReadOnlyProps() {
+  public ReadOnlyProps() {
     this.props = ImmutableMap.of();
     this.overrideProps = ImmutableMap.of();
   }

--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -515,4 +515,35 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>ha-enabled</id>
+      <properties>
+        <ha-test-enabled>true</ha-test-enabled>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <phoenix.ha.profile.active>${ha-test-enabled}</phoenix.ha.profile.active>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <phoenix.ha.profile.active>${ha-test-enabled}</phoenix.ha.profile.active>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CbrtFunctionEnd2EndIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CbrtFunctionEnd2EndIT.java
@@ -18,6 +18,7 @@
 package org.apache.phoenix.end2end;
 
 import static org.apache.phoenix.util.TestUtil.closeStmtAndConn;
+import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -26,6 +27,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import org.apache.phoenix.expression.function.CbrtFunction;
+import org.apache.phoenix.util.PropertiesUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -48,7 +50,8 @@ public class CbrtFunctionEnd2EndIT extends ParallelStatsDisabledIT {
     Connection conn = null;
     PreparedStatement stmt = null;
     try {
-      conn = DriverManager.getConnection(getUrl());
+      System.out.println("get url " + getUrl());
+      conn = DriverManager.getConnection(getUrl(), PropertiesUtil.deepCopy(TEST_PROPERTIES));
       String ddl;
       ddl = "CREATE TABLE " + signedTableName
         + " (k VARCHAR NOT NULL PRIMARY KEY, doub DOUBLE, fl FLOAT, inte INTEGER, lon BIGINT, smalli SMALLINT, tinyi TINYINT)";
@@ -142,7 +145,7 @@ public class CbrtFunctionEnd2EndIT extends ParallelStatsDisabledIT {
 
   @Test
   public void testSignedNumber() throws Exception {
-    Connection conn = DriverManager.getConnection(getUrl());
+    Connection conn = DriverManager.getConnection(getUrl(), PropertiesUtil.deepCopy(TEST_PROPERTIES));
     for (double d : new double[] { 0.0, 1.0, -1.0, 123.1234, -123.1234 }) {
       testSignedNumberSpec(conn, d);
     }
@@ -150,7 +153,7 @@ public class CbrtFunctionEnd2EndIT extends ParallelStatsDisabledIT {
 
   @Test
   public void testUnsignedNumber() throws Exception {
-    Connection conn = DriverManager.getConnection(getUrl());
+    Connection conn = DriverManager.getConnection(getUrl(), PropertiesUtil.deepCopy(TEST_PROPERTIES));
     for (double d : new double[] { 0.0, 1.0, 123.1234 }) {
       testUnsignedNumberSpec(conn, d);
     }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/ParallelStatsDisabledIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/ParallelStatsDisabledIT.java
@@ -53,12 +53,25 @@ public abstract class ParallelStatsDisabledIT extends BaseTest {
     props.put(BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY,
       Integer.toString(60 * 60)); // An hour
     props.put(QueryServices.USE_STATS_FOR_PARALLELIZATION, Boolean.toString(false));
-    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+
+    // Check if HA profile is enabled
+    if (Boolean.parseBoolean(System.getProperty("phoenix.ha.profile.active"))) {
+      // Set up HA cluster in single-cluster mode
+      setUpTestClusterForHA(new ReadOnlyProps(props.entrySet().iterator()),
+        new ReadOnlyProps(props.entrySet().iterator()));
+    } else {
+      // Regular setup
+      setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+    }
   }
 
   @AfterClass
   public static synchronized void freeResources() throws Exception {
-    BaseTest.freeResourcesIfBeyondThreshold();
+    if (Boolean.parseBoolean(System.getProperty("phoenix.ha.profile.active"))) {
+      tearDownForHA();
+    } else {
+      BaseTest.freeResourcesIfBeyondThreshold();
+    }
   }
 
   protected ResultSet executeQueryThrowsException(Connection conn, QueryBuilder queryBuilder,

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HighAvailabilityTestingUtility.java
@@ -73,6 +73,7 @@ import org.apache.phoenix.end2end.ServerMetadataCacheTestImpl;
 import org.apache.phoenix.hbase.index.util.IndexManagementUtil;
 import org.apache.phoenix.hbase.index.write.TestTrackingParallelWriterIndexCommitter;
 import org.apache.phoenix.jdbc.ClusterRoleRecord.ClusterRole;
+import org.apache.phoenix.util.ReadOnlyProps;
 import org.apache.phoenix.util.HAGroupStoreTestUtil;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -111,10 +112,15 @@ public class HighAvailabilityTestingUtility {
     private static String HA_DIR = "/phoenixHA";
 
     public HBaseTestingUtilityPair() {
+
+      this(new ReadOnlyProps());
+    }
+
+    public HBaseTestingUtilityPair(ReadOnlyProps overrideProps) {
       Configuration conf1 = hbaseCluster1.getConfiguration();
       Configuration conf2 = hbaseCluster2.getConfiguration();
-      setUpDefaultHBaseConfig(conf1);
-      setUpDefaultHBaseConfig(conf2);
+      setUpDefaultHBaseConfig(conf1, overrideProps);
+      setUpDefaultHBaseConfig(conf2, overrideProps);
     }
 
     /**
@@ -122,8 +128,21 @@ public class HighAvailabilityTestingUtility {
      * @throws Exception if fails to start either cluster
      */
     public void start() throws Exception {
+      start(false);
+    }
+
+    /**
+     * Start HBase cluster(s) for HA testing.
+     * @param singleClusterMode if true, only start cluster1 and point all ACTIVE/STANDBY URLs to it.
+     *                          This mode is used to test HA connection code paths without the
+     *                          resource overhead of running two physical clusters.
+     */
+    public void start(boolean singleClusterMode) throws Exception {
       hbaseCluster1.startMiniCluster();
-      hbaseCluster2.startMiniCluster();
+
+      if (!singleClusterMode) {
+        hbaseCluster2.startMiniCluster();
+      }
 
       /*
        * Note that in hbase2 testing utility these give inconsistent results, one gives ip other
@@ -132,43 +151,89 @@ public class HighAvailabilityTestingUtility {
        */
 
       String confAddress1 = hbaseCluster1.getConfiguration().get(HConstants.ZOOKEEPER_QUORUM);
-      String confAddress2 = hbaseCluster2.getConfiguration().get(HConstants.ZOOKEEPER_QUORUM);
 
       zkUrl1 = String.format("%s\\:%d::/hbase", confAddress1,
         hbaseCluster1.getZkCluster().getClientPort());
-      zkUrl2 = String.format("%s\\:%d::/hbase", confAddress2,
-        hbaseCluster2.getZkCluster().getClientPort());
 
       hdfsUrl1 = hbaseCluster1.getConfiguration().get(FileSystem.FS_DEFAULT_NAME_KEY) + HA_DIR;
-      hdfsUrl2 = hbaseCluster2.getConfiguration().get(FileSystem.FS_DEFAULT_NAME_KEY) + HA_DIR;
 
       masterAddress1 =
         hbaseCluster1.getConfiguration().get(HConstants.MASTER_ADDRS_KEY).replaceAll(":", "\\\\:");
-      masterAddress2 =
-        hbaseCluster2.getConfiguration().get(HConstants.MASTER_ADDRS_KEY).replaceAll(":", "\\\\:");
 
-      haAdmin1 = new PhoenixHAAdmin(getZkUrl1(), hbaseCluster1.getConfiguration(),
-        HighAvailibilityCuratorProvider.INSTANCE, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
-      haAdmin2 = new PhoenixHAAdmin(getZkUrl2(), hbaseCluster2.getConfiguration(),
-        HighAvailibilityCuratorProvider.INSTANCE, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
+      if (singleClusterMode) {
+        // In single-cluster mode, point cluster2 URLs to the SAME machine as cluster1
+        // but use a different hostname alias (localhost vs 127.0.0.1) so the URL strings
+        // differ. This satisfies HighAvailabilityGroup URL validation (which requires
+        // distinct URL strings) while routing all traffic to the single running cluster.
+        // JDBCUtil.formatUrl() does NOT normalize hostname-to-IP, so the strings remain
+        // different after normalization.
+        // Pick the alias separately for ZK and master, since MiniHBase populates
+        // ZOOKEEPER_QUORUM and MASTER_ADDRS_KEY independently and they may report
+        // different host strings (e.g., one "localhost", the other "127.0.0.1").
+        String zkAlias = "localhost".equals(confAddress1) ? "127.0.0.1" : "localhost";
 
-      admin1 = hbaseCluster1.getConnection().getAdmin();
-      admin2 = hbaseCluster2.getConnection().getAdmin();
+        zkUrl2 = String.format("%s\\:%d::/hbase", zkAlias,
+          hbaseCluster1.getZkCluster().getClientPort());
 
-      // Enable replication between the two HBase clusters.
-      ReplicationPeerConfig replicationPeerConfig1 =
-        ReplicationPeerConfig.newBuilder().setClusterKey(hbaseCluster2.getClusterKey()).build();
-      ReplicationPeerConfig replicationPeerConfig2 =
-        ReplicationPeerConfig.newBuilder().setClusterKey(hbaseCluster1.getClusterKey()).build();
+        hdfsUrl2 = hdfsUrl1;  // HDFS is shared, so use the same URL
 
-      admin1.addReplicationPeer(PHOENIX_HA_GROUP_STORE_PEER_ID_DEFAULT, replicationPeerConfig1);
-      admin2.addReplicationPeer(PHOENIX_HA_GROUP_STORE_PEER_ID_DEFAULT, replicationPeerConfig2);
+        // Rebuild masterAddress2 with the alias hostname but the same port as cluster1.
+        String rawMasterAddr1 = hbaseCluster1.getConfiguration().get(HConstants.MASTER_ADDRS_KEY);
+        int colonIdx = rawMasterAddr1.indexOf(':');
+        String masterHost = rawMasterAddr1.substring(0, colonIdx);
+        String masterPort = rawMasterAddr1.substring(colonIdx + 1);
+        String masterAlias = "localhost".equals(masterHost) ? "127.0.0.1" : "localhost";
+        masterAddress2 = (masterAlias + ":" + masterPort).replaceAll(":", "\\\\:");
 
-      LOG.info(
-        "MiniHBase DR cluster pair is ready for testing.  Cluster Urls [{},{}] "
-          + "and Master Urls [{}, {}] and HDFS Urls [{}, {}]",
-        getZkUrl1(), getZkUrl2(), getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(),
-        getHdfsUrl2());
+        haAdmin1 = new PhoenixHAAdmin(getZkUrl1(), hbaseCluster1.getConfiguration(),
+          HighAvailibilityCuratorProvider.INSTANCE, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
+        haAdmin2 = haAdmin1;  // Point to same admin (admin clients bypass URL validation)
+
+        admin1 = hbaseCluster1.getConnection().getAdmin();
+        admin2 = admin1;  // Point to same admin
+
+        LOG.info(
+          "MiniHBase single cluster ready for HA testing. Cluster Urls [{}, {}] "
+            + "Master Urls [{}, {}] HDFS Url [{}] "
+            + "(cluster2 URLs use loopback aliases zk='{}' master='{}' "
+            + "pointing to the same cluster1 process)",
+          getZkUrl1(), getZkUrl2(), getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(),
+          zkAlias, masterAlias);
+      } else {
+        // Dual-cluster mode (original behavior for true failover testing)
+        String confAddress2 = hbaseCluster2.getConfiguration().get(HConstants.ZOOKEEPER_QUORUM);
+
+        zkUrl2 = String.format("%s\\:%d::/hbase", confAddress2,
+          hbaseCluster2.getZkCluster().getClientPort());
+
+        hdfsUrl2 = hbaseCluster2.getConfiguration().get(FileSystem.FS_DEFAULT_NAME_KEY) + HA_DIR;
+
+        masterAddress2 =
+          hbaseCluster2.getConfiguration().get(HConstants.MASTER_ADDRS_KEY).replaceAll(":", "\\\\:");
+
+        haAdmin1 = new PhoenixHAAdmin(getZkUrl1(), hbaseCluster1.getConfiguration(),
+          HighAvailibilityCuratorProvider.INSTANCE, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
+        haAdmin2 = new PhoenixHAAdmin(getZkUrl2(), hbaseCluster2.getConfiguration(),
+          HighAvailibilityCuratorProvider.INSTANCE, ZK_CONSISTENT_HA_GROUP_RECORD_NAMESPACE);
+
+        admin1 = hbaseCluster1.getConnection().getAdmin();
+        admin2 = hbaseCluster2.getConnection().getAdmin();
+
+        // Enable replication between the two HBase clusters.
+        ReplicationPeerConfig replicationPeerConfig1 =
+          ReplicationPeerConfig.newBuilder().setClusterKey(hbaseCluster2.getClusterKey()).build();
+        ReplicationPeerConfig replicationPeerConfig2 =
+          ReplicationPeerConfig.newBuilder().setClusterKey(hbaseCluster1.getClusterKey()).build();
+
+        admin1.addReplicationPeer(PHOENIX_HA_GROUP_STORE_PEER_ID_DEFAULT, replicationPeerConfig1);
+        admin2.addReplicationPeer(PHOENIX_HA_GROUP_STORE_PEER_ID_DEFAULT, replicationPeerConfig2);
+
+        LOG.info(
+          "MiniHBase DR cluster pair is ready for testing.  Cluster Urls [{},{}] "
+            + "and Master Urls [{}, {}] and HDFS Urls [{}, {}]",
+          getZkUrl1(), getZkUrl2(), getMasterAddress1(), getMasterAddress2(), getHdfsUrl1(),
+          getHdfsUrl2());
+      }
       logClustersStates();
     }
 
@@ -1027,7 +1092,7 @@ public class HighAvailabilityTestingUtility {
     }
 
     /** Sets up the default HBase configuration for Phoenix HA testing. */
-    private static void setUpDefaultHBaseConfig(Configuration conf) {
+    private static void setUpDefaultHBaseConfig(Configuration conf, ReadOnlyProps overrideProps) {
       // Set Phoenix HA timeout for ZK client to be a smaller number
       conf.setInt(PHOENIX_HA_ZK_CONNECTION_TIMEOUT_MS_KEY, 1000);
       conf.setInt(PHOENIX_HA_ZK_SESSION_TIMEOUT_MS_KEY, 1000);
@@ -1085,6 +1150,10 @@ public class HighAvailabilityTestingUtility {
       // Enabling Prewarming of HAGroupStoreClient cache
       conf.setBoolean(HA_GROUP_STORE_CLIENT_PREWARM_ENABLED, true);
 
+      // override any defaults based on overrideProps
+      for (java.util.Map.Entry<String, String> entry : overrideProps) {
+        conf.set(entry.getKey(), entry.getValue());
+      }
     }
   }
 

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
@@ -26,6 +26,7 @@ import static org.apache.phoenix.util.PhoenixRuntime.CURRENT_SCN_ATTRIB;
 import static org.apache.phoenix.util.PhoenixRuntime.JDBC_PROTOCOL;
 import static org.apache.phoenix.util.PhoenixRuntime.JDBC_PROTOCOL_TERMINATOR;
 import static org.apache.phoenix.util.PhoenixRuntime.PHOENIX_TEST_DRIVER_URL_PARAM;
+import static org.apache.phoenix.jdbc.HighAvailabilityGroup.PHOENIX_HA_GROUP_ATTR;
 import static org.apache.phoenix.util.TestUtil.ATABLE_NAME;
 import static org.apache.phoenix.util.TestUtil.A_VALUE;
 import static org.apache.phoenix.util.TestUtil.BINARY_NAME;
@@ -148,8 +149,14 @@ import org.apache.phoenix.end2end.ServerMetadataCacheTestImpl;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.exception.SQLExceptionInfo;
 import org.apache.phoenix.hbase.index.util.IndexManagementUtil;
+import org.apache.phoenix.jdbc.HighAvailabilityGroup;
+import org.apache.phoenix.jdbc.HighAvailabilityPolicy;
+import org.apache.phoenix.jdbc.HighAvailabilityTestingUtility;
+import static org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.getHighAvailibilityGroup;
 import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.jdbc.PhoenixMonitoredConnection;
 import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
+import org.apache.phoenix.jdbc.PhoenixDriver;
 import org.apache.phoenix.jdbc.PhoenixEmbeddedDriver;
 import org.apache.phoenix.jdbc.PhoenixTestDriver;
 import org.apache.phoenix.schema.NewerTableAlreadyExistsException;
@@ -337,18 +344,41 @@ public abstract class BaseTest {
     return conf.get(QueryServices.ZOOKEEPER_PORT_ATTRIB);
   }
 
+  private static String haGroupName;
+  private static HighAvailabilityGroup haGroup;
   protected static String url;
   protected static PhoenixTestDriver driver;
   protected static boolean clusterInitialized = false;
   protected static HBaseTestingUtility utility;
   protected static final Configuration config = HBaseConfiguration.create();
+  protected static HighAvailabilityTestingUtility.HBaseTestingUtilityPair CLUSTERS;
 
   protected static String getUrl() {
     if (!clusterInitialized) {
       throw new IllegalStateException(
         "Cluster must be initialized before attempting to get the URL");
     }
+    if (Boolean.parseBoolean(System.getProperty("phoenix.ha.profile.active"))) {
+      url = CLUSTERS.getJdbcHAUrlWithoutPrincipal() + ";" + PHOENIX_TEST_DRIVER_URL_PARAM;
+    }
     return url;
+  }
+
+  protected static String getActiveUrl() {
+    if (!clusterInitialized) {
+      throw new IllegalStateException(
+        "Cluster must be initialized before attempting to get the URL");
+    }
+    java.util.Optional<String> activeUrl;
+    if (Boolean.parseBoolean(System.getProperty("phoenix.ha.profile.active"))) {
+      activeUrl = haGroup.getRoleRecord().getActiveUrl();
+      if (activeUrl.isPresent()) {
+        return activeUrl.get() + ";" + PHOENIX_TEST_DRIVER_URL_PARAM;
+      } else {
+        return CLUSTERS.getJdbcUrl1(haGroup) + ";" + PHOENIX_TEST_DRIVER_URL_PARAM;
+      }
+    }
+    return getUrl();
   }
 
   protected static String getUrl(String principal) throws Exception {
@@ -378,6 +408,48 @@ public abstract class BaseTest {
       return initMiniCluster(conf, overrideProps);
     } else {
       return initClusterDistributedMode(conf, overrideProps);
+    }
+  }
+
+  /**
+   * Set up HA cluster for testing in single-cluster mode.
+   * This mode tests HA connection code paths (FailoverPhoenixConnection) without the
+   * resource overhead of running two physical HBase clusters.
+   * Both ACTIVE and STANDBY URLs point to the same physical cluster.
+   */
+  public static void setUpTestClusterForHA(ReadOnlyProps serverProps, ReadOnlyProps clientProps)
+    throws Exception {
+    CLUSTERS = new HighAvailabilityTestingUtility.HBaseTestingUtilityPair(serverProps);
+    CLUSTERS.start(true);  // true = single-cluster mode (only starts cluster1)
+    driver = newTestDriver(clientProps);
+    DriverManager.registerDriver(driver);
+    haGroupName = TEST_PROPERTIES.getProperty(PHOENIX_HA_GROUP_ATTR);
+    // Use single-cluster initialization (only cluster1 is running)
+    CLUSTERS.initClusterRoleRecordFor1Cluster(haGroupName, HighAvailabilityPolicy.FAILOVER);
+    clusterInitialized = true;
+    Properties haGroupProps = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    for (Entry<String, String> entry : clientProps) {
+      haGroupProps.setProperty(entry.getKey(), entry.getValue());
+    }
+    haGroup = getHighAvailibilityGroup(CLUSTERS.getJdbcHAUrl(), haGroupProps);
+    LOGGER.info("Initialized HA group {} with URL {}", haGroup, CLUSTERS.getJdbcHAUrl());
+  }
+
+  /**
+   * Tear down HA cluster resources.
+   * Should be called in @AfterClass when using HA mode.
+   */
+  public static void tearDownForHA() throws Exception {
+    if (Boolean.parseBoolean(System.getProperty("phoenix.ha.profile.active"))) {
+      try {
+        DriverManager.deregisterDriver(PhoenixDriver.INSTANCE);
+        CLUSTERS.close();
+        haGroup.close();
+        driver.getConnectionQueryServices(CLUSTERS.getJdbcUrl1(haGroup), haGroup.getProperties()).close();
+        driver.getConnectionQueryServices(CLUSTERS.getJdbcUrl2(haGroup), haGroup.getProperties()).close();
+      } catch (Exception e) {
+        LOGGER.error("Fail to tear down the HA group and the CQS. Will ignore", e);
+      }
     }
   }
 
@@ -1713,6 +1785,9 @@ public abstract class BaseTest {
   }
 
   public static HBaseTestingUtility getUtility() {
+    if (Boolean.parseBoolean(System.getProperty("phoenix.ha.profile.active"))) {
+      return CLUSTERS.getHBaseCluster1();
+    }
     return utility;
   }
 

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/TestUtil.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/TestUtil.java
@@ -313,7 +313,22 @@ public class TestUtil {
   /**
    * Read-only properties used by all tests
    */
-  public static final Properties TEST_PROPERTIES = new Properties() {
+  private static Properties props_for_HA;
+  static {
+    if (Boolean.parseBoolean(System.getProperty("phoenix.ha.profile.active"))) {
+      props_for_HA = org.apache.phoenix.jdbc.HighAvailabilityTestingUtility.getHATestProperties();
+      props_for_HA.setProperty(
+        org.apache.phoenix.jdbc.HighAvailabilityGroup.PHOENIX_HA_GROUP_ATTR,
+        "HA_GROUP_" + generateUniqueName());
+    } else {
+      props_for_HA = new Properties();
+    }
+  }
+
+  /**
+   * Read-only properties used by all tests
+   */
+  public static final Properties TEST_PROPERTIES = new Properties(props_for_HA) {
     @Override
     public String put(Object key, Object value) {
       throw new UnsupportedOperationException();


### PR DESCRIPTION
What changes were proposed in this pull request?

  This PR adds a Maven profile (ha-enabled) that allows existing integration tests to run through Phoenix HA client code paths (FailoverPhoenixConnection, ParallelPhoenixConnection) using a single HBase cluster. When activated with mvn test
  -Pha-enabled, tests exercise the HA connection infrastructure without spinning up two physical clusters. The approach uses loopback aliases (localhost vs 127.0.0.1) for the ACTIVE and STANDBY cluster URLs — both resolve to the same cluster but
   are distinct strings, satisfying the HA URL validation requirement.

  Why are the changes needed?

  The original PR #2205 converted 300+ integration tests to HA mode but was closed because it spun up 2 complete HBase clusters for every test, which was too resource-intensive. This PR achieves the same HA code coverage (testing
  FailoverPhoenixConnection wrappers, HAGroupStoreRecord creation, HA URL handling, connection pooling with HA wrappers) while using only 1 physical cluster — reducing resource usage by 50%. CbrtFunctionEnd2EndIT is converted as
  proof-of-concept, with the pattern ready to apply to additional tests.

  Does this PR introduce any user-facing change?

  No. All changes are to test infrastructure only. No production behavior is changed. The two production code changes (making HighAvailabilityGroup.close() public and ReadOnlyProps() constructor public) only affect visibility for test access.

  How was this patch tested?

  - mvn test -Dtest=CbrtFunctionEnd2EndIT -Pha-enabled -pl phoenix-core — passes (2 tests, 78s) with HA single-cluster mode
  - mvn test -Dtest=CbrtFunctionEnd2EndIT -pl phoenix-core — passes (2 tests, 54s) without HA, verifying backward compatibility
  - mvn test -Dtest=HAGroupStoreClientIT -pl phoenix-core — passes, verifying existing dual-cluster HA tests are unaffected
  - mvn clean install -DskipTests — full project builds successfully

  Was this patch authored or co-authored using generative AI tooling?

  Yes. This patch was co-authored using Claude Code (Claude Opus 4.6/4.7). The AI assisted with investigating the root cause of connection timeout failures, identifying the loopback alias approach, implementing the fix, and debugging the
  separate alias derivation for ZK and master configs.
