### PR TITLE
[WIP] PHOENIX-7278 Add support to dump BAD_ROWS in a directory for CsvBulkL…

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/mapreduce/AbstractBulkLoadTool.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/mapreduce/AbstractBulkLoadTool.java
@@ -97,6 +97,8 @@ public abstract class AbstractBulkLoadTool extends Configured implements Tool {
     new Option("k", "skip-header", false, "Skip the first line of CSV files (the header)");
   static final Option ENABLE_CORRUPT_INDEXES = new Option("corruptindexes", "corruptindexes", false,
     "Allow bulk loading into non-empty tables with global secondary indexes");
+  static final Option BAD_RECORDS_PATH_OPT = new Option("B", "bad-records-path", true,
+    "HDFS path to write rejected/bad records (implies --ignore-errors)");
 
   /**
    * Set configuration values based on parsed command line options.
@@ -122,6 +124,7 @@ public abstract class AbstractBulkLoadTool extends Configured implements Tool {
     options.addOption(HELP_OPT);
     options.addOption(SKIP_HEADER_OPT);
     options.addOption(ENABLE_CORRUPT_INDEXES);
+    options.addOption(BAD_RECORDS_PATH_OPT);
     return options;
   }
 
@@ -238,6 +241,14 @@ public abstract class AbstractBulkLoadTool extends Configured implements Tool {
       Preconditions.checkArgument(!importColumns.isEmpty(), "Column info list is empty");
       FormatToBytesWritableMapper.configureColumnInfoList(conf, importColumns);
       boolean ignoreInvalidRows = cmdLine.hasOption(IGNORE_ERRORS_OPT.getOpt());
+
+      // --bad-records-path implies --ignore-errors
+      if (cmdLine.hasOption(BAD_RECORDS_PATH_OPT.getOpt())) {
+        conf.set(FormatToBytesWritableMapper.BAD_RECORDS_PATH_CONFKEY,
+          cmdLine.getOptionValue(BAD_RECORDS_PATH_OPT.getOpt()));
+        ignoreInvalidRows = true;
+      }
+
       conf.setBoolean(FormatToBytesWritableMapper.IGNORE_INVALID_ROW_CONFKEY, ignoreInvalidRows);
       String tbn = SchemaUtil.getEscapedFullTableName(qualifiedTableName);
       conf.set(FormatToBytesWritableMapper.TABLE_NAME_CONFKEY, tbn);

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/mapreduce/FormatToBytesWritableMapper.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/mapreduce/FormatToBytesWritableMapper.java
@@ -20,6 +20,9 @@ package org.apache.phoenix.mapreduce;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,6 +33,8 @@ import java.util.Properties;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -90,6 +95,9 @@ public abstract class FormatToBytesWritableMapper<RECORD>
   public static final String IGNORE_INVALID_ROW_CONFKEY =
     "phoenix.mapreduce.import.ignoreinvalidrow";
 
+  /** Configuration key for the HDFS path to write bad/rejected records */
+  public static final String BAD_RECORDS_PATH_CONFKEY = "phoenix.mapreduce.import.badrecordspath";
+
   /** Configuration key for the table names */
   public static final String TABLE_NAMES_CONFKEY = "phoenix.mapreduce.import.tablenames";
 
@@ -111,6 +119,7 @@ public abstract class FormatToBytesWritableMapper<RECORD>
   protected List<String> logicalNames;
   protected MapperUpsertListener<RECORD> upsertListener;
   protected boolean ignoreInvalidRows;
+  protected PrintWriter badRecordsWriter;
 
   /*
    * lookup table for column index. Index in the List matches to the index in tableNames List
@@ -149,9 +158,23 @@ public abstract class FormatToBytesWritableMapper<RECORD>
     }
 
     ignoreInvalidRows = conf.getBoolean(IGNORE_INVALID_ROW_CONFKEY, true);
-    upsertListener = new MapperUpsertListener<RECORD>(context, ignoreInvalidRows);
+    upsertListener = new MapperUpsertListener<RECORD>(context, ignoreInvalidRows,
+      this::writeBadRecord);
     upsertExecutor = buildUpsertExecutor(conf);
     preUpdateProcessor = PhoenixConfigurationUtil.loadPreUpsertProcessor(conf);
+
+    String badRecordsPath = conf.get(BAD_RECORDS_PATH_CONFKEY);
+    if (badRecordsPath != null) {
+      Path outputDir = new Path(badRecordsPath);
+      FileSystem fs = outputDir.getFileSystem(conf);
+      if (!fs.exists(outputDir)) {
+        fs.mkdirs(outputDir);
+      }
+      String taskAttemptId = context.getTaskAttemptID().toString();
+      Path badRecordFile = new Path(outputDir, taskAttemptId + ".bad");
+      badRecordsWriter = new PrintWriter(
+        new OutputStreamWriter(fs.create(badRecordFile, false), StandardCharsets.UTF_8));
+    }
   }
 
   @Override
@@ -172,6 +195,7 @@ public abstract class FormatToBytesWritableMapper<RECORD>
         if (!ignoreInvalidRows) {
           throw new IOException("Error parsing input: " + e.getMessage(), e);
         }
+        writeBadRecord(value.toString(), e.getMessage());
         return;
       }
 
@@ -337,9 +361,24 @@ public abstract class FormatToBytesWritableMapper<RECORD>
     }
   }
 
+  /**
+   * Write a rejected record to the bad records file if configured.
+   */
+  private void writeBadRecord(String record, String errorMessage) {
+    if (badRecordsWriter != null) {
+      String sanitizedError = errorMessage != null
+        ? errorMessage.replace('\n', ' ').replace('\t', ' ')
+        : "unknown";
+      badRecordsWriter.println(sanitizedError + "\t" + record);
+    }
+  }
+
   @Override
   protected void cleanup(Context context) throws IOException, InterruptedException {
     try {
+      if (badRecordsWriter != null) {
+        badRecordsWriter.close();
+      }
       if (conn != null) {
         conn.close();
       }
@@ -381,6 +420,14 @@ public abstract class FormatToBytesWritableMapper<RECORD>
   }
 
   /**
+   * Functional interface for writing bad records from the upsert listener.
+   */
+  @FunctionalInterface
+  interface BadRecordWriter {
+    void write(String record, String errorMessage);
+  }
+
+  /**
    * Listener that logs successful upserts and errors to job counters.
    */
   @VisibleForTesting
@@ -389,12 +436,15 @@ public abstract class FormatToBytesWritableMapper<RECORD>
     private final Mapper<LongWritable, Text, TableRowkeyPair,
       ImmutableBytesWritable>.Context context;
     private final boolean ignoreRecordErrors;
+    private final BadRecordWriter badRecordWriter;
 
-    private MapperUpsertListener(
+    @VisibleForTesting
+    MapperUpsertListener(
       Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context,
-      boolean ignoreRecordErrors) {
+      boolean ignoreRecordErrors, BadRecordWriter badRecordWriter) {
       this.context = context;
       this.ignoreRecordErrors = ignoreRecordErrors;
+      this.badRecordWriter = badRecordWriter;
     }
 
     @Override
@@ -406,6 +456,9 @@ public abstract class FormatToBytesWritableMapper<RECORD>
     public void errorOnRecord(T record, Throwable throwable) {
       LOGGER.error("Error on record " + record, throwable);
       context.getCounter(COUNTER_GROUP_NAME, "Errors on records").increment(1L);
+      if (badRecordWriter != null) {
+        badRecordWriter.write(String.valueOf(record), throwable.getMessage());
+      }
       if (!ignoreRecordErrors) {
         Throwables.propagate(throwable);
       }

--- a/phoenix-core/src/test/java/org/apache/phoenix/mapreduce/BadRecordsWriterTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/mapreduce/BadRecordsWriterTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.mapreduce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.phoenix.mapreduce.FormatToBytesWritableMapper.BadRecordWriter;
+import org.apache.phoenix.mapreduce.FormatToBytesWritableMapper.MapperUpsertListener;
+import org.apache.phoenix.mapreduce.bulkload.TableRowkeyPair;
+import org.junit.Test;
+
+/**
+ * Unit tests for bad records writing functionality in {@link FormatToBytesWritableMapper}.
+ * Tests the {@link BadRecordWriter} interface, {@link MapperUpsertListener} error handling,
+ * and configuration of the bad records path option.
+ */
+public class BadRecordsWriterTest {
+
+  @SuppressWarnings("unchecked")
+  private Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context
+    createMockContext() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      mock(Mapper.Context.class);
+    Counter counter = mock(Counter.class);
+    when(context.getCounter(anyString(), anyString())).thenReturn(counter);
+    return context;
+  }
+
+  @Test
+  public void testMapperUpsertListenerWritesBadRecordOnError() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      createMockContext();
+
+    List<String> captured = new ArrayList<>();
+    BadRecordWriter writer = (record, errorMessage) -> {
+      captured.add(errorMessage + "\t" + record);
+    };
+
+    MapperUpsertListener<String> listener = new MapperUpsertListener<>(context, true, writer);
+    listener.errorOnRecord("bad,record,data", new RuntimeException("type mismatch"));
+
+    assertEquals(1, captured.size());
+    assertEquals("type mismatch\tbad,record,data", captured.get(0));
+  }
+
+  @Test
+  public void testMapperUpsertListenerNullBadRecordWriter() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      createMockContext();
+
+    // Should not throw when badRecordWriter is null
+    MapperUpsertListener<String> listener = new MapperUpsertListener<>(context, true, null);
+    listener.errorOnRecord("bad,record,data", new RuntimeException("type mismatch"));
+    // No assertion needed — just verifying no NPE
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testMapperUpsertListenerPropagatesErrorWhenNotIgnoring() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      createMockContext();
+
+    List<String> captured = new ArrayList<>();
+    BadRecordWriter writer = (record, errorMessage) -> {
+      captured.add(errorMessage + "\t" + record);
+    };
+
+    MapperUpsertListener<String> listener = new MapperUpsertListener<>(context, false, writer);
+    listener.errorOnRecord("bad,record,data", new RuntimeException("type mismatch"));
+  }
+
+  @Test
+  public void testMapperUpsertListenerWritesBadRecordBeforePropagating() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      createMockContext();
+
+    List<String> captured = new ArrayList<>();
+    BadRecordWriter writer = (record, errorMessage) -> {
+      captured.add(errorMessage + "\t" + record);
+    };
+
+    MapperUpsertListener<String> listener = new MapperUpsertListener<>(context, false, writer);
+    try {
+      listener.errorOnRecord("bad,record,data", new RuntimeException("type mismatch"));
+    } catch (RuntimeException e) {
+      // expected
+    }
+
+    // Bad record should be written even when error is propagated
+    assertEquals(1, captured.size());
+    assertEquals("type mismatch\tbad,record,data", captured.get(0));
+  }
+
+  @Test
+  public void testMapperUpsertListenerIncrementsErrorCounter() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      createMockContext();
+    Counter counter = mock(Counter.class);
+    when(context.getCounter("Phoenix MapReduce Import", "Errors on records")).thenReturn(counter);
+
+    MapperUpsertListener<String> listener = new MapperUpsertListener<>(context, true, null);
+    listener.errorOnRecord("record", new RuntimeException("error"));
+
+    verify(counter).increment(1L);
+  }
+
+  @Test
+  public void testMapperUpsertListenerUpsertDoneIncrementsCounter() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      createMockContext();
+    Counter counter = mock(Counter.class);
+    when(context.getCounter("Phoenix MapReduce Import", "Upserts Done")).thenReturn(counter);
+
+    MapperUpsertListener<String> listener = new MapperUpsertListener<>(context, true, null);
+    listener.upsertDone(1L);
+
+    verify(counter).increment(1L);
+  }
+
+  @Test
+  public void testBadRecordWriterFunctionalInterface() {
+    // Verify that BadRecordWriter works as a functional interface with lambda
+    List<String> captured = new ArrayList<>();
+    BadRecordWriter writer = (record, errorMessage) -> {
+      captured.add(record + "|" + errorMessage);
+    };
+
+    writer.write("1,Alice,Sales", "invalid column count");
+    writer.write("2,\"Bob", "EOF reached before encapsulated token finished");
+
+    assertEquals(2, captured.size());
+    assertEquals("1,Alice,Sales|invalid column count", captured.get(0));
+    assertEquals("2,\"Bob|EOF reached before encapsulated token finished", captured.get(1));
+  }
+
+  @Test
+  public void testBadRecordWriterHandlesNullErrorMessage() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      createMockContext();
+
+    List<String> captured = new ArrayList<>();
+    BadRecordWriter writer = (record, errorMessage) -> {
+      captured.add(errorMessage + "\t" + record);
+    };
+
+    MapperUpsertListener<String> listener = new MapperUpsertListener<>(context, true, writer);
+    listener.errorOnRecord("record", new RuntimeException());
+
+    assertEquals(1, captured.size());
+    // When throwable.getMessage() is null, the writer receives null
+    assertTrue(captured.get(0).startsWith("null\t"));
+  }
+
+  @Test
+  public void testBadRecordsPathConfKey() {
+    assertEquals("phoenix.mapreduce.import.badrecordspath",
+      FormatToBytesWritableMapper.BAD_RECORDS_PATH_CONFKEY);
+  }
+
+  @Test
+  public void testMapperUpsertListenerMultipleErrors() {
+    Mapper<LongWritable, Text, TableRowkeyPair, ImmutableBytesWritable>.Context context =
+      createMockContext();
+
+    List<String> captured = new ArrayList<>();
+    BadRecordWriter writer = (record, errorMessage) -> {
+      captured.add(record);
+    };
+
+    MapperUpsertListener<String> listener = new MapperUpsertListener<>(context, true, writer);
+    listener.errorOnRecord("record1", new RuntimeException("error1"));
+    listener.errorOnRecord("record2", new RuntimeException("error2"));
+    listener.errorOnRecord("record3", new RuntimeException("error3"));
+
+    assertEquals(3, captured.size());
+    assertEquals("record1", captured.get(0));
+    assertEquals("record2", captured.get(1));
+    assertEquals("record3", captured.get(2));
+  }
+}

