### PR TITLE
PHOENIX-7850 addendum: exclude .github/PULL_REQUEST_TEMPLATE from RAT (5.2 backport)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1871,6 +1871,8 @@
             <!-- tmp files -->
             <exclude>dev/work/**</exclude>
             <exclude>dev/artifacts/**</exclude>
+            <!-- GitHub templates -->
+            <exclude>.github/PULL_REQUEST_TEMPLATE</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Backports the RAT exclude for `.github/PULL_REQUEST_TEMPLATE` from master (commit `ae0e932df5`, PHOENIX-7850 addendum) to the **5.2** branch.

## Problem
The 5.2 release build fails at `publish-dist`:
```
Failed to execute goal org.apache.rat:apache-rat-plugin:0.15:check (default) on project phoenix:
Too many files with unapproved license: 1
```
The flagged file is `.github/PULL_REQUEST_TEMPLATE`, a comment-only PR template with no (and no place for an) Apache license header. master/5.3 already exclude it from RAT; 5.2 was never updated, which blocks cutting 5.2.2 RCs.

## Fix
Add the same 2-line RAT `<exclude>` that exists on master:
```xml
<!-- GitHub templates -->
<exclude>.github/PULL_REQUEST_TEMPLATE</exclude>
```

## Testing
Identical to the already-merged master change; needed to unblock the 5.2.2 release build.