### PR TITLE
PHOENIX-7566 HAGroupStore state machine: ANISTS non-blocking, DS->STANDBY_TO_ACTIVE

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreRecord.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/HAGroupStoreRecord.java
@@ -76,11 +76,11 @@ public class HAGroupStoreRecord {
         case ABORT_TO_ACTIVE_NOT_IN_SYNC:
         case ACTIVE_IN_SYNC:
         case ACTIVE_NOT_IN_SYNC:
+        case ACTIVE_NOT_IN_SYNC_TO_STANDBY:
         case ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER:
         case ACTIVE_WITH_OFFLINE_PEER:
           return ClusterRoleRecord.ClusterRole.ACTIVE;
         case ACTIVE_IN_SYNC_TO_STANDBY:
-        case ACTIVE_NOT_IN_SYNC_TO_STANDBY:
           return ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY;
         case ABORT_TO_STANDBY:
         case DEGRADED_STANDBY:
@@ -114,7 +114,7 @@ public class HAGroupStoreRecord {
       ACTIVE_IN_SYNC_TO_STANDBY.allowedTransitions =
         ImmutableSet.of(ABORT_TO_ACTIVE_IN_SYNC, STANDBY);
       STANDBY_TO_ACTIVE.allowedTransitions = ImmutableSet.of(ABORT_TO_STANDBY, ACTIVE_IN_SYNC);
-      DEGRADED_STANDBY.allowedTransitions = ImmutableSet.of(STANDBY);
+      DEGRADED_STANDBY.allowedTransitions = ImmutableSet.of(STANDBY, STANDBY_TO_ACTIVE);
       ACTIVE_WITH_OFFLINE_PEER.allowedTransitions = ImmutableSet.of(ACTIVE_NOT_IN_SYNC);
       ABORT_TO_ACTIVE_IN_SYNC.allowedTransitions = ImmutableSet.of(ACTIVE_IN_SYNC);
       ABORT_TO_ACTIVE_NOT_IN_SYNC.allowedTransitions = ImmutableSet.of(ACTIVE_NOT_IN_SYNC);

--- a/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/jdbc/HAGroupStoreManagerIT.java
@@ -145,16 +145,17 @@ public class HAGroupStoreManagerIT extends HABaseIT {
     assertFalse(haGroupStoreManager.isMutationBlocked(haGroupName1));
     assertFalse(haGroupStoreManager.isMutationBlocked(haGroupName2));
 
-    // Update only second group to ACTIVE_NOT_IN_SYNC_TO_STANDBY
+    // Move only the second group into a mutation-blocking drain state
+    // (ACTIVE_IN_SYNC_TO_STANDBY maps to ACTIVE_TO_STANDBY, which blocks mutations).
     HAGroupStoreRecord transitionRecord2 = new HAGroupStoreRecord("1.0", haGroupName2,
-      HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC_TO_STANDBY, 0L,
+      HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY, 0L,
       HighAvailabilityPolicy.FAILOVER.toString(), this.peerZKUrl, CLUSTERS.getMasterAddress1(),
       CLUSTERS.getMasterAddress2(), CLUSTERS.getHdfsUrl1(), CLUSTERS.getHdfsUrl2(), 0L);
 
     haAdmin.updateHAGroupStoreRecordInZooKeeper(haGroupName2, transitionRecord2, 0);
     Thread.sleep(ZK_CURATOR_EVENT_PROPAGATION_TIMEOUT_MS);
 
-    // Global mutations should be blocked due to second group
+    // Blocking is per-group: only the second group is blocked; the first stays writable.
     assertFalse(haGroupStoreManager.isMutationBlocked(haGroupName1));
     assertTrue(haGroupStoreManager.isMutationBlocked(haGroupName2));
   }

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/HAGroupStoreRecordTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/HAGroupStoreRecordTest.java
@@ -333,6 +333,13 @@ public class HAGroupStoreRecordTest {
       .isTransitionAllowed(HAGroupStoreRecord.HAGroupState.STANDBY));
     assertFalse(HAGroupStoreRecord.HAGroupState.UNKNOWN
       .isTransitionAllowed(HAGroupStoreRecord.HAGroupState.OFFLINE));
+
+    // A degraded standby's allowed set is exactly {STANDBY, STANDBY_TO_ACTIVE}; it must promote
+    // via STANDBY_TO_ACTIVE and cannot jump directly to an active or offline state.
+    assertFalse(HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY
+      .isTransitionAllowed(HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC));
+    assertFalse(HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY
+      .isTransitionAllowed(HAGroupStoreRecord.HAGroupState.OFFLINE));
   }
 
   @Test

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/HAGroupStoreRecordTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/HAGroupStoreRecordTest.java
@@ -239,7 +239,7 @@ public class HAGroupStoreRecordTest {
       HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC.getClusterRole());
     assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE,
       HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC.getClusterRole());
