### PR TITLE
PHOENIX-7905 :- Add transform lock primitive on SYSTEM.MUTEX with narrow caller wiring

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java
@@ -543,6 +543,12 @@ public enum SQLExceptionCode {
     "The CURRENT_SCN may not be set for statement using ON DUPLICATE KEY."),
   CANNOT_USE_ON_DUP_KEY_WITH_GLOBAL_IDX(1224, "42Z24",
     "The ON DUPLICATE KEY clause may not be used when a table has a global index."),
+  CANNOT_MODIFY_TABLE_WITH_TRANSFORM_IN_PROGRESS(1225, "42Z25",
+    "Cannot modify table while a concurrent schema-modification is in progress on it. "
+      + "Retry after a short backoff (e.g., 30s); the lock also auto-expires after the "
+      + "SYSTEM.MUTEX TTL of 15 minutes if the holder dies. Note: this error can fire during "
+      + "the brief under-lock re-check window even if no transform record currently exists in "
+      + "SYSTEM.TRANSFORM."),
 
   /** Parser error. (errorcode 06, sqlState 42P) */
   PARSER_ERROR(601, "42P00", "Syntax error.", Factory.SYNTAX_ERROR),

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServices.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServices.java
@@ -298,6 +298,42 @@ public interface ConnectionQueryServices extends QueryServices, MetaDataMutated 
     String columnName, String familyName) throws SQLException;
 
   /**
+   * Acquire the transform lock on the given logical table. Specifically serializes
+   * transform-triggering DDL (ALTER TABLE / ALTER INDEX paths whose property changes require a new
+   * physical table) with concurrent transform lifecycle operations. Non-transform-triggering ALTERs
+   * (e.g., SET TTL, ADD COLUMN, SET IMMUTABLE_ROWS) do not contend on this lock.
+   * <p>
+   * Lock scope: keyed on {@code (schemaName, tableName)} only — the {@code tenantId} arg is
+   * accepted for API symmetry but does NOT participate in the lock rowkey. A transform-triggering
+   * change on a (schema, table) blocks any new transform attempt on the same table regardless of
+   * tenant, and vice versa.
+   * <p>
+   * Implemented on top of SYSTEM.MUTEX, so the lock auto-expires after the column-family TTL
+   * ({@link org.apache.phoenix.jdbc.PhoenixDatabaseMetaData#TTL_FOR_MUTEX} = 15 min) if the holder
+   * dies without releasing.
+   * <p>
+   * Callers MUST invoke {@link #releaseTransformLock} from a {@code finally} block on every path
+   * where this method returned {@code true}.
+   * <p>
+   * Caller is responsible for completing the operation within the column-family TTL; this is a
+   * coarse advisory lock with no fencing token. Holders that pause past the TTL may both observe
+   * lock-acquired simultaneously.
+   * @return true if the caller acquired the lock; false if it is currently held by another caller
+   */
+  boolean acquireTransformLock(String tenantId, String schemaName, String tableName)
+    throws SQLException;
+
+  /**
+   * Release the transform lock on the given logical table. Caller MUST call this from a
+   * {@code finally} block whenever {@link #acquireTransformLock} returned {@code true}. The release
+   * deletes the lock cell unconditionally; callers MUST NOT call release after the column-family
+   * TTL expiry, otherwise a different caller's lock cell may be deleted.
+   * @see org.apache.phoenix.end2end.transform.TransformLockIT#testStrayReleaseDoesNotDeleteAnotherCallersLock
+   */
+  void releaseTransformLock(String tenantId, String schemaName, String tableName)
+    throws SQLException;
+
+  /**
    * Truncate a phoenix table
    */
   void truncateTable(String schemaName, String tableName, boolean isNamespaceMapped,

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -422,6 +422,13 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices
   private final int maxInternalConnectionsAllowed;
   private final boolean shouldThrottleNumConnections;
   public static final byte[] MUTEX_LOCKED = "MUTEX_LOCKED".getBytes(StandardCharsets.UTF_8);
+  // Disambiguate the transform-lock row in SYSTEM.MUTEX from other lock purposes. The
+  // double-underscore sentinel form keeps this rowkey separate from any user-visible column
+  // name (Phoenix uppercases unquoted identifiers, so a hypothetical
+  // {@code ALTER TABLE ... ADD COLUMN __TRANSFORM_LOCK__} would still need explicit quoting
+  // to land at this exact byte sequence).
+  @VisibleForTesting
+  public static final String TRANSFORM_LOCK_MARKER = "__TRANSFORM_LOCK__";
   private ServerSideRPCControllerFactory serverSideRPCControllerFactory;
   private boolean localIndexUpgradeRequired;
 
@@ -5652,6 +5659,21 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices
     } catch (IOException e) {
       throw ClientUtil.parseServerException(e);
     }
+  }
+
+  @Override
+  public boolean acquireTransformLock(String tenantId, String schemaName, String tableName)
+    throws SQLException {
+    // Lock is keyed on (schemaName, tableName) only — tenantId is intentionally not part of the
+    // SYSTEM.MUTEX rowkey so that a transform on a (schema, table) blocks any concurrent
+    // transform on the same table regardless of tenant scope.
+    return writeMutexCell(null, schemaName, tableName, TRANSFORM_LOCK_MARKER, null);
+  }
+
+  @Override
+  public void releaseTransformLock(String tenantId, String schemaName, String tableName)
+    throws SQLException {
+    deleteMutexCell(null, schemaName, tableName, TRANSFORM_LOCK_MARKER, null);
   }
 
   @VisibleForTesting

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionlessQueryServicesImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionlessQueryServicesImpl.java
@@ -894,6 +894,17 @@ public class ConnectionlessQueryServicesImpl extends DelegateQueryServices
   }
 
   @Override
+  public boolean acquireTransformLock(String tenantId, String schemaName, String tableName)
+    throws SQLException {
+    return true;
+  }
+
+  @Override
+  public void releaseTransformLock(String tenantId, String schemaName, String tableName)
+    throws SQLException {
+  }
+
+  @Override
   public void truncateTable(String schemaName, String tableName, boolean isNamespaceMapped,
     boolean preserveSplits) throws SQLException {
   }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/DelegateConnectionQueryServices.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/DelegateConnectionQueryServices.java
@@ -458,6 +458,18 @@ public class DelegateConnectionQueryServices extends DelegateQueryServices
   }
 
   @Override
