### PR TITLE
PHOENIX-7944 (addendum) Move bcprov-jdk18on unused-declared ignore into phoenix-core pom

### DIFF
--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -470,6 +470,10 @@
             <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-1.2-api</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.slf4j:jul-to-slf4j</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.slf4j:jcl-over-slf4j</ignoredUnusedDeclaredDependency>
+            <!-- bcprov is declared as bcprov-jdk18on but on some HBase profiles (e.g. 2.6.0)
+                 HBase transitively pulls the older bcprov-jdk15on, so jdk18on is reported as
+                 unused-declared. Ignore it here (this child list overrides the parent's). -->
+            <ignoredUnusedDeclaredDependency>org.bouncycastle:bcprov-jdk18on</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>org.apache.phoenix:phoenix-core-client</ignoredNonTestScopedDependency>


### PR DESCRIPTION
## Addendum to PHOENIX-7944 (master)

Master counterpart of #2554. The original PHOENIX-7944 fix (#2553) added the bouncycastle ignore entries to the **root** pom's `maven-dependency-plugin` config (under `<build><pluginManagement>`), but `phoenix-core/pom.xml` re-declares the plugin under `<build><plugins>` with its own **non-empty** `<ignoredUnusedDeclaredDependencies>` list, which **overrides** (does not merge with) the inherited list. As a result the parent-level `bcprov-jdk18on` entry never applied to `phoenix-core`, and the `2.6.0` profile still fails at `analyze-only`:

```
[WARNING] Unused declared dependencies found:
[WARNING]    org.bouncycastle:bcprov-jdk18on:jar:1.79:test
```

The companion `bcprov-jdk15on` used-undeclared ignore kept working because `phoenix-core`'s `<ignoredUsedUndeclaredDependencies/>` is empty, so that parent entry passed through.

### Fix
Add `org.bouncycastle:bcprov-jdk18on` directly to `phoenix-core`'s child `<ignoredUnusedDeclaredDependencies>` list.

### Verification
Validated by running the exact check on the 5.3 branch (#2554): `mvn -Dhbase.profile=2.6.0 -pl phoenix-core dependency:analyze-only@enforce-dependencies` → `No dependency problems found` / BUILD SUCCESS.

> Note: on master only, the same check additionally surfaces an unrelated unused-declared `org.apache.hbase:hbase-zookeeper:test-jar:tests` (a test-jar dep that exists on master but not on 5.3). That is out of scope for this addendum and will be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)