### PR TITLE
PHOENIX-7935 Propagate requested EXPLAIN options to nested plan contexts

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientAggregatePlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientAggregatePlan.java
@@ -223,6 +223,9 @@ public class ClientAggregatePlan extends ClientProcessingPlan {
 
   @Override
   public ExplainPlan getExplainPlan() throws SQLException {
+    // Carry the requested EXPLAIN options down to the delegate so every participating scan renders
+    // the same disclosures (e.g. VERBOSE predicate-origin attribution) as the driver scan.
+    delegate.getContext().setExplainOptions(context.getExplainOptions());
     ExplainPlan explainPlan = delegate.getExplainPlan();
     List<String> planSteps = Lists.newArrayList(explainPlan.getPlanSteps());
     ExplainPlanAttributes explainPlanAttributes = explainPlan.getPlanStepsAsAttributes();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientScanPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/ClientScanPlan.java
@@ -119,6 +119,9 @@ public class ClientScanPlan extends ClientProcessingPlan {
 
   @Override
   public ExplainPlan getExplainPlan() throws SQLException {
+    // Carry the requested EXPLAIN options down to the delegate so every participating scan renders
+    // the same disclosures (e.g. VERBOSE predicate-origin attribution) as the driver scan.
+    delegate.getContext().setExplainOptions(context.getExplainOptions());
     ExplainPlan explainPlan = delegate.getExplainPlan();
     List<String> currentPlanSteps = explainPlan.getPlanSteps();
     ExplainPlanAttributes explainPlanAttributes = explainPlan.getPlanStepsAsAttributes();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/HashJoinPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/HashJoinPlan.java
@@ -330,6 +330,11 @@ public class HashJoinPlan extends DelegateQueryPlan {
     ExplainPlanAttributesBuilder builder = new ExplainPlanAttributesBuilder(delegateAttributes);
     List<ExplainPlanAttributes> subPlanAttributes = Lists.newArrayList();
     int count = subPlans.length;
+    // Carry the requested EXPLAIN options down to each sub-plan so every participating scan renders
+    // the same disclosures (e.g. VERBOSE predicate-origin attribution) as the driver scan.
+    for (int i = 0; i < count; i++) {
+      subPlans[i].getInnerPlan().getContext().setExplainOptions(getContext().getExplainOptions());
+    }
     for (int i = 0; i < count; i++) {
       planSteps.addAll(subPlans[i].getPreSteps(this));
       ExplainPlanAttributes subPlanAttribute = subPlans[i].getPreStepsAsAttributes(this);

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/SortMergeJoinPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/SortMergeJoinPlan.java
@@ -193,6 +193,10 @@ public class SortMergeJoinPlan implements QueryPlan {
     List<String> steps = Lists.newArrayList();
     steps
       .add("SORT-MERGE-JOIN (" + joinType.toString().toUpperCase() + ") TABLES  /* SORT_MERGE */");
+    // Carry the requested EXPLAIN options down to both join halves so every participating scan
+    // renders the same disclosures (e.g. VERBOSE predicate-origin attribution) as the driver scan.
+    lhsPlan.getContext().setExplainOptions(getContext().getExplainOptions());
+    rhsPlan.getContext().setExplainOptions(getContext().getExplainOptions());
     ExplainPlan lhsExplainPlan = lhsPlan.getExplainPlan();
     List<String> lhsPlanSteps = lhsExplainPlan.getPlanSteps();
     ExplainPlanAttributes lhsPlanAttributes = lhsExplainPlan.getPlanStepsAsAttributes();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/TupleProjectionPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/TupleProjectionPlan.java
@@ -147,6 +147,13 @@ public class TupleProjectionPlan extends DelegateQueryPlan {
 
   @Override
   public ExplainPlan getExplainPlan() throws SQLException {
+    // getContext() is the delegate's context (already carrying the requested EXPLAIN options).
+    // Carry those same options onto the separate post-filter context so this plan's CLIENT FILTER
+    // BY
+    // renders the same disclosures (e.g. VERBOSE predicate-origin attribution) as the driver scan.
+    if (statementContext != null) {
+      statementContext.setExplainOptions(getContext().getExplainOptions());
+    }
     ExplainPlan explainPlan = delegate.getExplainPlan();
     List<String> planSteps = Lists.newArrayList(explainPlan.getPlanSteps());
     ExplainPlanAttributes explainPlanAttributes = explainPlan.getPlanStepsAsAttributes();

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/execute/UnionPlan.java
@@ -239,6 +239,11 @@ public class UnionPlan implements QueryPlan {
     String abstractExplainPlan = "UNION ALL OVER " + this.plans.size() + " QUERIES";
     builder.setAbstractExplainPlan(abstractExplainPlan);
     steps.add(abstractExplainPlan);
+    // Carry the requested EXPLAIN options down to each branch so every participating scan renders
+    // the same disclosures (e.g. VERBOSE predicate-origin attribution) as the driver scan.
+    for (QueryPlan plan : plans) {
+      plan.getContext().setExplainOptions(getContext().getExplainOptions());
+    }
     // Compose each branch from its own getExplainPlan() so the full sub-plan structure of every
     // branch is preserved and explaining the union does not trigger sub-plan execution.
     UnionResultIterators.explainBranches(plans, steps, builder);


### PR DESCRIPTION
Previously `PhoenixStatement` set `ExplainOptions` only on the root plan's `StatementContext`. Nested plans (hash-join / semi-join / anti-join build sides, `UNION ALL` branches, sort-merge-join halves, and `ClientScanPlan` / `ClientAggregatePlan` / `TupleProjectionPlan` wrappers) kept their default options and rendered as plain explain output. Each parent's `getExplainPlan()` now copies `getContext().getExplainOptions()` onto its child plans' contexts before composing them. `ExplainTable` no longer special-cases the root scan.

Co-authored-by: Claude Opus 4.8[1m] <noreply@anthropic.com>