### PR TITLE
PHOENIX-7952 UpsertSelectIT is flaky due to a connection leak check using a global counter

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/UpsertSelectIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/UpsertSelectIT.java
@@ -107,10 +107,25 @@ public class UpsertSelectIT extends ParallelStatsDisabledIT {
 
   @After
   public void assertNoConnLeak() throws Exception {
-    boolean refCountLeaked = isAnyStoreRefCountLeaked();
+    // The server-side UPSERT SELECT path can open auxiliary connections that are closed
+    // asynchronously on background threads, so a simple synchronous read can race ahead of
+    // their decrement. Poll for the counter to settle down before declaring a leak.
+    waitForOpenConnectionsToSettle();
     assertTrue(PhoenixRuntime.areGlobalClientMetricsBeingCollected());
-    assertEquals(0, GLOBAL_OPEN_PHOENIX_CONNECTIONS.getMetric().getValue());
+    boolean refCountLeaked = isAnyStoreRefCountLeaked();
     assertFalse("refCount leaked", refCountLeaked);
+  }
+
+  private static void waitForOpenConnectionsToSettle() throws InterruptedException {
+    final long timeoutMs = 30000;
+    final long pollIntervalMs = 100;
+    long deadline = EnvironmentEdgeManager.currentTimeMillis() + timeoutMs;
+    long openConnections = GLOBAL_OPEN_PHOENIX_CONNECTIONS.getMetric().getValue();
+    while (openConnections != 0 && EnvironmentEdgeManager.currentTimeMillis() < deadline) {
+      Thread.sleep(pollIntervalMs);
+      openConnections = GLOBAL_OPEN_PHOENIX_CONNECTIONS.getMetric().getValue();
+    }
+    assertEquals(0, openConnections);
   }
 
   // name is used by failsafe as file name in reports


### PR DESCRIPTION
`UpsertSelectIT.testUpsertSelectOnDescToAsc` intermittently fails in `assertNoConnLeak` with `java.lang.AssertionError: expected:<0> but was:<1>`.

The test executes an auto commit server side `DESC→ASC UPSERT INTO ... SELECT ...` which drives `MutationState`'s parallel mutating iterator chain and may open auxiliary `PhoenixConnection`s that are closed asynchronously on background threads. The test's `@After` hook reads a global `GLOBAL_OPEN_PHOENIX_CONNECTIONS` counter exactly once, immediately after the test body returns. If a background close path has not yet run its decrement by that moment, the counter still reads 1 and the hook reports a false connection leak. The race window widens when `NABLE_SERVER_SIDE_UPSERT_MUTATIONS` is true, since more auxiliary connections are involved.

The fix is to replace the single read with a bounded poll, for example, waiting up to 30 seconds for the counter to settle, following the same pattern used for `MaxConcurrentConnectionsIT`, and/or to ensure that every auxiliary connection opened on the server-side `UPSERT SELECT` path is decremented before control returns to the caller.

Co-authored-by: Claude Opus 4.8[1m] <noreply@anthropic.com>