-    assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE_TO_STANDBY,
+    assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE,
       HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC_TO_STANDBY.getClusterRole());
     assertEquals(ClusterRoleRecord.ClusterRole.ACTIVE,
       HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC_WITH_OFFLINE_PEER.getClusterRole());
@@ -257,6 +257,12 @@ public class HAGroupStoreRecordTest {
       HAGroupStoreRecord.HAGroupState.STANDBY_TO_ACTIVE.getClusterRole());
     assertEquals(ClusterRoleRecord.ClusterRole.UNKNOWN,
       HAGroupStoreRecord.HAGroupState.UNKNOWN.getClusterRole());
+
+    // ANISTS is non-blocking (maps to ACTIVE); only AISTS blocks mutations.
+    assertFalse(HAGroupStoreRecord.HAGroupState.ACTIVE_NOT_IN_SYNC_TO_STANDBY.getClusterRole()
+      .isMutationBlocked());
+    assertTrue(HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC_TO_STANDBY.getClusterRole()
+      .isMutationBlocked());
   }
 
   @Test
@@ -294,6 +300,12 @@ public class HAGroupStoreRecordTest {
       .isTransitionAllowed(HAGroupStoreRecord.HAGroupState.ABORT_TO_STANDBY));
     assertTrue(HAGroupStoreRecord.HAGroupState.STANDBY_TO_ACTIVE
       .isTransitionAllowed(HAGroupStoreRecord.HAGroupState.ACTIVE_IN_SYNC));
+
+    // A degraded standby can recover to STANDBY or promote directly on failover.
+    assertTrue(HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY
+      .isTransitionAllowed(HAGroupStoreRecord.HAGroupState.STANDBY));
+    assertTrue(HAGroupStoreRecord.HAGroupState.DEGRADED_STANDBY
+      .isTransitionAllowed(HAGroupStoreRecord.HAGroupState.STANDBY_TO_ACTIVE));
   }
 
   @Test


### PR DESCRIPTION
HAGroupStore state-machine fixes for consistent failover (PHOENIX-7566).

### What changes were proposed in this pull request?
- In `HAGroupStoreRecord.getClusterRole()`, map `ACTIVE_NOT_IN_SYNC_TO_STANDBY` to the `ACTIVE` role (non-blocking). Only `ACTIVE_IN_SYNC_TO_STANDBY` remains `ACTIVE_TO_STANDBY` (mutation-blocking).
- Add `STANDBY_TO_ACTIVE` to `DEGRADED_STANDBY.allowedTransitions`, so a degraded standby can promote directly on failover (matches the TLA+ model).

### Why are the changes needed?
On the not-in-sync failover path, an active that is still draining its backlog was treated as mutation-blocked, even though it should keep serving writes until it is in sync and ready to hand off. Separately, a `DEGRADED_STANDBY` had no allowed transition to `STANDBY_TO_ACTIVE`, so it could not promote during failover. Together these prevented a clean failover when the active is behind.

### Does this PR introduce _any_ user-facing change?
No. Internal HA state-machine semantics only; no API, config, or CLI changes.

### How was this patch tested?
- `HAGroupStoreRecordTest` (17/17): role mapping + mutation-block coverage (`ACTIVE_NOT_IN_SYNC_TO_STANDBY` non-blocking, `ACTIVE_IN_SYNC_TO_STANDBY` blocking) and the `DEGRADED_STANDBY → STANDBY` / `STANDBY_TO_ACTIVE` transitions.
- `HAGroupStoreManagerIT` (17/17): per-group mutation blocking.

### Was this patch authored or co-authored using generative AI tooling?
Yes — co-authored with Cursor.