### PR TITLE
PHOENIX-7965 :- ConnectionQueryServicesImpl.getMetaDataCache() returns null after connection close, causing a bare NPE during concurrent query compilation

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -1090,7 +1090,16 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices
   }
 
   public PMetaData getMetaDataCache() {
-    return latestMetaData;
+    // A concurrent close() (e.g. connection pool teardown or cluster failover) nulls out
+    // latestMetaData. Read it once into a local so the null-check and the returned reference
+    // are guaranteed to be the same value; a caller that immediately dereferences the result
+    // then surfaces the descriptive "connection closed" exception instead of a bare NPE,
+    // matching every other cache accessor/mutator on this class.
+    PMetaData cache = latestMetaData;
+    if (cache == null) {
+      throwConnectionClosedException();
+    }
+    return cache;
   }
 
   @Override

--- a/phoenix-core/src/test/java/org/apache/phoenix/query/ConnectionQueryServicesImplTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/ConnectionQueryServicesImplTest.java
@@ -73,6 +73,7 @@ import org.apache.phoenix.exception.PhoenixIOException;
 import org.apache.phoenix.jdbc.ConnectionInfo;
 import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
 import org.apache.phoenix.monitoring.GlobalClientMetrics;
+import org.apache.phoenix.schema.PMetaData;
 import org.apache.phoenix.util.ReadOnlyProps;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -407,5 +408,58 @@ public class ConnectionQueryServicesImplTest {
     verify(mockAdmin, Mockito.times(1)).disableTable(TableName.valueOf("TEST_TABLE"));
     verify(mockAdmin, Mockito.times(1)).deleteTable(TableName.valueOf("TEST_TABLE"));
     verify(mockConn).getAdmin();
+  }
+
+  /**
+   * When a connection is closed concurrently with query compilation (e.g. connection pool teardown
+   * or cluster failover), the metadata cache is nulled out. getMetaDataCache() must surface the
+   * descriptive "connection closed" exception rather than returning null and letting callers hit a
+   * bare NPE.
+   */
+  @Test
+  public void testGetMetaDataCacheThrowsWhenClosed()
+    throws NoSuchFieldException, IllegalAccessException {
+    ConnectionQueryServicesImpl cqsi = newRealCqsi();
+    // Simulate the post-close() state where close() has set latestMetaData = null.
+    setLatestMetaData(cqsi, null);
+    try {
+      cqsi.getMetaDataCache();
+      fail("Expected IllegalStateException for a closed connection, but no exception was thrown");
+    } catch (IllegalStateException e) {
+      assertEquals("Connection to the cluster is closed", e.getMessage());
+    }
+  }
+
+  /**
+   * When the metadata cache is present (open connection), getMetaDataCache() returns it unchanged.
+   */
+  @Test
+  public void testGetMetaDataCacheReturnsCacheWhenOpen()
+    throws NoSuchFieldException, IllegalAccessException {
+    ConnectionQueryServicesImpl cqsi = newRealCqsi();
+    PMetaData metaData = Mockito.mock(PMetaData.class);
+    setLatestMetaData(cqsi, metaData);
+    assertSame(metaData, cqsi.getMetaDataCache());
+  }
+
+  /**
+   * Builds a real ConnectionQueryServicesImpl so that getMetaDataCache() and its private
+   * throwConnectionClosedIfNullMetaData() guard execute for real. A CALLS_REAL_METHODS mock cannot
+   * be used here because Mockito does not route the internal call to the private guard method.
+   */
+  private static ConnectionQueryServicesImpl newRealCqsi() {
+    QueryServices mockQueryServices = Mockito.mock(QueryServices.class);
+    ReadOnlyProps emptyProps = ReadOnlyProps.EMPTY_PROPS;
+    when(mockQueryServices.getProps()).thenReturn(emptyProps);
+    ConnectionInfo mockConnectionInfo = Mockito.mock(ConnectionInfo.class);
+    when(mockConnectionInfo.asProps()).thenReturn(emptyProps);
+    return new ConnectionQueryServicesImpl(mockQueryServices, mockConnectionInfo, new Properties());
+  }
+
+  private static void setLatestMetaData(ConnectionQueryServicesImpl cqsi, PMetaData value)
+    throws NoSuchFieldException, IllegalAccessException {
+    Field field = ConnectionQueryServicesImpl.class.getDeclaredField("latestMetaData");
+    field.setAccessible(true);
+    field.set(cqsi, value);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ConnectionQueryServicesImpl.getMetaDataCache()` returned the `volatile latestMetaData` field directly, with no null guard:

```java
public PMetaData getMetaDataCache() {
  return latestMetaData;
}
```

This PR adds a guard so a closed connection surfaces a descriptive exception instead of a bare NPE. The read is done once into a local so the null-check and the returned reference are guaranteed to be the same value (no time-of-check/time-of-use re-read window):

```java
public PMetaData getMetaDataCache() {
  PMetaData cache = latestMetaData;
  if (cache == null) {
    throwConnectionClosedException();
  }
  return cache;
}
```

`throwConnectionClosedException()` is the same private helper that the existing `throwConnectionClosedIfNullMetaData()` (used by `addTable`, `removeTable`, `pruneTables`, the internal `getTable` path, etc.) delegates to — it throws `IllegalStateException("Connection to the cluster is closed")`. `getMetaDataCache()` was the one cache accessor missing this guard.

### Why are the changes needed?

`close()` sets `latestMetaData = null`. When a connection is closed concurrently with query compilation (for example, connection-pool teardown or a cluster role transition), an in-flight compile reaches the cache via `PhoenixConnection.getTableRef()` / `getFunction()` / `getSchema()`, which call `getMetaDataCache().getTableRef(key)` (and friends) on the `null` return. The result is a **bare, causeless `NullPointerException`** with no message — difficult to attribute to a closed connection during triage.

Every other accessor/mutator on this class already guards this state and throws the descriptive `IllegalStateException`; `getMetaDataCache()` was inconsistent. This change makes the failure mode uniform and diagnosable.

### Does this PR introduce _any_ user-facing change?

No behavioral change on an open connection: when `latestMetaData` is present, the method returns exactly the same cache reference as before. The only change is the failure mode when the connection has been closed — an opaque `NullPointerException` is upgraded to a descriptive `IllegalStateException("Connection to the cluster is closed")`. No caller relies on a `null` return (every production caller immediately dereferences the result), so no caller is regressed.

### How was this patch tested?

Added unit tests in `ConnectionQueryServicesImplTest` exercising a **real** `ConnectionQueryServicesImpl` instance (not a mock, so the real guard executes):

- `testGetMetaDataCacheThrowsWhenClosed` — reflectively nulls `latestMetaData` (closed-connection state) and asserts `getMetaDataCache()` throws `IllegalStateException` with message `"Connection to the cluster is closed"`.
- `testGetMetaDataCacheReturnsCacheWhenOpen` — asserts the method returns the cache unchanged when present.

Both pass (`Tests run: 2, Failures: 0, Errors: 0`) via a reactor build (`mvn -pl phoenix-core -am test`). `mvn spotless:apply` reports the tree clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 (1M context))
