### PR TITLE
PHOENIX-7947 PhoenixConnection.getTable NPE when auto-unboxing

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/PhoenixConnection.java
@@ -640,7 +640,13 @@ public class PhoenixConnection
         throw new TableNotFoundException(fullTableName);
       }
     } catch (TableNotFoundException e) {
-      table = getTableNoCache(pTenantId, fullTableName, timestamp);
+      // timestamp is @Nullable Long; avoid a Long -> long auto-unboxing NPE when the caller
+      // asked for the latest table (null timestamp) and the cache missed.
+      if (timestamp == null) {
+        table = getTableNoCache(pTenantId, fullTableName);
+      } else {
+        table = getTableNoCache(pTenantId, fullTableName, timestamp);
+      }
     }
     return table;
   }


### PR DESCRIPTION
`GlobalConnectionTenantTableIT` has three deterministically failing tests that all throw the same NPE ("Cannot invoke "java.lang.Long.longValue()" because "timestamp" is null at PhoenixConnection.java:643"). The root cause is in `PhoenixConnection.getTable(@Nullable String tenantId, String fullTableName, @Nullable Long timestamp)`. Its documented contract says a null timestamp means "use the cache, fall back to a server lookup on miss," and the cache hit path honors that, but the cache miss catch dispatches to `getTableNoCache(PName, String, long)` whose third parameter is a primitive long, so when `timestamp == null` the JVM auto-unboxes the null `Long` and throws a NPE.

Co-authored-by: Claude Opus 4.8[1m] <noreply@anthropic.com>