### PR TITLE
PHOENIX-7946 CDCQueryIT IllegalArgumentException in testSelectWithTimeRange

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
@@ -777,18 +777,29 @@ public class CDCQueryIT extends CDCBaseIT {
           lastDeletionTSpos = uniqueTimestamps.size() - 1;
         }
       }
-      Random rand = new Random();
-      int randMinTSpos = rand.nextInt(lastDeletionTSpos - 1);
-      int randMaxTSpos =
-        randMinTSpos + 1 + rand.nextInt(uniqueTimestamps.size() - (randMinTSpos + 1));
+      // Always verify the full range.
       verifyChangesViaSCN(tenantId, conn, cdcFullName, pkColumns, datatableName, dataColumns,
         changes, 0, System.currentTimeMillis());
-      verifyChangesViaSCN(tenantId, conn, cdcFullName, pkColumns, datatableName, dataColumns,
-        changes, randMinTSpos, randMaxTSpos);
-      verifyChangesViaSCN(tenantId, conn, cdcFullName, pkColumns, datatableName, dataColumns,
-        changes, randMinTSpos, lastDeletionTSpos);
-      verifyChangesViaSCN(tenantId, conn, cdcFullName, pkColumns, datatableName, dataColumns,
-        changes, lastDeletionTSpos, randMaxTSpos);
+      // The random sub-range checks below require a deletion at a unique-timestamp position of
+      // at least 2 so that Random.nextInt(lastDeletionTSpos - 1) receives a positive bound, plus
+      // at least one unique timestamp after randMinTSpos so the second nextInt bound is positive
+      // too. When the generated change set does not satisfy this (no deletions, or a deletion
+      // only at position 0 or 1), skip the random sub-range exercise; the full-range
+      // verification above still covers the data.
+      if (lastDeletionTSpos != null && lastDeletionTSpos >= 2) {
+        Random rand = new Random();
+        int randMinTSpos = rand.nextInt(lastDeletionTSpos - 1);
+        int remainingTSCount = uniqueTimestamps.size() - (randMinTSpos + 1);
+        if (remainingTSCount > 0) {
+          int randMaxTSpos = randMinTSpos + 1 + rand.nextInt(remainingTSCount);
+          verifyChangesViaSCN(tenantId, conn, cdcFullName, pkColumns, datatableName, dataColumns,
+            changes, randMinTSpos, randMaxTSpos);
+          verifyChangesViaSCN(tenantId, conn, cdcFullName, pkColumns, datatableName, dataColumns,
+            changes, randMinTSpos, lastDeletionTSpos);
+          verifyChangesViaSCN(tenantId, conn, cdcFullName, pkColumns, datatableName, dataColumns,
+            changes, lastDeletionTSpos, randMaxTSpos);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
`CDCQueryIT` can fail with `IllegalArgumentException: bound must be positive at CDCQueryIT.java:786`, where the test calls `rand.nextInt(lastDeletionTSpos - 1)` to pick a random index into the unique timestamp list. `lastDeletionTSpos` is only assigned when the synthesized CDC change row stream contains at least one deletion encountered at a unique timestamp. Under the parameterized test matrix it can stay null, or be 0 or 1. The fix is to skip the random sub-range exercise when the available window is < 2.

Co-authored-by: Claude Opus 4.8[1m] <noreply@anthropic.com>
