### PR TITLE
PHOENIX-7892 Fix MutableIndexIT EXPLAIN assertions for projection filters

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/MutableIndexIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/index/MutableIndexIT.java
@@ -408,13 +408,10 @@ public class MutableIndexIT extends ParallelStatsDisabledIT {
       if (localIndex) {
         assertPlan(conn, query).iteratorType("PARALLEL 1-WAY").scanType("RANGE SCAN")
           .table(fullIndexName + "(" + fullTableName + ")").keyRanges(" [1]")
-          .serverWhereFilter(
-            "SERVER FILTER BY " + (columnEncoded ? "FIRST KEY" : "EMPTY COLUMN") + " ONLY")
-          .clientSortAlgo("CLIENT MERGE SORT");
+          .serverProjectionFilter(columnEncoded).clientSortAlgo("CLIENT MERGE SORT");
       } else {
         assertPlan(conn, query).iteratorType("PARALLEL 1-WAY").scanType("FULL SCAN")
-          .table(fullIndexName).serverWhereFilter(
-            "SERVER FILTER BY " + (columnEncoded ? "FIRST KEY" : "EMPTY COLUMN") + " ONLY");
+          .table(fullIndexName).serverProjectionFilter(columnEncoded);
       }
       // make sure the data table looks like what we expect
       rs = conn.createStatement().executeQuery(query);
@@ -537,13 +534,10 @@ public class MutableIndexIT extends ParallelStatsDisabledIT {
       if (localIndex) {
         assertPlan(conn, query).iteratorType("PARALLEL 1-WAY").scanType("RANGE SCAN")
           .table(fullIndexName + "(" + fullTableName + ")").keyRanges(" [1]")
-          .serverWhereFilter(
-            "SERVER FILTER BY " + (columnEncoded ? "FIRST KEY" : "EMPTY COLUMN") + " ONLY")
-          .clientSortAlgo("CLIENT MERGE SORT");
+          .serverProjectionFilter(columnEncoded).clientSortAlgo("CLIENT MERGE SORT");
       } else {
         assertPlan(conn, query).iteratorType("PARALLEL 1-WAY").scanType("FULL SCAN")
-          .table(fullIndexName).serverWhereFilter(
-            "SERVER FILTER BY " + (columnEncoded ? "FIRST KEY" : "EMPTY COLUMN") + " ONLY");
+          .table(fullIndexName).serverProjectionFilter(columnEncoded);
       }
 
       // check that the data table matches as expected


### PR DESCRIPTION
`MutableIndexIT` was refactored to `ExplainPlanAttributes` earlier and was not updated by PHOENIX-7886, so its `testCompoundIndexKey` and `testMultipleUpdatesToSingleRow` cases still assert
`serverWhereFilter("SERVER FILTER BY ... ONLY")`, which is now `null`, producing 10 failures across the parameterized configurations. Switch those assertions to `serverProjectionFilter(columnEncoded)`, matching the `BaseIndexIT` pattern. Full `MutableIndexIT` now passes.

Co-authored-by: Claude Opus 4.8[1m] <noreply@anthropic.com>