### PR TITLE
PHOENIX-7937 Trim whitespace in EXPLAIN FORMAT JSON scan attributes

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/iterate/ExplainTable.java
@@ -344,10 +344,10 @@ public abstract class ExplainTable {
       if (OrderBy.REV_ROW_KEY_ORDER_BY.equals(orderBy)) {
         explainPlanAttributesBuilder.setClientSortedBy("REVERSE");
       }
-      explainPlanAttributesBuilder.setExplainScanType(scanTypeDetails);
+      explainPlanAttributesBuilder.setExplainScanType(scanTypeDetails.trim());
       explainPlanAttributesBuilder.setTableName(tableName);
       if (!scanRanges.isPointLookup()) {
-        explainPlanAttributesBuilder.setKeyRanges(appendKeyRanges());
+        explainPlanAttributesBuilder.setKeyRanges(appendKeyRanges().trim());
       }
     }
 
@@ -662,7 +662,8 @@ public abstract class ExplainTable {
     if (countProject == null || countProject.isEmpty()) {
       return;
     }
-    // Only override the internal COUNT(*)/COUNT(1) aggregate projection used for mutation row counts.
+    // Only override the internal COUNT(*)/COUNT(1) aggregate projection used for mutation row
+    // counts.
     if (countProject.size() != 1 || !countProject.get(0).startsWith("COUNT(")) {
       return;
     }

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/explain/ExplainPlanTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/explain/ExplainPlanTest.java
@@ -1885,8 +1885,7 @@ public class ExplainPlanTest extends BaseConnectionlessQueryTest {
 
   /**
    * Convenience wrapper that builds {@link #defaultAttrs()} for scans.
-   * @param scanType the {@code explainScanType} string (with its trailing space, e.g.
-   *                 {@code "FULL SCAN "})
+   * @param scanType the {@code explainScanType} string e.g. {@code "FULL SCAN"})
    * @param table    the {@code tableName} value
    * @param keys     the {@code keyRanges} string (may be {@code null} or empty)
    */
@@ -1896,11 +1895,7 @@ public class ExplainPlanTest extends BaseConnectionlessQueryTest {
     n.put("consistency", "STRONG");
     n.put("explainScanType", scanType.trim());
     n.put("tableName", table);
-    // For a data table scan the per scan INDEX line names the same entity as tableName. View and
-    // index scans that diverge override indexName on the returned node.
     n.put("indexName", table);
-    // A data table scan that participated in optimizer index selection records its decision rule.
-    // A point lookup short-circuits to the point lookup rule. Index targets set their own rule.
     n.put("indexRule", scanType.trim().startsWith("POINT LOOKUP") ? "point lookup" : "data table");
     if (keys != null) {
       n.put("keyRanges", keys.trim());

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/explain/ExplainPlanTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/explain/ExplainPlanTest.java
@@ -874,9 +874,9 @@ public class ExplainPlanTest extends BaseConnectionlessQueryTest {
         "    REGIONS PLANNED <N>", "    SERVER 1 ROW LIMIT", "CLIENT 1 ROW LIMIT"),
       attrs().put("tenantId", TENANT_ID).put("viewName", MT_VIEW).put("viewBaseName", MT_BASE)
         .put("iteratorTypeAndScanSize", "SERIAL <N>-WAY").put("consistency", "STRONG")
-        .put("explainScanType", "RANGE SCAN ").put("tableName", "EO_MT_BASE")
+        .put("explainScanType", "RANGE SCAN").put("tableName", "EO_MT_BASE")
         .put("indexName", "EO_MT_VIEW").put("indexRule", "data table")
-        .put("keyRanges", " ['tenant42']").put("serverRowLimit", 1).put("clientRowLimit", 1)
+        .put("keyRanges", "['tenant42']").put("serverRowLimit", 1).put("clientRowLimit", 1)
         .set("clientSteps", clientSteps("CLIENT 1 ROW LIMIT")));
   }
 
@@ -1894,7 +1894,7 @@ public class ExplainPlanTest extends BaseConnectionlessQueryTest {
     ObjectNode n = defaultAttrs();
     n.put("iteratorTypeAndScanSize", "PARALLEL <N>-WAY");
     n.put("consistency", "STRONG");
-    n.put("explainScanType", scanType);
+    n.put("explainScanType", scanType.trim());
     n.put("tableName", table);
     // For a data table scan the per scan INDEX line names the same entity as tableName. View and
     // index scans that diverge override indexName on the returned node.
@@ -1903,7 +1903,7 @@ public class ExplainPlanTest extends BaseConnectionlessQueryTest {
     // A point lookup short-circuits to the point lookup rule. Index targets set their own rule.
     n.put("indexRule", scanType.trim().startsWith("POINT LOOKUP") ? "point lookup" : "data table");
     if (keys != null) {
-      n.put("keyRanges", keys);
+      n.put("keyRanges", keys.trim());
     }
     return n;
   }


### PR DESCRIPTION
Trim scan attribute string values before populating `ExplainPlanAttributes`. Text plan is unchanged. The JSON field values are canonicalized.

Co-authored-by: Claude Opus 4.8[1m] <noreply@anthropic.com>
