### PR TITLE
PHOENIX-7944 maven-dependency-plugin analyze-only fails on hbase-2.6.0 profile due to bouncycastle jdk15on/jdk18on mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1653,6 +1653,10 @@
               <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-1.2-api</ignoredUnusedDeclaredDependency>
+              <!-- The bouncycastle artifact name/version differs across HBase profiles: we declare
+                   jdk18on:1.79, but the 2.6.0 profile's HBase pulls jdk15on:1.68 transitively. The
+                   analyzer then flags jdk18on as unused for that profile. -->
+              <ignoredUnusedDeclaredDependency>org.bouncycastle:bcprov-jdk18on</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
             <ignoredUsedUndeclaredDependencies>
               <ignoredUsedUndeclaredDependency>
@@ -1669,6 +1673,11 @@
                   without having to also declare a dependency on commons-text dependency
                   (which we do not use directly at all)-->
                 org.apache.commons:commons-configuration2
+              </ignoredUsedUndeclaredDependency>
+              <ignoredUsedUndeclaredDependency>
+                <!-- The 2.6.0 profile's HBase (2.6.1-hadoop3) pulls bcprov-jdk15on:1.68
+                  transitively for tests, while we declare jdk18on (see note above). -->
+                org.bouncycastle:bcprov-jdk15on
               </ignoredUsedUndeclaredDependency>
             </ignoredUsedUndeclaredDependencies>
           </configuration>


### PR DESCRIPTION
## PHOENIX-7944

The 5.3.2RC1 `publish-release` build failed deterministically on the `hbase-2.6.0` profile (3rd of 4: `2.5.0 2.5 2.6.0 2.6`). `maven-dependency-plugin:3.1.1:analyze-only (enforce-dependencies)` on phoenix-core reports:

- **Used undeclared:** `org.bouncycastle:bcprov-jdk15on:jar:1.68:test`
- **Unused declared:** `org.bouncycastle:bcprov-jdk18on:jar:1.79:test`

### Root cause
The `2.6.0` profile resolves HBase to `2.6.1-hadoop3` (`hbase-2.6.0.runtime.version`), whose test deps transitively pull the OLD `bcprov-jdk15on:1.68`, while phoenix-core declares the NEW `bcprov-jdk18on:1.79`. The 2.5.x profiles do not pull jdk15on, so they pass — which is why RC0 (no 2.6.0 profile) and the 5.2.2 release never hit this. Adding 2.6.0 to `hbase.profile.list` (#2550) exposed the pre-existing latent mismatch.

### Fix
In the root pom `maven-dependency-plugin` config, ignore `org.bouncycastle:bcprov-jdk18on` as unused-declared and `org.bouncycastle:bcprov-jdk15on` as used-undeclared — mirroring the existing log4j / commons-configuration2 cross-profile handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)