### PR TITLE
PHOENIX-7922 Consolidate the EXPLAIN rewrite pass entry points

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/DeleteCompiler.java
@@ -598,9 +598,7 @@ public class DeleteCompiler {
     select = StatementNormalizer.normalize(select, resolverToBe);
     // Pre-build a context so the early rewrite pass records top of plan breadcrumbs that are
     // adopted by the DELETE data query plan's compilation context.
-    StatementContext rewriteContext =
-      new StatementContext(statement, FromCompiler.EMPTY_TABLE_RESOLVER,
-        new BindManager(statement.getParameters()), new Scan(), new SequenceManager(statement));
+    StatementContext rewriteContext = StatementContext.forRewrite(statement);
     SelectStatement transformedSelect =
       SubqueryRewriter.transform(select, resolverToBe, connection, rewriteContext);
     boolean hasPreProcessing = transformedSelect != select;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/QueryCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/QueryCompiler.java
@@ -724,11 +724,7 @@ public class QueryCompiler {
 
   protected QueryPlan compileSubquery(SelectStatement subquerySelectStatement,
     boolean pushDownMaxRows, StatementContext parentContext) throws SQLException {
-    // Pre-build a context so the subquery's early rewrite pass records breadcrumbs that are then
-    // adopted by the subquery's compilation context.
-    StatementContext rewriteContext =
-      new StatementContext(this.statement, FromCompiler.EMPTY_TABLE_RESOLVER, bindManager,
-        new Scan(), new SequenceManager(this.statement));
+    StatementContext rewriteContext = StatementContext.forRewrite(this.statement, bindManager);
     RewriteResult rewriteResult = ParseNodeUtil.rewrite(subquerySelectStatement, rewriteContext);
     int maxRows = this.statement.getMaxRows();
     // overwrite maxRows to avoid its impact on inner queries.

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/StatementContext.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/StatementContext.java
@@ -125,6 +125,23 @@ public class StatementContext {
     this(statement, new Scan());
   }
 
+  /**
+   * Build a top-level {@link StatementContext} suitable for the early
+   * {@link SubselectRewriter}/{@link SubqueryRewriter} rewrite pass, accumulating rewrite
+   * breadcrumbs.
+   */
+  public static StatementContext forRewrite(PhoenixStatement statement) {
+    return forRewrite(statement, new BindManager(statement.getParameters()));
+  }
+
+  /**
+   * Variant of {@link #forRewrite(PhoenixStatement)} that reuses an existing {@link BindManager}.
+   */
+  public static StatementContext forRewrite(PhoenixStatement statement, BindManager bindManager) {
+    return new StatementContext(statement, FromCompiler.EMPTY_TABLE_RESOLVER, bindManager,
+      new Scan(), new SequenceManager(statement));
+  }
+
   public StatementContext(StatementContext context) {
     this.resolver = context.resolver;
     this.connection = context.connection;

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/SubqueryRewriter.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/SubqueryRewriter.java
@@ -74,11 +74,6 @@ public class SubqueryRewriter extends ParseNodeRewriter {
   private ParseNode topNode;
 
   public static SelectStatement transform(SelectStatement select, ColumnResolver resolver,
-    PhoenixConnection connection) throws SQLException {
-    return transform(select, resolver, connection, null);
-  }
-
-  public static SelectStatement transform(SelectStatement select, ColumnResolver resolver,
     PhoenixConnection connection, StatementContext context) throws SQLException {
     ParseNode where = select.getWhere();
     if (where == null) return select;
@@ -88,11 +83,6 @@ public class SubqueryRewriter extends ParseNodeRewriter {
     if (normWhere == where) return select;
 
     return NODE_FACTORY.select(select, rewriter.tableNode, normWhere);
-  }
-
-  protected SubqueryRewriter(SelectStatement select, ColumnResolver resolver,
-    PhoenixConnection connection) {
-    this(select, resolver, connection, null);
   }
 
   protected SubqueryRewriter(SelectStatement select, ColumnResolver resolver,

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/SubselectRewriter.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/SubselectRewriter.java
@@ -298,11 +298,6 @@ public class SubselectRewriter extends ParseNodeRewriter {
       newSelectAliasedNodes);
   }
 
-  public static SelectStatement flatten(SelectStatement select, PhoenixConnection connection)
-    throws SQLException {
-    return flatten(select, connection, null);
-  }
-
   public static SelectStatement flatten(SelectStatement select, PhoenixConnection connection,
     StatementContext context) throws SQLException {
     TableNode from = select.getFrom();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UpsertCompiler.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/compile/UpsertCompiler.java
@@ -583,9 +583,7 @@ public class UpsertCompiler {
       assert (select != null);
       // Pre-build a context so the early rewrite pass records top-of-plan breadcrumbs that are
       // adopted by the UPSERT SELECT query plan's compilation context.
-      StatementContext rewriteContext =
-        new StatementContext(statement, FromCompiler.EMPTY_TABLE_RESOLVER,
-          new BindManager(statement.getParameters()), new Scan(), new SequenceManager(statement));
+      StatementContext rewriteContext = StatementContext.forRewrite(statement);
       select = SubselectRewriter.flatten(select, connection, rewriteContext);
       ColumnResolver selectResolver =
         FromCompiler.getResolverForQuery(select, connection, false, upsert.getTable().getName());

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixStatement.java
@@ -80,7 +80,6 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.phoenix.call.CallRunner;
 import org.apache.phoenix.compile.BaseMutationPlan;
-import org.apache.phoenix.compile.BindManager;
 import org.apache.phoenix.compile.CloseStatementCompiler;
 import org.apache.phoenix.compile.ColumnProjector;
 import org.apache.phoenix.compile.CreateFunctionCompiler;
@@ -95,7 +94,6 @@ import org.apache.phoenix.compile.ExplainJsonRenderer;
 import org.apache.phoenix.compile.ExplainPlan;
 import org.apache.phoenix.compile.ExplainPlanAttributes;
 import org.apache.phoenix.compile.ExpressionProjector;
-import org.apache.phoenix.compile.FromCompiler;
 import org.apache.phoenix.compile.GroupByCompiler.GroupBy;
 import org.apache.phoenix.compile.ListJarsQueryPlan;
 import org.apache.phoenix.compile.MutationPlan;
@@ -867,9 +865,7 @@ public class PhoenixStatement implements PhoenixMonitoredStatement, SQLCloseable
       // Pre-build the top-level StatementContext so the early SubselectRewriter/SubqueryRewriter
       // pass can record top of plan rewrite breadcrumbs onto it. The same accumulator is then
       // adopted by the compilation context via QueryCompiler.withRewriteContext.
-      StatementContext rewriteContext = new StatementContext(phoenixStatement,
-        FromCompiler.EMPTY_TABLE_RESOLVER, new BindManager(phoenixStatement.getParameters()),
-        new Scan(), new SequenceManager(phoenixStatement));
+      StatementContext rewriteContext = StatementContext.forRewrite(phoenixStatement);
       RewriteResult rewriteResult = ParseNodeUtil.rewrite(this, rewriteContext);
       QueryPlan queryPlan = new QueryCompiler(phoenixStatement,
         rewriteResult.getRewrittenSelectStatement(), rewriteResult.getColumnResolver(),

--- a/phoenix-core/src/test/java/org/apache/phoenix/util/TestUtil.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/util/TestUtil.java
@@ -1445,15 +1445,18 @@ public class TestUtil {
   public static JoinTable getJoinTable(String query, PhoenixConnection connection)
     throws SQLException {
     SQLParser parser = new SQLParser(query);
-    SelectStatement select = SubselectRewriter.flatten(parser.parseQuery(), connection);
+    PhoenixStatement stmt = connection.createStatement().unwrap(PhoenixStatement.class);
+    StatementContext rewriteContext = StatementContext.forRewrite(stmt);
+    SelectStatement select =
+      SubselectRewriter.flatten(parser.parseQuery(), connection, rewriteContext);
     ColumnResolver resolver = FromCompiler.getResolverForQuery(select, connection);
     select = StatementNormalizer.normalize(select, resolver);
-    SelectStatement transformedSelect = SubqueryRewriter.transform(select, resolver, connection);
+    SelectStatement transformedSelect =
+      SubqueryRewriter.transform(select, resolver, connection, rewriteContext);
     if (transformedSelect != select) {
       resolver = FromCompiler.getResolverForQuery(transformedSelect, connection);
       select = StatementNormalizer.normalize(transformedSelect, resolver);
     }
-    PhoenixStatement stmt = connection.createStatement().unwrap(PhoenixStatement.class);
     return JoinCompiler.compile(stmt, select, resolver);
   }
 


### PR DESCRIPTION
Consolidate the rewrite pass entry points.

Add `forRewrite()` on `StatementContext`, carrying rewrite breadcrumbs across the early rewrite pass at four call sites (`PhoenixStatement.ExecutableSelectStatement.compilePlan`, `DeleteCompiler.compile`, `UpsertCompiler.compile`, and `QueryCompiler.compileSubquery`). The bespoke `BindManager` and `FromCompiler` additions in `PhoenixStatement` and `DeleteCompiler` go away. Drops the legacy single argument rewriter overloads `SubselectRewriter.flatten(SelectStatement, PhoenixConnection)` and `SubqueryRewriter.transform(SelectStatement, ColumnResolver, PhoenixConnection)` plus the matching 3-arg `new SubqueryRewriter(...)` constructor. The four legacy overloads are deleted, and the trivial forwarding layer goes with them. 

No behavior change. EXPLAIN text and JSON output are unchanged.

Co-authored-by: Claude Opus 4.8[1m] <noreply@anthropic.com>