### PR TITLE
PHOENIX-7944 (addendum) Move bcprov-jdk18on unused-declared ignore into phoenix-core pom

### DIFF
--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -456,6 +456,10 @@
             <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-1.2-api</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.slf4j:jul-to-slf4j</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.slf4j:jcl-over-slf4j</ignoredUnusedDeclaredDependency>
+            <!-- bcprov is declared as bcprov-jdk18on but on some HBase profiles (e.g. 2.6.0)
+                 HBase transitively pulls the older bcprov-jdk15on, so jdk18on is reported as
+                 unused-declared. Ignore it here (this child list overrides the parent's). -->
+            <ignoredUnusedDeclaredDependency>org.bouncycastle:bcprov-jdk18on</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
           <ignoredUsedUndeclaredDependencies/>
         </configuration>


### PR DESCRIPTION
## Addendum to PHOENIX-7944

The original PHOENIX-7944 fix (#2552) added the bouncycastle ignore entries to the **root** pom's `maven-dependency-plugin` configuration (under `<build><pluginManagement>`). The 5.3.2RC2 release built from that fix **still failed** on the `2.6.0` HBase profile at the `phoenix-core` `analyze-only (enforce-dependencies)` step:

```
[WARNING] Unused declared dependencies found:
[WARNING]    org.bouncycastle:bcprov-jdk18on:jar:1.79:test
[ERROR] Failed to execute goal ...maven-dependency-plugin:3.1.1:analyze-only (enforce-dependencies) on project phoenix-core: Dependency problems found
```

### Root cause
`phoenix-core/pom.xml` re-declares `maven-dependency-plugin` under `<build><plugins>` with its **own non-empty** `<ignoredUnusedDeclaredDependencies>` list. A non-empty child element **overrides** (does not merge with) the inherited `pluginManagement` list, so the parent-level `bcprov-jdk18on` entry never applied to `phoenix-core`.

The companion `bcprov-jdk15on` *used-undeclared* ignore kept working only because `phoenix-core`'s `<ignoredUsedUndeclaredDependencies/>` is **empty/self-closing** — so that parent entry passed through. That asymmetry is exactly why RC2 showed only the one remaining error.

### Fix
Add `org.bouncycastle:bcprov-jdk18on` directly to `phoenix-core`'s child `<ignoredUnusedDeclaredDependencies>` list, next to the existing slf4j/log4j entries. The parent-pom `bcprov-jdk15on` entry stays (still required); the now-redundant parent `bcprov-jdk18on` entry is harmless.

### Verification
Ran the exact release check locally on this branch under the failing profile:
```
mvn -Dhbase.profile=2.6.0 -pl phoenix-core \
    dependency:3.1.1:analyze-only@enforce-dependencies
...
[INFO] --- dependency:3.1.1:analyze-only (enforce-dependencies) @ phoenix-core ---
[INFO] No dependency problems found
[INFO] BUILD SUCCESS
```

Also audited all modules: only `phoenix-core` both declares `bcprov-jdk18on` **and** overrides the ignore list. `phoenix-core-client` has no plugin `<configuration>` (inherits the parent list); `phoenix-core-server` uses `<ignoreNonCompile>true</ignoreNonCompile>`. Both are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)