### PR TITLE
PHOENIX-7945 - Retain orphaned delete markers during Phoenix compaction

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
@@ -383,6 +383,14 @@ abstract public class BaseScannerRegionObserver implements RegionObserver {
     options.setTTL(HConstants.FOREVER);
     options.setMaxVersions(Integer.MAX_VALUE);
     options.setMinVersions(Integer.MAX_VALUE);
+    // Prevent HBase from purging orphaned delete markers (those without corresponding
+    // puts) during compaction. Without this, DropDeletesCompactionScanQueryMatcher drops
+    // delete markers whose timestamp < earliestPutTs, before Phoenix CompactionScanner
+    // can see them. Once delivered to CompactionScanner, orphaned markers within the
+    // max-lookback window are retained by getLastRowVersionInMaxLookbackWindow (which
+    // unconditionally retains all cells with timestamp > maxLookbackWindowStart), and
+    // markers outside max-lookback are purged — same lifecycle as normal deleted rows.
+    options.setTimeToPurgeDeletes(Long.MAX_VALUE);
   }
 
   @Override

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/CompactionScanner.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/coprocessor/CompactionScanner.java
@@ -2154,9 +2154,12 @@ public class CompactionScanner implements InternalScanner {
       top: for (int index = 0; index < result.size(); index++) {
         Cell cell = result.get(index);
         if (cell.getTimestamp() > maxLookbackWindowStart) {
-          // All cells within the max lookback window are retained. Here we retain all
-          // except the ones at the lower edge of the window. Those will be included in
-          // the last row version in the rest of the body of the loop
+          // All cells within the max lookback window are retained regardless of type
+          // (puts, delete markers, etc.). This is the mechanism that preserves orphaned
+          // delete markers (those without corresponding puts, e.g. from replication)
+          // within the max-lookback window. The timeToPurgeDeletes setting in
+          // setScanOptionsForFlushesAndCompactions ensures HBase delivers these markers
+          // to CompactionScanner rather than dropping them at the StoreScanner layer.
           retainedCells.add(cell);
           continue;
         }
@@ -2516,6 +2519,11 @@ public class CompactionScanner implements InternalScanner {
       }
       getLastRowVersionInMaxLookbackWindow(result, lastRowVersion, retainedCells, emptyColumn);
       if (lastRowVersion.isEmpty()) {
+        // For orphaned delete markers (no puts in the row), lastRowVersion is empty.
+        // Within max-lookback: already in retainedCells (added unconditionally above).
+        // Outside max-lookback on major: retainedCells is empty, so marker is purged.
+        // Outside max-lookback on minor/flush: marker was added to retainedCells by
+        // the !major branch in getLastRowVersionInMaxLookbackWindow.
         return true;
       }
       if (!major) {

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OrphanDeleteMarkerCompactionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OrphanDeleteMarkerCompactionIT.java
@@ -1,0 +1,446 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.end2end;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Map;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellScanner;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.coprocessor.CompactionScanner;
+import org.apache.phoenix.coprocessorclient.BaseScannerRegionObserverConstants;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.query.BaseTest;
+import org.apache.phoenix.query.ConnectionQueryServices;
+import org.apache.phoenix.query.QueryServices;
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
+import org.apache.phoenix.util.EnvironmentEdgeManager;
+import org.apache.phoenix.util.ManualEnvironmentEdge;
+import org.apache.phoenix.util.ReadOnlyProps;
+import org.apache.phoenix.util.TestUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Integration test to verify the lifecycle of orphaned delete markers (DeleteFamily markers
+ * without corresponding Put cells) during compaction.
+ *
+ * Orphan delete markers follow the same lifecycle as normal deleted rows:
+ * - Within max-lookback: retained
+ * - Outside max-lookback: purged
+ * - Outside TTL: purged
+ *
+ * The root cause of the bug is HBase's DropDeletesCompactionScanQueryMatcher.tryDropDelete()
+ * which drops delete markers whose timestamp < earliestPutTs when KeepDeletedCells=TTL and
+ * timeToPurgeDeletes is 0. The fix sets timeToPurgeDeletes to Long.MAX_VALUE so HBase
+ * never purges delete markers before Phoenix CompactionScanner processes them.
+ *
+ * Users who need orphan delete markers retained beyond max-lookback (e.g., for replication
+ * scenarios) can use the per-table max-lookback override to extend it up to TTL.
+ */
+@Category(NeedsOwnMiniClusterTest.class)
+public class OrphanDeleteMarkerCompactionIT extends BaseTest {
+  private static final int MAX_LOOKBACK_AGE = 15;
+  private ManualEnvironmentEdge injectEdge;
+
+  @BeforeClass
+  public static synchronized void doSetup() throws Exception {
+    Map<String, String> props = Maps.newHashMapWithExpectedSize(4);
+    props.put(QueryServices.GLOBAL_INDEX_ROW_AGE_THRESHOLD_TO_DELETE_MS_ATTRIB, Long.toString(0));
+    props.put(BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY,
+      Integer.toString(MAX_LOOKBACK_AGE));
+    props.put(HRegion.MEMSTORE_PERIODIC_FLUSH_INTERVAL, "0");
+    setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
+  }
+
+  @Before
+  public void beforeTest() {
+    EnvironmentEdgeManager.reset();
+    injectEdge = new ManualEnvironmentEdge();
+    injectEdge.setValue(EnvironmentEdgeManager.currentTimeMillis());
+  }
+
+  @After
+  public synchronized void afterTest() throws Exception {
+    boolean refCountLeaked = isAnyStoreRefCountLeaked();
+    EnvironmentEdgeManager.reset();
+    Assert.assertFalse("refCount leaked", refCountLeaked);
+  }
+
+  /**
+   * Verifies that an orphaned delete marker within the max-lookback window survives major
+   * compaction. Without the timeToPurgeDeletes fix, HBase's tryDropDelete() would drop it
+   * because earliestPutTs (from a different row's HFile) > marker timestamp.
+   */
+  @Test(timeout = 120000L)
+  public void testOrphanedDeleteMarkerRetainedWithinMaxLookback() throws Exception {
+    try (Connection conn = DriverManager.getConnection(getUrl())) {
+      String tableName = generateUniqueName();
+      Statement stmt = conn.createStatement();
+      stmt.execute("CREATE TABLE " + tableName
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
+        + " TTL=300");
+      conn.commit();
+
+      EnvironmentEdgeManager.injectEdge(injectEdge);
+      injectEdge.incrementValue(1);
+
+      TableName hbaseTableName = TableName.valueOf(tableName);
+      ConnectionQueryServices cqs =
+        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      Table hTable = cqs.getTable(hbaseTableName.getName());
+
+      // Write an orphaned DeleteFamily marker using raw HBase API.
+      long oldDeleteTs = EnvironmentEdgeManager.currentTimeMillis();
+      byte[] rowA = Bytes.toBytes("a");
+      Delete delete = new Delete(rowA, oldDeleteTs);
+      hTable.delete(delete);
+
+      // Flush to persist the delete marker into its own HFile
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Advance time but stay WITHIN max-lookback window (advance 10s < 15s max-lookback)
+      injectEdge.incrementValue(10 * 1000L);
+
+      // Write a put for a DIFFERENT row — creates an HFile with earliestPutTs > marker ts,
+      // which triggers the tryDropDelete bug without the timeToPurgeDeletes fix.
+      stmt.execute("UPSERT INTO " + tableName + " VALUES ('b', 'v1', 'v2')");
+      conn.commit();
+
+      // Flush to create a second HFile
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      int deleteMarkersBefore = countDeleteMarkers(conn, hbaseTableName);
+      assertTrue("Expected at least one delete marker before compaction, found "
+        + deleteMarkersBefore, deleteMarkersBefore > 0);
+
+      // Major compact
+      TestUtil.majorCompact(getUtility(), hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Assert: marker within max-lookback is retained
+      int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
+      assertTrue("Orphaned delete marker within max-lookback should be retained after "
+          + "major compaction. Before=" + deleteMarkersBefore + ", After=" + deleteMarkersAfter,
+        deleteMarkersAfter > 0);
+
+      // Verify correct query behavior
+      ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " WHERE id = 'a'");
+      Assert.assertFalse("Deleted row should not be visible", rs.next());
+      rs = stmt.executeQuery("SELECT * FROM " + tableName + " WHERE id = 'b'");
+      Assert.assertTrue("Row 'b' should still be visible", rs.next());
+      assertEquals("v1", rs.getString("val1"));
+
+      hTable.close();
+    }
+  }
+
+  /**
+   * Verifies that an orphaned delete marker is purged once it ages past the max-lookback
+   * window but is still within TTL — same lifecycle as a normal Phoenix deleted row.
+   */
+  @Test(timeout = 120000L)
+  public void testOrphanedDeleteMarkerPurgedBetweenMaxLookbackAndTTL() throws Exception {
+    try (Connection conn = DriverManager.getConnection(getUrl())) {
+      String tableName = generateUniqueName();
+      Statement stmt = conn.createStatement();
+      stmt.execute("CREATE TABLE " + tableName
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
+        + " TTL=300");
+      conn.commit();
+
+      EnvironmentEdgeManager.injectEdge(injectEdge);
+      injectEdge.incrementValue(1);
+
+      TableName hbaseTableName = TableName.valueOf(tableName);
+      ConnectionQueryServices cqs =
+        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      Table hTable = cqs.getTable(hbaseTableName.getName());
+
+      // Write orphaned delete marker
+      long oldDeleteTs = EnvironmentEdgeManager.currentTimeMillis();
+      byte[] rowA = Bytes.toBytes("a");
+      Delete delete = new Delete(rowA, oldDeleteTs);
+      hTable.delete(delete);
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Write a put for a different row
+      stmt.execute("UPSERT INTO " + tableName + " VALUES ('b', 'v1', 'v2')");
+      conn.commit();
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Advance past max-lookback (20s > 15s) but still within TTL (300s)
+      injectEdge.incrementValue((MAX_LOOKBACK_AGE + 5) * 1000L);
+
+      // Major compact
+      TestUtil.majorCompact(getUtility(), hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Assert: marker outside max-lookback is purged (same as normal deleted row)
+      int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
+      assertEquals("Orphaned delete marker outside max-lookback should be purged "
+        + "(same as normal deleted row)", 0, deleteMarkersAfter);
+
+      hTable.close();
+    }
+  }
+
+  /**
+   * Verifies that an orphaned delete marker is purged when it is outside TTL.
+   */
+  @Test(timeout = 120000L)
+  public void testOrphanedDeleteMarkerPurgedOutsideTTL() throws Exception {
+    int ttl = 20;
+    try (Connection conn = DriverManager.getConnection(getUrl())) {
+      String tableName = generateUniqueName();
+      Statement stmt = conn.createStatement();
+      stmt.execute("CREATE TABLE " + tableName
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
+        + " TTL=" + ttl);
+      conn.commit();
+
+      EnvironmentEdgeManager.injectEdge(injectEdge);
+      injectEdge.incrementValue(1);
+
+      TableName hbaseTableName = TableName.valueOf(tableName);
+      ConnectionQueryServices cqs =
+        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      Table hTable = cqs.getTable(hbaseTableName.getName());
+
+      // Write orphaned delete marker
+      long oldDeleteTs = EnvironmentEdgeManager.currentTimeMillis();
+      byte[] rowA = Bytes.toBytes("a");
+      Delete delete = new Delete(rowA, oldDeleteTs);
+      hTable.delete(delete);
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Write a newer put for a different row
+      stmt.execute("UPSERT INTO " + tableName + " VALUES ('b', 'v1', 'v2')");
+      conn.commit();
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Advance time past TTL + max-lookback
+      injectEdge.incrementValue((ttl + MAX_LOOKBACK_AGE) * 1000L + 1000L);
+
+      // Major compact
+      TestUtil.majorCompact(getUtility(), hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Assert: marker outside TTL is purged
+      int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
+      assertEquals("Orphaned delete marker should be purged after TTL expires",
+        0, deleteMarkersAfter);
+
+      hTable.close();
+    }
+  }
+
+  /**
+   * Verifies that overriding max-lookback to match TTL retains the orphaned delete marker
+   * in the max-lookback-to-TTL window. This is the escape hatch for replication scenarios
+   * where users need markers retained longer than the global max-lookback.
+   */
+  @Test(timeout = 120000L)
+  public void testMaxLookbackOverrideRetainsOrphanedDeleteMarkerUntilTTL() throws Exception {
+    int ttl = 60;
+    try (Connection conn = DriverManager.getConnection(getUrl())) {
+      String tableName = generateUniqueName();
+      Statement stmt = conn.createStatement();
+      stmt.execute("CREATE TABLE " + tableName
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
+        + " TTL=" + ttl);
+      conn.commit();
+
+      // Override max-lookback for this table to match TTL (60s instead of global 15s)
+      CompactionScanner.overrideMaxLookback(tableName, "0", ttl * 1000L);
+
+      EnvironmentEdgeManager.injectEdge(injectEdge);
+      injectEdge.incrementValue(1);
+
+      TableName hbaseTableName = TableName.valueOf(tableName);
+      ConnectionQueryServices cqs =
+        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      Table hTable = cqs.getTable(hbaseTableName.getName());
+
+      // Write orphaned delete marker
+      long oldDeleteTs = EnvironmentEdgeManager.currentTimeMillis();
+      byte[] rowA = Bytes.toBytes("a");
+      Delete delete = new Delete(rowA, oldDeleteTs);
+      hTable.delete(delete);
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Write a put for a different row
+      stmt.execute("UPSERT INTO " + tableName + " VALUES ('b', 'v1', 'v2')");
+      conn.commit();
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Advance 30s — past the global max-lookback (15s) but within the
+      // per-table override (60s) and within TTL (60s)
+      injectEdge.incrementValue(30 * 1000L);
+
+      // Major compact
+      TestUtil.majorCompact(getUtility(), hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Assert: marker is retained because the per-table max-lookback is 60s
+      int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
+      assertTrue("Orphaned delete marker should be retained when within per-table "
+          + "max-lookback override. After=" + deleteMarkersAfter,
+        deleteMarkersAfter > 0);
+
+      // Now advance past the override (total ~31s more, so ~61s from marker creation)
+      injectEdge.incrementValue(31 * 1000L);
+
+      // Major compact again
+      TestUtil.majorCompact(getUtility(), hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Assert: marker is now purged — exceeded max-lookback override
+      deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
+      assertEquals("Orphaned delete marker should be purged after exceeding "
+        + "max-lookback override", 0, deleteMarkersAfter);
+
+      hTable.close();
+    }
+  }
+
+  /**
+   * Verifies minor compaction retains orphaned delete markers regardless of age
+   * (minor compactions never expire cells).
+   */
+  @Test(timeout = 120000L)
+  public void testOrphanedDeleteMarkerRetainedDuringMinorCompaction() throws Exception {
+    try (Connection conn = DriverManager.getConnection(getUrl())) {
+      String tableName = generateUniqueName();
+      Statement stmt = conn.createStatement();
+      stmt.execute("CREATE TABLE " + tableName
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
+        + " TTL=300");
+      conn.commit();
+
+      EnvironmentEdgeManager.injectEdge(injectEdge);
+      injectEdge.incrementValue(1);
+
+      TableName hbaseTableName = TableName.valueOf(tableName);
+      ConnectionQueryServices cqs =
+        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      Table hTable = cqs.getTable(hbaseTableName.getName());
+
+      // Write orphaned delete marker
+      long oldDeleteTs = EnvironmentEdgeManager.currentTimeMillis();
+      byte[] rowA = Bytes.toBytes("a");
+      Delete delete = new Delete(rowA, oldDeleteTs);
+      hTable.delete(delete);
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Write puts for different rows to create multiple HFiles
+      injectEdge.incrementValue(5000);
+      stmt.execute("UPSERT INTO " + tableName + " VALUES ('b', 'v1', 'v2')");
+      conn.commit();
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      stmt.execute("UPSERT INTO " + tableName + " VALUES ('c', 'v3', 'v4')");
+      conn.commit();
+      flush(hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      int deleteMarkersBefore = countDeleteMarkers(conn, hbaseTableName);
+      assertTrue("Expected at least one delete marker before minor compaction",
+        deleteMarkersBefore > 0);
+
+      // Run minor compaction
+      TestUtil.minorCompact(getUtility(), hbaseTableName);
+      injectEdge.incrementValue(1);
+
+      // Assert: minor compaction never expires cells
+      int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
+      assertTrue("Orphaned delete marker should be retained after minor compaction. "
+          + "Before=" + deleteMarkersBefore + ", After=" + deleteMarkersAfter,
+        deleteMarkersAfter > 0);
+
+      // Verify correct query behavior
+      ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " WHERE id = 'a'");
+      Assert.assertFalse("Deleted row should not be visible", rs.next());
+      rs = stmt.executeQuery("SELECT * FROM " + tableName + " WHERE id = 'b'");
+      Assert.assertTrue("Row 'b' should still be visible", rs.next());
+
+      hTable.close();
+    }
+  }
+
+  private void flush(TableName table) throws IOException {
+    Admin admin = getUtility().getAdmin();
+    admin.flush(table);
+  }
+
+  private int countDeleteMarkers(Connection conn, TableName tableName)
+    throws Exception {
+    ConnectionQueryServices cqs =
+      conn.unwrap(PhoenixConnection.class).getQueryServices();
+    Table table = cqs.getTable(tableName.getName());
+    Scan scan = new Scan();
+    scan.setRaw(true);
+    scan.readAllVersions();
+    int deleteMarkerCount = 0;
+    try (ResultScanner scanner = table.getScanner(scan)) {
+      Result result;
+      while ((result = scanner.next()) != null) {
+        CellScanner cellScanner = result.cellScanner();
+        while (cellScanner.advance()) {
+          Cell cell = cellScanner.current();
+          if (cell.getType() == Cell.Type.DeleteFamily
+            || cell.getType() == Cell.Type.DeleteColumn
+            || cell.getType() == Cell.Type.Delete) {
+            deleteMarkerCount++;
+          }
+        }
+      }
+    }
+    return deleteMarkerCount;
+  }
+}

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OrphanDeleteMarkerCompactionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OrphanDeleteMarkerCompactionIT.java
@@ -26,7 +26,6 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Map;
-
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.TableName;
@@ -44,7 +43,6 @@ import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.query.ConnectionQueryServices;
 import org.apache.phoenix.query.QueryServices;
-import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
 import org.apache.phoenix.util.EnvironmentEdgeManager;
 import org.apache.phoenix.util.ManualEnvironmentEdge;
 import org.apache.phoenix.util.ReadOnlyProps;
@@ -56,22 +54,19 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.phoenix.thirdparty.com.google.common.collect.Maps;
+
 /**
- * Integration test to verify the lifecycle of orphaned delete markers (DeleteFamily markers
- * without corresponding Put cells) during compaction.
- *
- * Orphan delete markers follow the same lifecycle as normal deleted rows:
- * - Within max-lookback: retained
- * - Outside max-lookback: purged
- * - Outside TTL: purged
- *
- * The root cause of the bug is HBase's DropDeletesCompactionScanQueryMatcher.tryDropDelete()
- * which drops delete markers whose timestamp < earliestPutTs when KeepDeletedCells=TTL and
- * timeToPurgeDeletes is 0. The fix sets timeToPurgeDeletes to Long.MAX_VALUE so HBase
- * never purges delete markers before Phoenix CompactionScanner processes them.
- *
- * Users who need orphan delete markers retained beyond max-lookback (e.g., for replication
- * scenarios) can use the per-table max-lookback override to extend it up to TTL.
+ * Integration test to verify the lifecycle of orphaned delete markers (DeleteFamily markers without
+ * corresponding Put cells) during compaction. Orphan delete markers follow the same lifecycle as
+ * normal deleted rows: - Within max-lookback: retained - Outside max-lookback: purged - Outside
+ * TTL: purged The root cause of the bug is HBase's
+ * DropDeletesCompactionScanQueryMatcher.tryDropDelete() which drops delete markers whose timestamp
+ * < earliestPutTs when KeepDeletedCells=TTL and timeToPurgeDeletes is 0. The fix sets
+ * timeToPurgeDeletes to Long.MAX_VALUE so HBase never purges delete markers before Phoenix
+ * CompactionScanner processes them. Users who need orphan delete markers retained beyond
+ * max-lookback (e.g., for replication scenarios) can use the per-table max-lookback override to
+ * extend it up to TTL.
  */
 @Category(NeedsOwnMiniClusterTest.class)
 public class OrphanDeleteMarkerCompactionIT extends BaseTest {
@@ -104,8 +99,8 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
 
   /**
    * Verifies that an orphaned delete marker within the max-lookback window survives major
-   * compaction. Without the timeToPurgeDeletes fix, HBase's tryDropDelete() would drop it
-   * because earliestPutTs (from a different row's HFile) > marker timestamp.
+   * compaction. Without the timeToPurgeDeletes fix, HBase's tryDropDelete() would drop it because
+   * earliestPutTs (from a different row's HFile) > marker timestamp.
    */
   @Test(timeout = 120000L)
   public void testOrphanedDeleteMarkerRetainedWithinMaxLookback() throws Exception {
@@ -113,16 +108,14 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
       String tableName = generateUniqueName();
       Statement stmt = conn.createStatement();
       stmt.execute("CREATE TABLE " + tableName
-        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
-        + " TTL=300");
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)" + " TTL=300");
       conn.commit();
 
       EnvironmentEdgeManager.injectEdge(injectEdge);
       injectEdge.incrementValue(1);
 
       TableName hbaseTableName = TableName.valueOf(tableName);
-      ConnectionQueryServices cqs =
-        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      ConnectionQueryServices cqs = conn.unwrap(PhoenixConnection.class).getQueryServices();
       Table hTable = cqs.getTable(hbaseTableName.getName());
 
       // Write an orphaned DeleteFamily marker using raw HBase API.
@@ -148,8 +141,9 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
       injectEdge.incrementValue(1);
 
       int deleteMarkersBefore = countDeleteMarkers(conn, hbaseTableName);
-      assertTrue("Expected at least one delete marker before compaction, found "
-        + deleteMarkersBefore, deleteMarkersBefore > 0);
+      assertTrue(
+        "Expected at least one delete marker before compaction, found " + deleteMarkersBefore,
+        deleteMarkersBefore > 0);
 
       // Major compact
       TestUtil.majorCompact(getUtility(), hbaseTableName);
@@ -157,7 +151,8 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
 
       // Assert: marker within max-lookback is retained
       int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
-      assertTrue("Orphaned delete marker within max-lookback should be retained after "
+      assertTrue(
+        "Orphaned delete marker within max-lookback should be retained after "
           + "major compaction. Before=" + deleteMarkersBefore + ", After=" + deleteMarkersAfter,
         deleteMarkersAfter > 0);
 
@@ -173,8 +168,8 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
   }
 
   /**
-   * Verifies that an orphaned delete marker is purged once it ages past the max-lookback
-   * window but is still within TTL — same lifecycle as a normal Phoenix deleted row.
+   * Verifies that an orphaned delete marker is purged once it ages past the max-lookback window but
+   * is still within TTL — same lifecycle as a normal Phoenix deleted row.
    */
   @Test(timeout = 120000L)
   public void testOrphanedDeleteMarkerPurgedBetweenMaxLookbackAndTTL() throws Exception {
@@ -182,16 +177,14 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
       String tableName = generateUniqueName();
       Statement stmt = conn.createStatement();
       stmt.execute("CREATE TABLE " + tableName
-        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
-        + " TTL=300");
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)" + " TTL=300");
       conn.commit();
 
       EnvironmentEdgeManager.injectEdge(injectEdge);
       injectEdge.incrementValue(1);
 
       TableName hbaseTableName = TableName.valueOf(tableName);
-      ConnectionQueryServices cqs =
-        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      ConnectionQueryServices cqs = conn.unwrap(PhoenixConnection.class).getQueryServices();
       Table hTable = cqs.getTable(hbaseTableName.getName());
 
       // Write orphaned delete marker
@@ -234,16 +227,14 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
       String tableName = generateUniqueName();
       Statement stmt = conn.createStatement();
       stmt.execute("CREATE TABLE " + tableName
-        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
-        + " TTL=" + ttl);
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)" + " TTL=" + ttl);
       conn.commit();
 
       EnvironmentEdgeManager.injectEdge(injectEdge);
       injectEdge.incrementValue(1);
 
       TableName hbaseTableName = TableName.valueOf(tableName);
-      ConnectionQueryServices cqs =
-        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      ConnectionQueryServices cqs = conn.unwrap(PhoenixConnection.class).getQueryServices();
       Table hTable = cqs.getTable(hbaseTableName.getName());
 
       // Write orphaned delete marker
@@ -269,17 +260,17 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
 
       // Assert: marker outside TTL is purged
       int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
-      assertEquals("Orphaned delete marker should be purged after TTL expires",
-        0, deleteMarkersAfter);
+      assertEquals("Orphaned delete marker should be purged after TTL expires", 0,
+        deleteMarkersAfter);
 
       hTable.close();
     }
   }
 
   /**
-   * Verifies that overriding max-lookback to match TTL retains the orphaned delete marker
-   * in the max-lookback-to-TTL window. This is the escape hatch for replication scenarios
-   * where users need markers retained longer than the global max-lookback.
+   * Verifies that overriding max-lookback to match TTL retains the orphaned delete marker in the
+   * max-lookback-to-TTL window. This is the escape hatch for replication scenarios where users need
+   * markers retained longer than the global max-lookback.
    */
   @Test(timeout = 120000L)
   public void testMaxLookbackOverrideRetainsOrphanedDeleteMarkerUntilTTL() throws Exception {
@@ -288,8 +279,7 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
       String tableName = generateUniqueName();
       Statement stmt = conn.createStatement();
       stmt.execute("CREATE TABLE " + tableName
-        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
-        + " TTL=" + ttl);
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)" + " TTL=" + ttl);
       conn.commit();
 
       // Override max-lookback for this table to match TTL (60s instead of global 15s)
@@ -299,8 +289,7 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
       injectEdge.incrementValue(1);
 
       TableName hbaseTableName = TableName.valueOf(tableName);
-      ConnectionQueryServices cqs =
-        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      ConnectionQueryServices cqs = conn.unwrap(PhoenixConnection.class).getQueryServices();
       Table hTable = cqs.getTable(hbaseTableName.getName());
 
       // Write orphaned delete marker
@@ -328,8 +317,7 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
       // Assert: marker is retained because the per-table max-lookback is 60s
       int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
       assertTrue("Orphaned delete marker should be retained when within per-table "
-          + "max-lookback override. After=" + deleteMarkersAfter,
-        deleteMarkersAfter > 0);
+        + "max-lookback override. After=" + deleteMarkersAfter, deleteMarkersAfter > 0);
 
       // Now advance past the override (total ~31s more, so ~61s from marker creation)
       injectEdge.incrementValue(31 * 1000L);
@@ -340,16 +328,17 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
 
       // Assert: marker is now purged — exceeded max-lookback override
       deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
-      assertEquals("Orphaned delete marker should be purged after exceeding "
-        + "max-lookback override", 0, deleteMarkersAfter);
+      assertEquals(
+        "Orphaned delete marker should be purged after exceeding " + "max-lookback override", 0,
+        deleteMarkersAfter);
 
       hTable.close();
     }
   }
 
   /**
-   * Verifies minor compaction retains orphaned delete markers regardless of age
-   * (minor compactions never expire cells).
+   * Verifies minor compaction retains orphaned delete markers regardless of age (minor compactions
+   * never expire cells).
    */
   @Test(timeout = 120000L)
   public void testOrphanedDeleteMarkerRetainedDuringMinorCompaction() throws Exception {
@@ -357,16 +346,14 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
       String tableName = generateUniqueName();
       Statement stmt = conn.createStatement();
       stmt.execute("CREATE TABLE " + tableName
-        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)"
-        + " TTL=300");
+        + " (id VARCHAR NOT NULL PRIMARY KEY, val1 VARCHAR, val2 VARCHAR)" + " TTL=300");
       conn.commit();
 
       EnvironmentEdgeManager.injectEdge(injectEdge);
       injectEdge.incrementValue(1);
 
       TableName hbaseTableName = TableName.valueOf(tableName);
-      ConnectionQueryServices cqs =
-        conn.unwrap(PhoenixConnection.class).getQueryServices();
+      ConnectionQueryServices cqs = conn.unwrap(PhoenixConnection.class).getQueryServices();
       Table hTable = cqs.getTable(hbaseTableName.getName());
 
       // Write orphaned delete marker
@@ -399,9 +386,8 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
 
       // Assert: minor compaction never expires cells
       int deleteMarkersAfter = countDeleteMarkers(conn, hbaseTableName);
-      assertTrue("Orphaned delete marker should be retained after minor compaction. "
-          + "Before=" + deleteMarkersBefore + ", After=" + deleteMarkersAfter,
-        deleteMarkersAfter > 0);
+      assertTrue("Orphaned delete marker should be retained after minor compaction. " + "Before="
+        + deleteMarkersBefore + ", After=" + deleteMarkersAfter, deleteMarkersAfter > 0);
 
       // Verify correct query behavior
       ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " WHERE id = 'a'");
