### PR TITLE
PHOENIX-7945 Fix OrphanDeleteMarkerCompactionIT timeout on HBase 2.6 (addendum)

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/OrphanDeleteMarkerCompactionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/OrphanDeleteMarkerCompactionIT.java
@@ -75,11 +75,12 @@ public class OrphanDeleteMarkerCompactionIT extends BaseTest {
 
   @BeforeClass
   public static synchronized void doSetup() throws Exception {
-    Map<String, String> props = Maps.newHashMapWithExpectedSize(4);
+    Map<String, String> props = Maps.newHashMapWithExpectedSize(5);
     props.put(QueryServices.GLOBAL_INDEX_ROW_AGE_THRESHOLD_TO_DELETE_MS_ATTRIB, Long.toString(0));
     props.put(BaseScannerRegionObserverConstants.PHOENIX_MAX_LOOKBACK_AGE_CONF_KEY,
       Integer.toString(MAX_LOOKBACK_AGE));
     props.put(HRegion.MEMSTORE_PERIODIC_FLUSH_INTERVAL, "0");
+    props.put("hbase.procedure.remote.dispatcher.delay.msec", "0");
     setUpTestDriver(new ReadOnlyProps(props.entrySet().iterator()));
   }
 


### PR DESCRIPTION
## Summary

- Adds `hbase.procedure.remote.dispatcher.delay.msec=0` to `OrphanDeleteMarkerCompactionIT.doSetup()` to prevent deterministic deadlock on HBase 2.6 CI profile.

## Root Cause

HBase 2.6 (HBASE-26867) moved `Admin.flush()` from ZK-based `execProcedure` to ProcedureV2 (`FlushTableProcedure` → `FlushRegionProcedure`). The `RemoteProcedureDispatcher` uses a `DelayQueue` keyed on `EnvironmentEdgeManager.currentTime()` with a default 150ms delay. When `ManualEnvironmentEdge` is injected and only the blocked test thread can advance time, the dispatch item never expires — deterministic deadlock causing 120s timeout.

## Fix

Set `hbase.procedure.remote.dispatcher.delay.msec=0` so the dispatch item expires immediately from the `DelayQueue`. This is consistent with the fix already applied to 10+ other Phoenix test classes after PHOENIX-7353/7354.

## Test plan

- [x] All 5 tests in `OrphanDeleteMarkerCompactionIT` pass on HBase 2.6 profile (59.76s)
- [ ] CI green on hbase-2.6 profile