### PR TITLE
PHOENIX-7927 Fix EXPLAIN plumbing related NPE in DelegateQueryPlan.setOptimizerDecision

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/DelegateQueryPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/DelegateQueryPlan.java
@@ -39,6 +39,10 @@ import org.apache.phoenix.schema.TableRef;
 
 public abstract class DelegateQueryPlan implements QueryPlan {
   protected final QueryPlan delegate;
+  // Fallback storage for the optimizer decision used only when this plan has no delegate to
+  // forward to. Some DelegateQueryPlan subclasses intentionally pass a null delegate and override
+  // getContext()/getTableRef()/getProjector() to serve from local state.
+  private OptimizerDecision optimizerDecision;
 
   public DelegateQueryPlan(QueryPlan delegate) {
     this.delegate = delegate;
@@ -175,11 +179,15 @@ public abstract class DelegateQueryPlan implements QueryPlan {
 
   @Override
   public OptimizerDecision getOptimizerDecision() {
-    return delegate.getOptimizerDecision();
+    return delegate != null ? delegate.getOptimizerDecision() : optimizerDecision;
   }
 
   @Override
   public void setOptimizerDecision(OptimizerDecision decision) {
-    delegate.setOptimizerDecision(decision);
+    if (delegate != null) {
+      delegate.setOptimizerDecision(decision);
+    } else {
+      this.optimizerDecision = decision;
+    }
   }
 }


### PR DESCRIPTION
NPE in `DelegateQueryPlan.setOptimizerDecision` because the delegate is null, via `TotalSegmentsFunctionIT`.

`getApplicablePlansForSingleFlatQuery` can call `recordDecision` on a `DelegateQueryPlan` with a null delegate. `ClientProcessingPlan` overrides `getContext()` / `getTableRef()` / `getProjector()` to use local fields, so a null delegate is fine except for the two optimizer-decision accessors that `DelegateQueryPlan` is forwarding unconditionally. This is a regression from PHOENIX-7891 that breaks any query involving `TOTAL_SEGMENTS`.

Co-authored-by: Claude Opus 4.8[1m] <noreply@anthropic.com> 