### PR TITLE
PHOENIX-7943 Add 2.6.0 to hbase.profile.list for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <hbase.suffix>hbase-${hbase.profile}</hbase.suffix>
 
     <!-- This is used by the release script only -->
-    <hbase.profile.list>2.5.0 2.5 2.6</hbase.profile.list>
+    <hbase.profile.list>2.5.0 2.5 2.6.0 2.6</hbase.profile.list>
     <!-- The default hbase versions to build with (override with hbase.version) -->
     <hbase-2.5.0.runtime.version>2.5.3-hadoop3</hbase-2.5.0.runtime.version>
     <hbase-2.5.4.runtime.version>2.5.10-hadoop3</hbase-2.5.4.runtime.version>


### PR DESCRIPTION
## Summary
Adds the `2.6.0` HBase profile to `hbase.profile.list` so the release driver builds and stages 2.6.0 client artifacts alongside the existing 2.5.0 / 2.5 / 2.6 profiles.

The `2.6.0` profile and its `phoenix-hbase-compat-2.6.0` module already exist in the build; they were simply missing from the release profile list, so 2.6.0 Maven artifacts were not published in the RC staging repository.

## Change
```
-<hbase.profile.list>2.5.0 2.5 2.6</hbase.profile.list>
+<hbase.profile.list>2.5.0 2.5 2.6.0 2.6</hbase.profile.list>
```

JIRA: https://issues.apache.org/jira/browse/PHOENIX-7943