### PR TITLE
PHOENIX-7929: java.util.ServiceConfigurationError in queryserver star…

### DIFF
--- a/phoenix-client-parent/pom.xml
+++ b/phoenix-client-parent/pom.xml
@@ -80,6 +80,7 @@
                   <exclude>META-INF/*.RSA</exclude>
                   <exclude>META-INF/license/*</exclude>
                   <exclude>META-INF/NOTICE</exclude>
+                  <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
                   <exclude>LICENSE.*</exclude>
                   <exclude>NOTICE.*</exclude>
                   <exclude>NOTICE</exclude>


### PR DESCRIPTION
…tup with jdk21 runtime


### What changes were proposed in this pull request?

exclude dnsjava InetAddressResolverProvider



### Why are the changes needed?

Phoenix queryserver fails to start with jdk21



### Does this PR introduce _any_ user-facing change?
no



### How was this patch tested?

Manually



### Was this patch authored or co-authored using generative AI tooling?
No