@@ -418,10 +404,8 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
     admin.flush(table);
   }
 
-  private int countDeleteMarkers(Connection conn, TableName tableName)
-    throws Exception {
-    ConnectionQueryServices cqs =
-      conn.unwrap(PhoenixConnection.class).getQueryServices();
+  private int countDeleteMarkers(Connection conn, TableName tableName) throws Exception {
+    ConnectionQueryServices cqs = conn.unwrap(PhoenixConnection.class).getQueryServices();
     Table table = cqs.getTable(tableName.getName());
     Scan scan = new Scan();
     scan.setRaw(true);
@@ -433,9 +417,10 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
         CellScanner cellScanner = result.cellScanner();
         while (cellScanner.advance()) {
           Cell cell = cellScanner.current();
-          if (cell.getType() == Cell.Type.DeleteFamily
-            || cell.getType() == Cell.Type.DeleteColumn
-            || cell.getType() == Cell.Type.Delete) {
+          if (
+            cell.getType() == Cell.Type.DeleteFamily || cell.getType() == Cell.Type.DeleteColumn
+              || cell.getType() == Cell.Type.Delete
+          ) {
             deleteMarkerCount++;
           }
         }


### PR DESCRIPTION
## Summary

Orphaned delete markers (DeleteFamily markers without corresponding puts) are dropped during major compaction before Phoenix CompactionScanner can process them.


## Root Cause

HBase `DropDeletesCompactionScanQueryMatcher.tryDropDelete()` drops delete markers whose timestamp < `earliestPutTs` when `KeepDeletedCells=TTL` and `timeToPurgeDeletes` is 0. Since `earliestPutTs` is a **global minimum across ALL HFiles** being compacted, a put in any other row HFile can cause orphaned markers to be dropped before Phoenix CompactionScanner ever sees them.

## Fix

Set `timeToPurgeDeletes = Long.MAX_VALUE` in `setScanOptionsForFlushesAndCompactions()`. This short-circuits `tryDropDelete()` so HBase never purges delete markers -- Phoenix CompactionScanner then applies its standard max-lookback logic.


## How CompactionScanner Preserves Orphan Markers Within Max-Lookback

Once `timeToPurgeDeletes` ensures HBase delivers all cells to CompactionScanner, the existing max-lookback logic handles orphan delete markers correctly:

In `getLastRowVersionInMaxLookbackWindow()`, the very first check is:
```java
if (cell.getTimestamp() > maxLookbackWindowStart) {
    retainedCells.add(cell);  // unconditionally retained regardless of cell type
    continue;
}
```

This retains ALL cells within the max-lookback window -- puts, delete markers, orphaned markers alike. No special handling needed. The marker goes directly into `retainedCells` and survives compaction.

For markers **outside** max-lookback: they fall through to the column-formation logic where `deleteFamilyCell` is set but `lastRowVersion` stays empty (no puts exist). Back in `retainCellsForMaxLookback`, `lastRowVersion.isEmpty()` returns true with empty `retainedCells` -- the marker is purged. This matches the behavior of normal deleted rows outside max-lookback.

## Orphan Delete Marker Lifecycle (with fix)

Same as normal deleted rows:

| Time Zone | Behavior |
|-----------|----------|
| Within max-lookback | Retained |
| Outside max-lookback (but within TTL) | **Purged** |
| Outside TTL | Purged |

Users who need markers retained beyond max-lookback (for replication lag) can use the per-table max-lookback override to extend it up to TTL.

## Comparison with HBase (without Phoenix)

| Configuration | Behavior for orphan markers |
|--------------|----------------------------|
| `KeepDeletedCells=FALSE` (default) | Always dropped (SKIP) |
| `KeepDeletedCells=TTL` | Still dropped via `earliestPutTs` bug |
| `timeToPurgeDeletes > 0` | Only reliable mechanism -- marker retained until `now - markerTs > timeToPurgeDeletes` |

Phoenix already sets `KeepDeletedCells=TTL` for its compaction scans, but that alone is insufficient because `tryDropDelete()` runs before the cell reaches CompactionScanner. Setting `timeToPurgeDeletes = Long.MAX_VALUE` is the equivalent of telling HBase "never purge markers -- Phoenix will handle it."

## Negative Test Validation

Verified that removing the `timeToPurgeDeletes` fix causes the within-max-lookback test to fail:

```
java.lang.AssertionError: Orphaned delete marker within max-lookback should be retained
after major compaction. Before=1, After=0
  at OrphanDeleteMarkerCompactionIT.testOrphanedDeleteMarkerRetainedWithinMaxLookback(OrphanDeleteMarkerCompactionIT.java:160)
```

This confirms:
- Without the fix, HBase drops the orphaned marker at the StoreScanner layer (`tryDropDelete`) even when the marker is well within the max-lookback window
- The existing CompactionScanner max-lookback logic is correct but never gets a chance to run because it never receives the cell

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://phoenix.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] PHOENIX-XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes, and prefix it with the JIRA id, e.g. 'PHOENIX-XXXX Your PR title ...'.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Phoenix versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Co-authored-by: Claude Opus 4.8[1m] [noreply@anthropic.com](mailto:noreply@anthropic.com)