--- a/phoenix-core/src/test/java/org/apache/phoenix/mapreduce/BulkLoadToolTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/mapreduce/BulkLoadToolTest.java
@@ -65,6 +65,14 @@ public class BulkLoadToolTest {
   }
 
   @Test
+  public void testParseOptions_BadRecordsPath() {
+    CommandLine cmdLine = bulkLoadTool.parseOptions(new String[] { "--input", "/input", "--table",
+      "mytable", "--bad-records-path", "/tmp/bad-records" });
+    assertEquals("/tmp/bad-records",
+      cmdLine.getOptionValue(AbstractBulkLoadTool.BAD_RECORDS_PATH_OPT.getOpt()));
+  }
+
+  @Test
   public void testGetQualifiedTableName() {
     assertEquals("MYSCHEMA.MYTABLE", SchemaUtil.getQualifiedTableName("mySchema", "myTable"));
   }


### PR DESCRIPTION
…oadTool

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://phoenix.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] PHOENIX-XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes, and prefix it with the JIRA id, e.g. 'PHOENIX-XXXX Your PR title ...'.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added a --bad-records-path (-B) CLI option to CsvBulkLoadTool / JsonBulkLoadTool that writes rejected/malformed records to an HDFS directory during bulk import. When a record fails parsing (e.g., unterminated CSV quote) or fails upsert (e.g., type mismatch), the offending record and its error message are written to a per-task-attempt file (<taskAttemptId>.bad) under the configured path. This option implies --ignore-errors.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Previously, when --ignore-errors was used, bad records were silently skipped with only a counter increment. Operators had no way to identify which records failed or why, making it difficult to fix source data and re-import. This change provides an audit trail of rejected records for post-job analysis and data remediation.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Phoenix versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. A new CLI option --bad-records-path / -B is available for CsvBulkLoadTool and JsonBulkLoadTool. When specified, rejected records are written to the given HDFS path. Using this option implicitly enables --ignore-errors.



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit tests in BadRecordsWriterTest covering MapperUpsertListener error handling, BadRecordWriter interface, null writer safety, counter increments, error propagation behavior, and multi-error scenarios (10 tests, all passing).
Existing BulkLoadToolTest.testParseOptions_BadRecordsPath verifies option parsing.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes using claude code