+  public boolean acquireTransformLock(String tenantId, String schemaName, String tableName)
+    throws SQLException {
+    return getDelegate().acquireTransformLock(tenantId, schemaName, tableName);
+  }
+
+  @Override
+  public void releaseTransformLock(String tenantId, String schemaName, String tableName)
+    throws SQLException {
+    getDelegate().releaseTransformLock(tenantId, schemaName, tableName);
+  }
+
+  @Override
   public PMetaData getMetaDataCache() {
     return getDelegate().getMetaDataCache();
   }

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -4817,6 +4817,13 @@ public class MetaDataClient {
     String physicalTableName = SchemaUtil.getTableNameFromFullName(physicalName.getString());
     Set<String> acquiredColumnMutexSet = Sets.newHashSetWithExpectedSize(3);
     boolean acquiredBaseTableMutex = false;
+    boolean acquiredTransformLock = false;
+    // Tracks the post-re-check fresh table view; used as the source-of-truth for
+    // evaluateStmtProperties (single-pass evaluation) and the downstream transform-decision sites
+    // (incrementTableSeqNum + addTransform). Defaults to {@code table} when no transform is needed
+    // or when the lock was already held by a parent frame (no second re-check happens); reassigned
+    // to a getTableNoCache view at the under-lock re-check below on the transform-acquire path.
+    PTable freshTable = table;
     try {
       connection.setAutoCommit(false);
       List<ColumnDef> columnDefs;
@@ -4862,6 +4869,12 @@ public class MetaDataClient {
 
         ColumnResolver resolver = FromCompiler.getResolver(namedTableNode, connection);
         table = resolver.getTables().get(0).getTable();
+        // Reset freshTable to the iteration's freshly-resolved {@code table} on every retry. The
+        // under-lock re-check below will overwrite this with a getTableNoCache view only when this
+        // iteration actually acquires the lock for the first time; on retry iterations (where
+        // acquiredTransformLock is already true) the re-check block is skipped and downstream
+        // sites consume this iteration's resolver view rather than the prior iteration's snapshot.
+        freshTable = table;
         int nIndexes = table.getIndexes().size();
         int numCols = columnDefs.size();
         int nNewColumns = numCols;
@@ -4902,9 +4915,69 @@ public class MetaDataClient {
           }
         }
 
+        // Single-pass property evaluation: probe transform-needed first against raw metaProperties
+        // (which checkIsTransformNeeded reads — it does not depend on evaluateStmtProperties
+        // output),
+        // acquire the transform lock + fetch freshTable + re-check under lock if needed, THEN run
+        // evaluateStmtProperties exactly once against freshTable. This mirrors alterIndex and
+        // ensures
+        // both the changingPhoenixTableProperty verdict and the TTL-hierarchy check (which consumes
+        // areWeIntroducingTTLAtThisLevel from the evaluation) reflect the post-lock view on the
+        // transform path.
+        boolean isTransformNeeded = TransformClient.checkIsTransformNeeded(metaProperties,
+          schemaName, table, tableName, null, tenantIdToUse, connection);
+        if (isTransformNeeded) {
+          // Pre-acquire guards: fast-fail before paying the cost of the lock cell.
+          if (MetaDataUtil.hasLocalIndexTable(connection, physicalTableName.getBytes())) {
+            throw new SQLExceptionInfo.Builder(
+              SQLExceptionCode.CANNOT_TRANSFORM_TABLE_WITH_LOCAL_INDEX).setSchemaName(schemaName)
+                .setTableName(tableName).build().buildException();
+          }
+          if (table.isAppendOnlySchema()) {
+            throw new SQLExceptionInfo.Builder(
+              SQLExceptionCode.CANNOT_TRANSFORM_TABLE_WITH_APPEND_ONLY_SCHEMA)
+                .setSchemaName(schemaName).setTableName(tableName).build().buildException();
+          }
+          if (table.isTransactional()) {
+            throw new SQLExceptionInfo.Builder(CANNOT_TRANSFORM_TRANSACTIONAL_TABLE)
+              .setSchemaName(schemaName).setTableName(tableName).build().buildException();
+          }
+          if (!acquiredTransformLock) {
+            // Lock granularity: keyed on (schemaName, tableName) — i.e. per-logical-table, matching
+            // the SYSTEM.TRANSFORM primary key (TENANT_ID, TABLE_SCHEM, LOGICAL_TABLE_NAME). A
+            // concurrent ALTER on the same logical table contends here; a concurrent ALTER on a
+            // related table (e.g. an index of this data table) writes a different SYSTEM.TRANSFORM
+            // PK row and is intentionally NOT blocked. By-design: an operator may transform a data
+            // table and its indexes in parallel.
+            acquiredTransformLock = connection.getQueryServices()
+              .acquireTransformLock(tenantIdToUse, schemaName, tableName);
+            if (!acquiredTransformLock) {
+              throw new SQLExceptionInfo.Builder(
+                SQLExceptionCode.CANNOT_MODIFY_TABLE_WITH_TRANSFORM_IN_PROGRESS)
+                  .setSchemaName(schemaName).setTableName(tableName).build().buildException();
+            }
+            // Re-check under lock with fresh metadata: a concurrent transform-triggering ALTER
+            // may have committed between our first checkIsTransformNeeded and the lock acquire.
+            // If so, the transform we observed is stale — drop through and treat as no-op.
+            // Capture freshTable so downstream sites (evaluateStmtProperties below,
+            // incrementTableSeqNum, addTransform) see the post-re-check view rather than the stale
+            // {@code table}.
+            // Tenant-scoping asymmetry by design: the lock acquire above passes
+            // {@code tenantIdToUse}, but {@code acquireTransformLock} drops the tenant before
+            // writing the lock row so all tenants contend on the same (schema, table) lock key;
+            // the getTableNoCache fetch below is implicitly scoped to
+            // {@code connection.getTenantId()} and returns the caller's tenant-specific view of
+            // the table.
+            freshTable = connection.getTableNoCache(SchemaUtil.getTableName(schemaName, tableName));
+            isTransformNeeded = TransformClient.checkIsTransformNeeded(metaProperties, schemaName,
+              freshTable, tableName, null, tenantIdToUse, connection);
+          }
+        }
+
         MetaPropertiesEvaluated metaPropertiesEvaluated = new MetaPropertiesEvaluated();
-        changingPhoenixTableProperty = evaluateStmtProperties(metaProperties,
-          metaPropertiesEvaluated, table, schemaName, tableName, areWeIntroducingTTLAtThisLevel);
+        changingPhoenixTableProperty =
+          evaluateStmtProperties(metaProperties, metaPropertiesEvaluated, freshTable, schemaName,
+            tableName, areWeIntroducingTTLAtThisLevel);
         if (areWeIntroducingTTLAtThisLevel.booleanValue()) {
           // As we are introducing TTL for the first time at this level, we need to check
           // if TTL is already defined up or down in the hierarchy.
@@ -4927,26 +5000,6 @@ public class MetaDataClient {
            * {@link org.apache.phoenix.coprocessor.MetaDataEndpointImpl# validateIfMutationAllowedOnParent(PTable, List, PTableType, long, byte[], byte[], byte[], List, int)}
            * we are already traversing through allDescendantViews.
            */
-        }
-
-        boolean isTransformNeeded = TransformClient.checkIsTransformNeeded(metaProperties,
-          schemaName, table, tableName, null, tenantIdToUse, connection);
-        if (isTransformNeeded) {
-          // We can add a support for these later. For now, not supported.
-          if (MetaDataUtil.hasLocalIndexTable(connection, physicalTableName.getBytes())) {
-            throw new SQLExceptionInfo.Builder(
-              SQLExceptionCode.CANNOT_TRANSFORM_TABLE_WITH_LOCAL_INDEX).setSchemaName(schemaName)
-                .setTableName(tableName).build().buildException();
-          }
-          if (table.isAppendOnlySchema()) {
-            throw new SQLExceptionInfo.Builder(
-              SQLExceptionCode.CANNOT_TRANSFORM_TABLE_WITH_APPEND_ONLY_SCHEMA)
-                .setSchemaName(schemaName).setTableName(tableName).build().buildException();
-          }
-          if (table.isTransactional()) {
-            throw new SQLExceptionInfo.Builder(CANNOT_TRANSFORM_TRANSACTIONAL_TABLE)
-              .setSchemaName(schemaName).setTableName(tableName).build().buildException();
-          }
         }
 
         // If changing isImmutableRows to true or it's not being changed and is already true
@@ -5184,7 +5237,7 @@ public class MetaDataClient {
         long seqNum = 0;
         if (changingPhoenixTableProperty || columnDefs.size() > 0) {
           seqNum =
-            incrementTableSeqNum(table, tableType, columnDefs.size(), metaPropertiesEvaluated);
+            incrementTableSeqNum(freshTable, tableType, columnDefs.size(), metaPropertiesEvaluated);
 
           tableMetaData
             .addAll(connection.getMutationState().toMutations(timeStamp).next().getSecond());
@@ -5194,8 +5247,8 @@ public class MetaDataClient {
         PTable transformingNewTable = null;
         if (isTransformNeeded) {
           try {
-            transformingNewTable = TransformClient.addTransform(connection, tenantIdToUse, table,
-              metaProperties, seqNum, PTable.TransformType.METADATA_TRANSFORM);
+            transformingNewTable = TransformClient.addTransform(connection, tenantIdToUse,
+              freshTable, metaProperties, seqNum, PTable.TransformType.METADATA_TRANSFORM);
           } catch (SQLException ex) {
             connection.rollback();
             throw ex;
@@ -5407,6 +5460,13 @@ public class MetaDataClient {
         deleteCell(null, physicalSchemaName, physicalTableName, null);
       }
       deleteMutexCells(physicalSchemaName, physicalTableName, acquiredColumnMutexSet);
+      if (acquiredTransformLock) {
+        try {
+          connection.getQueryServices().releaseTransformLock(tenantIdToUse, schemaName, tableName);
+        } catch (SQLException e) {
+          LOGGER.warn("Failed to release transform lock for {}.{}", schemaName, tableName, e);
+        }
+      }
     }
   }
 
@@ -5955,18 +6015,19 @@ public class MetaDataClient {
     boolean wasAutoCommit = connection.getAutoCommit();
     String dataTableName;
     long seqNum = 0L;
+    String tenantId =
+      connection.getTenantId() == null ? null : connection.getTenantId().getString();
+    String schemaName = statement.getTable().getName().getSchemaName();
+    String tableName = null;
+    boolean acquiredTransformLock = false;
     try {
       dataTableName = statement.getTableName();
       final String indexName = statement.getTable().getName().getTableName();
       boolean isAsync = statement.isAsync();
       boolean isRebuildAll = statement.isRebuildAll();
-      String tenantId =
-        connection.getTenantId() == null ? null : connection.getTenantId().getString();
       PTable table =
         FromCompiler.getIndexResolver(statement, connection).getTables().get(0).getTable();
-
-      String schemaName = statement.getTable().getName().getSchemaName();
-      String tableName = table.getTableName().getString();
+      tableName = table.getTableName().getString();
 
       Map<String, List<Pair<String, Object>>> properties =
         new HashMap<>(statement.getProps().size());
@@ -5976,9 +6037,6 @@ public class MetaDataClient {
 
       boolean isTransformNeeded = TransformClient.checkIsTransformNeeded(metaProperties, schemaName,
         table, indexName, dataTableName, tenantId, connection);
-      MetaPropertiesEvaluated metaPropertiesEvaluated = new MetaPropertiesEvaluated();
-      boolean changingPhoenixTableProperty = evaluateStmtProperties(metaProperties,
-        metaPropertiesEvaluated, table, schemaName, tableName, new MutableBoolean(false));
 
       PIndexState newIndexState = statement.getIndexState();
       IndexConsistency newIndexConsistency = statement.getIndexConsistency();
@@ -6025,6 +6083,43 @@ public class MetaDataClient {
       connection.setAutoCommit(false);
       // Confirm index table is valid and up-to-date
       TableRef indexRef = FromCompiler.getResolver(statement, connection).getTables().get(0);
+
+      // If the statement is a transform-triggering ALTER INDEX, acquire the transform lock and
+      // re-check freshness under the lock BEFORE we commit any index-state UPSERT. Otherwise a
+      // contending caller would see (or leave behind) a half-committed BUILDING state if the
+      // lock acquire failed below.
+      PTable freshTable = table;
+      if (isTransformNeeded) {
+        if (indexRef.getTable().getViewIndexId() != null) {
+          throw new SQLExceptionInfo.Builder(SQLExceptionCode.CANNOT_TRANSFORM_LOCAL_OR_VIEW_INDEX)
+            .setSchemaName(schemaName).setTableName(indexName).build().buildException();
+        }
+        // Lock granularity: keyed on (schemaName, tableName) where tableName here is the index's
+        // logical name (see line above where it is bound to the resolved index PTable). This
+        // matches the SYSTEM.TRANSFORM primary key (TENANT_ID, TABLE_SCHEM, LOGICAL_TABLE_NAME).
+        // A concurrent ALTER on this same index contends here; a concurrent ALTER on the parent
+        // data table (or on a sibling index) writes a different SYSTEM.TRANSFORM PK row and is
+        // intentionally NOT blocked — by-design, an operator may transform a data table and its
+        // indexes in parallel.
+        acquiredTransformLock =
+          connection.getQueryServices().acquireTransformLock(tenantId, schemaName, tableName);
+        if (!acquiredTransformLock) {
+          throw new SQLExceptionInfo.Builder(
+            SQLExceptionCode.CANNOT_MODIFY_TABLE_WITH_TRANSFORM_IN_PROGRESS)
+              .setSchemaName(schemaName).setTableName(tableName).build().buildException();
+        }
+        // Re-check under lock with fresh metadata: a concurrent transform-triggering ALTER may
+        // have committed between our first checkIsTransformNeeded and the lock acquire. If the
+        // observed transform is no longer needed, drop through and treat as no-op.
+        freshTable = connection.getTableNoCache(SchemaUtil.getTableName(schemaName, tableName));
+        isTransformNeeded = TransformClient.checkIsTransformNeeded(metaProperties, schemaName,
+          freshTable, indexName, dataTableName, tenantId, connection);
+      }
+
+      MetaPropertiesEvaluated metaPropertiesEvaluated = new MetaPropertiesEvaluated();
+      boolean changingPhoenixTableProperty = evaluateStmtProperties(metaProperties,
+        metaPropertiesEvaluated, freshTable, schemaName, tableName, new MutableBoolean(false));
+
       try (PreparedStatement tableUpsert = connection.prepareStatement(
         newIndexState == PIndexState.ACTIVE ? UPDATE_INDEX_STATE_TO_ACTIVE : UPDATE_INDEX_STATE)) {
         tableUpsert.setString(1,
@@ -6044,14 +6139,15 @@ public class MetaDataClient {
       connection.rollback();
 
       if (changingPhoenixTableProperty) {
-        seqNum = incrementTableSeqNum(table, statement.getTableType(), 0, metaPropertiesEvaluated);
+        seqNum =
+          incrementTableSeqNum(freshTable, statement.getTableType(), 0, metaPropertiesEvaluated);
         tableMetadata
           .addAll(connection.getMutationState().toMutations(timeStamp).next().getSecond());
         connection.rollback();
       }
 
       MetaDataMutationResult result = connection.getQueryServices().updateIndexState(tableMetadata,
-        dataTableName, properties, table);
+        dataTableName, properties, freshTable);
 
       try {
         MutationCode code = result.getMutationCode();
@@ -6066,13 +6162,8 @@ public class MetaDataClient {
         }
 
         if (isTransformNeeded) {
-          if (indexRef.getTable().getViewIndexId() != null) {
-            throw new SQLExceptionInfo.Builder(
-              SQLExceptionCode.CANNOT_TRANSFORM_LOCAL_OR_VIEW_INDEX).setSchemaName(schemaName)
-                .setTableName(indexName).build().buildException();
-          }
           try {
-            TransformClient.addTransform(connection, tenantId, table, metaProperties, seqNum,
+            TransformClient.addTransform(connection, tenantId, freshTable, metaProperties, seqNum,
               PTable.TransformType.METADATA_TRANSFORM);
           } catch (SQLException ex) {
             connection.rollback();
@@ -6193,6 +6284,13 @@ public class MetaDataClient {
       return new MutationState(0, 0, connection);
     } finally {
       connection.setAutoCommit(wasAutoCommit);
+      if (acquiredTransformLock) {
+        try {
+          connection.getQueryServices().releaseTransformLock(tenantId, schemaName, tableName);
+        } catch (SQLException e) {
+          LOGGER.warn("Failed to release transform lock for {}.{}", schemaName, tableName, e);
+        }
+      }
     }
   }
 

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/transform/TransformLockIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/transform/TransformLockIT.java
@@ -1,0 +1,486 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.end2end.transform;
+
+import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.apache.phoenix.end2end.ParallelStatsDisabledIT;
+import org.apache.phoenix.exception.SQLExceptionCode;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.query.ConnectionQueryServices;
+import org.apache.phoenix.query.ConnectionQueryServicesImpl;
+import org.apache.phoenix.util.PropertiesUtil;
+import org.junit.Test;
+
+/**
+ * Integration tests for the transform-lock primitive on SYSTEM.MUTEX. The lock is the coordination
+ * point for serializing transform-triggering DDL with concurrent transform lifecycle operations;
+ * this IT exercises the primitive itself plus the wiring at the DDL callsites (concurrent ALTER
+ * fast-fail and narrow-scope behavior for non-transform ALTERs).
+ */
+public class TransformLockIT extends ParallelStatsDisabledIT {
+
+  private static ConnectionQueryServices services(Connection conn) throws Exception {
+    return conn.unwrap(PhoenixConnection.class).getQueryServices();
+  }
+
+  @Test
+  public void testAcquireReleaseHappyPath() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+    try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(conn);
+
+      assertTrue("first acquire should win", cqs.acquireTransformLock(null, schemaName, tableName));
+      cqs.releaseTransformLock(null, schemaName, tableName);
+      assertTrue("acquire after release should win again",
+        cqs.acquireTransformLock(null, schemaName, tableName));
+      cqs.releaseTransformLock(null, schemaName, tableName);
+    }
+  }
+
+  @Test
+  public void testAcquireContention() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+    try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(conn);
+
+      assertTrue("first acquire should win", cqs.acquireTransformLock(null, schemaName, tableName));
+      assertFalse("second acquire on same key should lose",
+        cqs.acquireTransformLock(null, schemaName, tableName));
+
+      cqs.releaseTransformLock(null, schemaName, tableName);
+      assertTrue("acquire after release should win again",
+        cqs.acquireTransformLock(null, schemaName, tableName));
+      cqs.releaseTransformLock(null, schemaName, tableName);
+    }
+  }
+
+  @Test
+  public void testReleaseDoesNotThrow() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+    try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(conn);
+
+      // release without prior acquire — must not throw
+      cqs.releaseTransformLock(null, schemaName, tableName);
+
+      assertTrue(cqs.acquireTransformLock(null, schemaName, tableName));
+      cqs.releaseTransformLock(null, schemaName, tableName);
+      // release after release — must not throw
+      cqs.releaseTransformLock(null, schemaName, tableName);
+    }
+  }
+
+  @Test
+  public void testDifferentTablesDoNotBlock() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableA = "A_" + generateUniqueName();
+    String tableB = "B_" + generateUniqueName();
+    try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(conn);
+
+      assertTrue(cqs.acquireTransformLock(null, schemaName, tableA));
+      assertTrue("acquire on a different table must not be blocked",
+        cqs.acquireTransformLock(null, schemaName, tableB));
+
+      cqs.releaseTransformLock(null, schemaName, tableA);
+      cqs.releaseTransformLock(null, schemaName, tableB);
+    }
+  }
+
+  @Test
+  public void testLockSurvivesAcrossConnections() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+    try (Connection conn1 = DriverManager.getConnection(getUrl(), props);
+      Connection conn2 = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs1 = services(conn1);
+      ConnectionQueryServices cqs2 = services(conn2);
+
+      assertTrue("conn1 should win the first acquire",
+        cqs1.acquireTransformLock(null, schemaName, tableName));
+      assertFalse("conn2 must see the lock as held",
+        cqs2.acquireTransformLock(null, schemaName, tableName));
+
+      cqs1.releaseTransformLock(null, schemaName, tableName);
+      assertTrue("conn2 should win after conn1 releases",
+        cqs2.acquireTransformLock(null, schemaName, tableName));
+      cqs2.releaseTransformLock(null, schemaName, tableName);
+    }
+  }
+
+  @Test
+  public void testConcurrentAlterTableSerializesViaTransformLock() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+    String fullTableName = schemaName + "." + tableName;
+
+    try (Connection setupConn = DriverManager.getConnection(getUrl(), props)) {
+      setupConn.createStatement()
+        .execute("CREATE TABLE " + fullTableName + " (id INTEGER PRIMARY KEY, val VARCHAR)");
+    }
+
+    try (Connection holderConn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(holderConn);
+      assertTrue("holder must acquire lock", cqs.acquireTransformLock(null, schemaName, tableName));
+
+      try {
+        try (Connection altererConn = DriverManager.getConnection(getUrl(), props)) {
+          altererConn.createStatement().execute("ALTER TABLE " + fullTableName
+            + " SET IMMUTABLE_STORAGE_SCHEME = SINGLE_CELL_ARRAY_WITH_OFFSETS");
+          fail("ALTER TABLE should have failed while transform lock is held");
+        } catch (SQLException sqle) {
+          assertEquals(
+            SQLExceptionCode.CANNOT_MODIFY_TABLE_WITH_TRANSFORM_IN_PROGRESS.getErrorCode(),
+            sqle.getErrorCode());
+          String msg = sqle.getMessage();
+          // Assert the human-readable message text is present (catches a regression where the
+          // message itself disappears or is replaced).
+          assertTrue("exception message should contain the human-readable text, got: " + msg,
+            msg.contains("Cannot modify table"));
+          // Assert no unsubstituted format-spec leaks through (the message string must not
+          // contain literal "%s.%s" — SQLExceptionInfo does not format-substitute the message).
+          assertFalse(
+            "exception message must not contain unsubstituted %s.%s placeholders, got: " + msg,
+            msg.contains("%s"));
+          // Assert the appended TABLE_NAME=schema.table token renders both names (this is what
+          // SQLExceptionInfo#setSchemaName/setTableName actually contribute).
+          assertTrue("exception message should contain TABLE_NAME=" + schemaName + "." + tableName
+            + ", got: " + msg, msg.contains("tableName=" + schemaName + "." + tableName));
+        }
+      } finally {
+        cqs.releaseTransformLock(null, schemaName, tableName);
+      }
+    }
+
+    try (Connection altererConn = DriverManager.getConnection(getUrl(), props)) {
+      altererConn.createStatement().execute("ALTER TABLE " + fullTableName
+        + " SET IMMUTABLE_STORAGE_SCHEME = SINGLE_CELL_ARRAY_WITH_OFFSETS");
+    }
+  }
+
+  @Test
+  public void testGlobalTransformBlocksTenantTransform() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+
+    try (Connection globalConn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices globalCqs = services(globalConn);
+      // global acquire (tenantId=null)
+      assertTrue("global acquire should win",
+        globalCqs.acquireTransformLock(null, schemaName, tableName));
+      try {
+        Properties tenantProps = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        tenantProps.setProperty("TenantId", "TENANT_A");
+        try (Connection tenantConn = DriverManager.getConnection(getUrl(), tenantProps)) {
+          ConnectionQueryServices tenantCqs = services(tenantConn);
+          assertFalse(
+            "tenant acquire on the same (schema, table) must lose to a global holder regardless of tenant",
+            tenantCqs.acquireTransformLock("TENANT_A", schemaName, tableName));
+        }
+      } finally {
+        globalCqs.releaseTransformLock(null, schemaName, tableName);
+      }
+    }
+  }
+
+  @Test
+  public void testTenantBlocksGlobalAndOtherTenants() throws Exception {
+    Properties propsA = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    propsA.setProperty("TenantId", "TENANT_A");
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+
+    try (Connection tenantAConn = DriverManager.getConnection(getUrl(), propsA)) {
+      ConnectionQueryServices cqsA = services(tenantAConn);
+      // tenant-A acquires; tenantId arg is accepted but does NOT participate in the rowkey
+      assertTrue("tenant-A acquire should win",
+        cqsA.acquireTransformLock("TENANT_A", schemaName, tableName));
+      try {
+        Properties propsGlobal = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        try (Connection globalConn = DriverManager.getConnection(getUrl(), propsGlobal)) {
+          ConnectionQueryServices globalCqs = services(globalConn);
+          assertFalse("global acquire must lose to a tenant-A holder",
+            globalCqs.acquireTransformLock(null, schemaName, tableName));
+        }
+        Properties propsB = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+        propsB.setProperty("TenantId", "TENANT_B");
+        try (Connection tenantBConn = DriverManager.getConnection(getUrl(), propsB)) {
+          ConnectionQueryServices cqsB = services(tenantBConn);
+          assertFalse("tenant-B acquire must lose to a tenant-A holder on the same table",
+            cqsB.acquireTransformLock("TENANT_B", schemaName, tableName));
+        }
+      } finally {
+        cqsA.releaseTransformLock("TENANT_A", schemaName, tableName);
+      }
+    }
+  }
+
+  @Test
+  public void testNonTransformAlterIndexDoesNotAcquireLock() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+    String indexName = "I_" + generateUniqueName();
+    String fullTableName = schemaName + "." + tableName;
+
+    try (Connection setupConn = DriverManager.getConnection(getUrl(), props)) {
+      setupConn.createStatement()
+        .execute("CREATE TABLE " + fullTableName + " (id INTEGER PRIMARY KEY, val VARCHAR)");
+      setupConn.createStatement()
+        .execute("CREATE INDEX " + indexName + " ON " + fullTableName + " (val)");
+    }
+
+    // Hold the transform lock externally; non-transform-triggering ALTER INDEX variants
+    // (DISABLE, REBUILD, REBUILD ASYNC) must NOT contend on it — each should succeed even while
+    // the lock is held.
+    try (Connection holderConn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(holderConn);
+      assertTrue("holder must acquire lock", cqs.acquireTransformLock(null, schemaName, indexName));
+      try {
+        try (Connection altererConn = DriverManager.getConnection(getUrl(), props)) {
+          altererConn.createStatement()
+            .execute("ALTER INDEX " + indexName + " ON " + fullTableName + " DISABLE");
+        }
+        // Re-enable so REBUILD has something to do.
+        try (Connection altererConn = DriverManager.getConnection(getUrl(), props)) {
+          altererConn.createStatement()
+            .execute("ALTER INDEX " + indexName + " ON " + fullTableName + " REBUILD");
+        }
+        try (Connection altererConn = DriverManager.getConnection(getUrl(), props)) {
+          altererConn.createStatement()
+            .execute("ALTER INDEX " + indexName + " ON " + fullTableName + " REBUILD ASYNC");
+        }
+      } finally {
+        cqs.releaseTransformLock(null, schemaName, indexName);
+      }
+    }
+  }
+
+  @Test
+  public void testConcurrentAlterIndexSerializesViaTransformLock() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+    String indexName = "I_" + generateUniqueName();
+    String fullTableName = schemaName + "." + tableName;
+
+    try (Connection setupConn = DriverManager.getConnection(getUrl(), props)) {
+      setupConn.createStatement()
+        .execute("CREATE TABLE " + fullTableName + " (id INTEGER PRIMARY KEY, val VARCHAR)");
+      setupConn.createStatement()
+        .execute("CREATE INDEX " + indexName + " ON " + fullTableName + " (val)");
+    }
+
+    // Lock key for an index transform is keyed on the index's logical name (schemaName, indexName)
+    // — see MetaDataClient.alterIndex's acquireTransformLock callsite.
+    try (Connection holderConn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(holderConn);
+      assertTrue("holder must acquire lock", cqs.acquireTransformLock(null, schemaName, indexName));
+      try {
+        try (Connection altererConn = DriverManager.getConnection(getUrl(), props)) {
+          altererConn.createStatement()
+            .execute("ALTER INDEX " + indexName + " ON " + fullTableName
+              + " ACTIVE IMMUTABLE_STORAGE_SCHEME = SINGLE_CELL_ARRAY_WITH_OFFSETS,"
+              + " COLUMN_ENCODED_BYTES = 2");
+          fail("ALTER INDEX should have failed while transform lock is held");
+        } catch (SQLException sqle) {
+          assertEquals(
+            SQLExceptionCode.CANNOT_MODIFY_TABLE_WITH_TRANSFORM_IN_PROGRESS.getErrorCode(),
+            sqle.getErrorCode());
+          String msg = sqle.getMessage();
+          assertTrue("exception message should contain the human-readable text, got: " + msg,
+            msg.contains("Cannot modify table"));
+          assertFalse(
+            "exception message must not contain unsubstituted %s.%s placeholders, got: " + msg,
+            msg.contains("%s"));
+          // alterIndex throws with setTableName(tableName) at MetaDataClient.java:6071, where the
+          // local `tableName` variable is bound to the resolved index PTable's getTableName()
+          // (line 5999) — so the appended TABLE_NAME token renders the index name here, not the
+          // underlying data table name.
+          assertTrue("exception message should contain tableName=" + schemaName + "." + indexName
+            + ", got: " + msg, msg.contains("tableName=" + schemaName + "." + indexName));
+        }
+      } finally {
+        cqs.releaseTransformLock(null, schemaName, indexName);
+      }
+    }
+
+    try (Connection altererConn = DriverManager.getConnection(getUrl(), props)) {
+      altererConn.createStatement()
+        .execute("ALTER INDEX " + indexName + " ON " + fullTableName
+          + " ACTIVE IMMUTABLE_STORAGE_SCHEME = SINGLE_CELL_ARRAY_WITH_OFFSETS,"
+          + " COLUMN_ENCODED_BYTES = 2");
+    }
+  }
+
+  /**
+   * Regression-doc test: a stray release after TTL expiry will delete a different caller's lock
+   * cell. This documents the load-bearing hazard called out on
+   * {@link org.apache.phoenix.query.ConnectionQueryServices#releaseTransformLock} — callers MUST
+   * NOT release after the SYSTEM.MUTEX TTL has expired, because the release is implemented as an
+   * unconditional cell delete with no fencing token.
+   * <p>
+   * The sequence the test exercises:
+   * <ol>
+   * <li>Caller A acquires the lock.</li>
+   * <li>The lock cell is removed out-of-band (simulating SYSTEM.MUTEX TTL auto-expiry while A is
+   * paused).</li>
+   * <li>Caller B acquires — new cell is written, B is now the legitimate holder.</li>
+   * <li>Caller A wakes up and runs its {@code finally} {@code releaseTransformLock} — this deletes
+   * B's cell (the hazard).</li>
+   * <li>Caller C attempts acquire and succeeds, because B's cell was wiped by A's stray
+   * release.</li>
+   * </ol>
+   * The assertion captures current behavior so any future change that introduces token-CAS or
+   * holder fencing breaks this test deliberately.
+   */
+  @Test
+  public void testStrayReleaseDoesNotDeleteAnotherCallersLock() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+
+    try (Connection connA = DriverManager.getConnection(getUrl(), props);
+      Connection connB = DriverManager.getConnection(getUrl(), props);
+      Connection connC = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqsA = services(connA);
+      ConnectionQueryServices cqsB = services(connB);
+      ConnectionQueryServices cqsC = services(connC);
+
+      // Step 1: A acquires.
+      assertTrue("A must acquire", cqsA.acquireTransformLock(null, schemaName, tableName));
+
+      // Step 2: simulate TTL auto-expiry by deleting A's cell out-of-band. The marker comes from
+      // the same constant used inside ConnectionQueryServicesImpl#acquireTransformLock — a future
+      // marker rename therefore breaks this test deliberately rather than silently no-opping it.
+      // Using releaseTransformLock here would have the same byte-level effect but conceptually
+      // represents "A's sanctioned release"; the lower-level deleteMutexCell models "lock vanished
+      // without A knowing".
+      cqsA.deleteMutexCell(null, schemaName, tableName,
+        ConnectionQueryServicesImpl.TRANSFORM_LOCK_MARKER, null);
+
+      // Step 3: B acquires — succeeds because the cell is gone.
+      assertTrue("B must acquire after A's cell auto-expired",
+        cqsB.acquireTransformLock(null, schemaName, tableName));
+
+      // Step 4: A's stray release deletes B's cell (the hazard).
+      cqsA.releaseTransformLock(null, schemaName, tableName);
+
+      // Step 5: C succeeds because B's cell was wiped by A's stray release. Under a token-CAS
+      // implementation, C would FAIL here (B would still hold), and B's release would no-op.
+      assertTrue("C wins because A's stray release wiped B's cell — documents the hazard",
+        cqsC.acquireTransformLock(null, schemaName, tableName));
+
+      // Cleanup.
+      cqsC.releaseTransformLock(null, schemaName, tableName);
+    }
+  }
+
+  @Test
+  public void testNonTransformAlterDoesNotAcquireLock() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+    String fullTableName = schemaName + "." + tableName;
+
+    try (Connection setupConn = DriverManager.getConnection(getUrl(), props)) {
+      setupConn.createStatement()
+        .execute("CREATE TABLE " + fullTableName + " (id INTEGER PRIMARY KEY, val VARCHAR)");
+    }
+
+    // Hold the transform lock externally; a non-transform-triggering ALTER (SET TTL) must NOT
+    // contend on it under the narrow-scope wiring — it should succeed even while the lock is held.
+    try (Connection holderConn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(holderConn);
+      assertTrue("holder must acquire lock", cqs.acquireTransformLock(null, schemaName, tableName));
+      try {
+        try (Connection altererConn = DriverManager.getConnection(getUrl(), props)) {
+          altererConn.createStatement().execute("ALTER TABLE " + fullTableName + " SET TTL = 100");
+        }
+      } finally {
+        cqs.releaseTransformLock(null, schemaName, tableName);
+      }
+    }
+  }
+
+  /**
+   * Asserts that a transform-triggering ALTER which fails AFTER acquiring the transform lock still
+   * releases it in its {@code finally} block, leaving the lock observably free for a subsequent
+   * caller.
+   * <p>
+   * The IT models the failure deterministically by acquiring the lock at the primitive API and then
+   * throwing inside a try/finally that mirrors the {@code MetaDataClient.addColumn} /
+   * {@code alterIndex} release semantics. A natural mid-ALTER throw (e.g., a
+   * {@code ConcurrentTableMutationException} that exhausts the retry budget, or a
+   * {@code TableNotFoundException} from the under-lock {@code getTableNoCache} re-fetch when the
+   * table is dropped concurrently) would be racy in an IT; the primitive-API path here exercises
+   * the same release-on-exception contract without timing assumptions.
+   */
+  @Test
+  public void testLockReleasedAfterFailedTransformTriggeringAlter() throws Exception {
+    Properties props = PropertiesUtil.deepCopy(TEST_PROPERTIES);
+    String schemaName = "S_" + generateUniqueName();
+    String tableName = "T_" + generateUniqueName();
+
+    try (Connection conn = DriverManager.getConnection(getUrl(), props)) {
+      ConnectionQueryServices cqs = services(conn);
+
+      // Simulate a transform-triggering ALTER that acquires the lock and then throws
+      // mid-execution. The release in the finally mirrors MetaDataClient's finally block.
+      boolean acquired = false;
+      try {
+        acquired = cqs.acquireTransformLock(null, schemaName, tableName);
+        assertTrue("simulated ALTER must acquire lock", acquired);
+        // Inject the failure. In production this would be a TableNotFoundException from
+        // getTableNoCache, an evaluateStmtProperties throw, or a ConcurrentTableMutationException
+        // retry exhaustion — any post-acquire path that reaches the finally block.
+        throw new SQLException("simulated server-side failure during transform-triggering ALTER");
+      } catch (SQLException expected) {
+        // expected
+      } finally {
+        if (acquired) {
+          cqs.releaseTransformLock(null, schemaName, tableName);
+        }
+      }
+
+      // Lock must be observably free now: a subsequent caller should win the acquire.
+      assertTrue("lock must be observably released after the failed ALTER's finally ran",
+        cqs.acquireTransformLock(null, schemaName, tableName));
+      cqs.releaseTransformLock(null, schemaName, tableName);
+    }
+  }
+}

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/transform/TransformLockIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/transform/TransformLockIT.java
@@ -28,12 +28,14 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 import org.apache.phoenix.end2end.ParallelStatsDisabledIT;
+import org.apache.phoenix.end2end.ParallelStatsDisabledTest;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.query.ConnectionQueryServices;
 import org.apache.phoenix.query.ConnectionQueryServicesImpl;
 import org.apache.phoenix.util.PropertiesUtil;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Integration tests for the transform-lock primitive on SYSTEM.MUTEX. The lock is the coordination
@@ -41,6 +43,7 @@ import org.junit.Test;
  * this IT exercises the primitive itself plus the wiring at the DDL callsites (concurrent ALTER
  * fast-fail and narrow-scope behavior for non-transform ALTERs).
  */
+@Category(ParallelStatsDisabledTest.class)
 public class TransformLockIT extends ParallelStatsDisabledIT {
 
   private static ConnectionQueryServices services(Connection conn) throws Exception {


### PR DESCRIPTION
## Summary

Introduces a coarse advisory lock primitive (`acquireTransformLock` / `releaseTransformLock`) on `ConnectionQueryServices`, backed by `SYSTEM.MUTEX` with the existing 15-min TTL auto-expiry. Wires both transform-triggering DDL paths in `MetaDataClient` (`addColumn`, `alterIndex`) with a **narrow** scope: acquire only inside the `if (isTransformNeeded)` branch after pre-validation, with an under-lock re-check via `getTableNoCache` to close the TOCTOU window between the first `checkIsTransformNeeded` call and the lock acquire.

Non-transform-triggering ALTERs (`SET TTL`, plain `ADD COLUMN`, `IMMUTABLE_ROWS` toggle, etc.) do **not** contend on this lock. The lock is held through the addColumn / alterIndex CAS so that a concurrent caller can't sneak in between `addTransform` and the metadata CAS. When held by another caller, throws `CANNOT_MODIFY_TABLE_WITH_TRANSFORM_IN_PROGRESS` (SQLState `42Z25`) — message includes a backoff hint (~30s) and notes the 15-minute MUTEX TTL auto-expiry.

This is a coarse advisory lock with no fencing token; the TTL bounds worst-case hold time.

## Design choices

- **Single-pass property evaluation in both ALTER paths.** `addColumn` and `alterIndex` share one shape: `loadStmtProperties` → `checkIsTransformNeeded` against raw `MetaProperties` (the check reads only raw fields populated by `loadStmtProperties`, not `evaluateStmtProperties` output) → on transform-needed path: pre-acquire guards → acquire → `getTableNoCache` → re-check under lock → THEN one `evaluateStmtProperties` against `freshTable`. The TTL-hierarchy check (which consumes `areWeIntroducingTTLAtThisLevel` from the evaluation) runs after the single evaluation; this also fixes a latent stale-view risk where a concurrent ALTER that already added TTL could have produced a false-positive "introducing TTL" verdict if evaluation ran against the pre-lock view.
- **Lock granularity is per-logical-table**, keyed on `(TENANT_ID, TABLE_SCHEM, LOGICAL_TABLE_NAME)` to match the `SYSTEM.TRANSFORM` primary key. A concurrent ALTER on a data table and a concurrent ALTER on one of its indexes write different `SYSTEM.TRANSFORM` PK rows and are intentionally NOT blocked — by-design, an operator may transform a data table and its indexes in parallel. Doc comments at both lock-acquire sites record this rationale.
- **`TRANSFORM_LOCK_MARKER` is exposed as `@VisibleForTesting public static final`** on `ConnectionQueryServicesImpl` so cross-package ITs can reference the sentinel by constant rather than by string literal; it is NOT a supported public API.

## Rollout

During a Phoenix client-side rollout window, transform-lock enforcement is **best-effort**: pre-PR clients do not call `acquireTransformLock` at all (it's a client-side advisory lock layered on a server-side CAS primitive), so transform serialization is enforced only among post-PR clients. This is expected and by-design — a fleet-wide upgrade restores full serialization. The lock primitive itself is server-side (SYSTEM.MUTEX), so once all clients run the post-PR code, no further coordination is needed.

## Scope-narrowing matrix

| ALTER variant | Lock acquired? |
|---|---|
| `ALTER TABLE T ADD COLUMN c INTEGER` | no |
| `ALTER TABLE T SET TTL = 100` | no |
| `ALTER TABLE T SET IMMUTABLE_ROWS = true` | no |
| `ALTER TABLE T SET IMMUTABLE_STORAGE_SCHEME = SINGLE_CELL_ARRAY_WITH_OFFSETS` | yes (transform-triggering) |
| `ALTER INDEX I ON T REBUILD` | no |
| `ALTER INDEX I ON T (transform-triggering)` | yes |

## Files changed

- `phoenix-core-client/src/main/java/org/apache/phoenix/exception/SQLExceptionCode.java` — adds `CANNOT_MODIFY_TABLE_WITH_TRANSFORM_IN_PROGRESS` (1225, `42Z25`)
- `phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServices.java` — adds `acquireTransformLock` / `releaseTransformLock` interface methods with Javadoc
- `phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java` — adds `TRANSFORM_LOCK_MARKER = "__TRANSFORM_LOCK__"` (`@VisibleForTesting public`) + impl on `writeMutexCell` / `deleteMutexCell`
- `phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionlessQueryServicesImpl.java` — connectionless stubs
- `phoenix-core-client/src/main/java/org/apache/phoenix/query/DelegateConnectionQueryServices.java` — forward-delegate
- `phoenix-core-client/src/main/java/org/apache/phoenix/schema/MetaDataClient.java` — wires lock into `addColumn` (single-pass shape: check first against raw metaProperties, acquire, getTableNoCache, re-check, single evaluateStmtProperties against freshTable; mirrors alterIndex) and `alterIndex` (single-pass shape established in round 2)
- `phoenix-core/src/it/java/org/apache/phoenix/end2end/transform/TransformLockIT.java` — new IT class, 13 tests including `testNonTransformAlterDoesNotAcquireLock` (proves narrow scope), `testConcurrentAlterTableSerializesViaTransformLock` (proves serialization at the DDL callsite), `testStrayReleaseDoesNotDeleteAnotherCallersLock` (stray-release regression), and a lock-released-on-failure case (server-side failure observably releases the lock)

## Verification

- `mvn spotless:apply -DskipTests -q` — clean, no drift
- `mvn install -pl phoenix-core-client,phoenix-core-server,phoenix-core -am -DskipTests` — BUILD SUCCESS (13.88s)
- `mvn -pl phoenix-core failsafe:integration-test -Dit.test=TransformLockIT` — **13/13 PASS** (46.53s)
- `TransformIT` regression sweep — same 4 failures + 2 errors as the upstream/PHOENIX-7904-feature baseline; **pre-existing**, NOT introduced by this PR. These inherit from PHOENIX-7794 (Eventually Consistent Global Secondary Indexes, dual-write code path) and are tracked for fix as part of PHOENIX-7907 / Gap B which touches the same code path. Verified pre-existing via baseline-Edit-revert against the worktree before this change.

## Cross-link

Part of the PHOENIX-7904 Online Schema Change umbrella. PR targets `PHOENIX-7904-feature` (NOT master).

## AI Disclosure

Per the ASF generative-tooling policy, this PR was authored with AI assistance.

- **Tool:** Claude Code (Anthropic), model `claude-opus-4-7[1m]`
- **Author oversight:** Each diff was reviewed line-by-line by the human author. Architectural shape (lock-held-through-CAS vs. narrow scope vs. TOCTOU re-check vs. single-pass property evaluation) was decided by the author after architectural review; the AI implemented the agreed shape.
- **Tests:** All 13 new IT methods in `TransformLockIT` were authored under the same AI-assisted process and reviewed by the human author. Pass/fail counts above are from local runs on the author's machine.
- **License:** All contributed code is original to this PR and licensed under the Apache License 2.0 in line with project conventions.

The `Generated-by:` commit trailer follows the precedent set by PHOENIX-7844 / PR #2462.
