### PR TITLE
PHOENIX-7969 Update supported client versions in backward compatibility

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/BackwardCompatibilityTestUtil.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/BackwardCompatibilityTestUtil.java
@@ -143,10 +143,10 @@ public final class BackwardCompatibilityTestUtil {
       if (hbaseProfileNode == null) {
         return clientVersionGroups;
       }
-      for (final JsonNode groupNode : hbaseProfileNode) {
+      for (final JsonNode clientVersionGroupNode : hbaseProfileNode) {
         List<MavenCoordinates> artifacts = new ArrayList<>();
-        for (final JsonNode clientVersion : groupNode) {
-          artifacts.add(mapper.treeToValue(clientVersion, MavenCoordinates.class));
+        for (final JsonNode artifactNode : clientVersionGroupNode) {
+          artifacts.add(mapper.treeToValue(artifactNode, MavenCoordinates.class));
         }
         if (!artifacts.isEmpty()) {
           clientVersionGroups.add(new ClientVersionGroup(artifacts.get(0), artifacts));

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/BackwardCompatibilityTestUtil.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/BackwardCompatibilityTestUtil.java
@@ -139,14 +139,18 @@ public final class BackwardCompatibilityTestUtil {
       BackwardCompatibilityIT.class.getClassLoader().getResourceAsStream(COMPATIBLE_CLIENTS_JSON)) {
       assertNotNull(inputStream);
       JsonNode jsonNode = mapper.readTree(inputStream);
-      JsonNode HBaseProfile = jsonNode.get(hbaseProfile);
-      List<MavenCoordinates> artifacts = new ArrayList<>();
-      for (final JsonNode clientVersion : HBaseProfile) {
-        artifacts.add(mapper.treeToValue(clientVersion, MavenCoordinates.class));
+      JsonNode hbaseProfileNode = jsonNode.get(hbaseProfile);
+      if (hbaseProfileNode == null) {
+        return clientVersionGroups;
       }
-      if (!artifacts.isEmpty()) {
-        MavenCoordinates primary = artifacts.get(0);
-        clientVersionGroups.add(new ClientVersionGroup(primary, artifacts));
+      for (final JsonNode groupNode : hbaseProfileNode) {
+        List<MavenCoordinates> artifacts = new ArrayList<>();
+        for (final JsonNode clientVersion : groupNode) {
+          artifacts.add(mapper.treeToValue(clientVersion, MavenCoordinates.class));
+        }
+        if (!artifacts.isEmpty()) {
+          clientVersionGroups.add(new ClientVersionGroup(artifacts.get(0), artifacts));
+        }
       }
     }
     return clientVersionGroups;

--- a/phoenix-core/src/it/resources/compatible_client_versions.json
+++ b/phoenix-core/src/it/resources/compatible_client_versions.json
@@ -1,50 +1,149 @@
 {
   "_comment": "Lists all phoenix compatible client versions against the current branch version for a given hbase profile.",
   "2.4": [
-    {
-      "artifactId": "phoenix-client-hbase-2.4",
-      "version": "5.1.2"
-    }
+    [
+      {
+        "artifactId": "phoenix-client-hbase-2.4",
+        "version": "5.1.2"
+      }
+    ]
   ],
   "2.5": [
-    {
-      "artifactId": "phoenix-client-hbase-2.5",
-      "version": "5.1.3"
-    }
+    [
+      {
+        "artifactId": "phoenix-client-embedded-hbase-2.5",
+        "version": "5.2.2"
+      },
+      {
+        "artifactId": "sqlline",
+        "version": "1.9.0",
+        "groupId": "sqlline"
+      },
+      {
+        "artifactId": "jline-terminal",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "jline-reader",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "jline-builtins",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "log4j-1.2-api",
+        "version": "2.25.3",
+        "groupId": "org.apache.logging.log4j"
+      }
+    ],
+    [
+      {
+        "artifactId": "phoenix-client-embedded-hbase-2.5",
+        "version": "5.3.2"
+      },
+      {
+        "artifactId": "sqlline",
+        "version": "1.9.0",
+        "groupId": "sqlline"
+      },
+      {
+        "artifactId": "jline-terminal",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "jline-reader",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "jline-builtins",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "log4j-1.2-api",
+        "version": "2.25.3",
+        "groupId": "org.apache.logging.log4j"
+      },
+      {
+        "artifactId": "commons-logging",
+        "version": "1.2",
+        "groupId": "commons-logging"
+      }
+    ]
   ],
   "2.6": [
-    {
-      "artifactId": "phoenix-client-embedded-hbase-2.6",
-      "version": "5.2.1"
-    },
-    {
-      "artifactId": "phoenix-core-client",
-      "version": "5.2.1"
-    },
-    {
-      "artifactId": "sqlline",
-      "version": "1.9.0",
-      "groupId": "sqlline"
-    },
-    {
-      "artifactId": "jline-terminal",
-      "version": "3.12.1",
-      "groupId": "org.jline"
-    },
-    {
-      "artifactId": "jline-reader",
-      "version": "3.12.1",
-      "groupId": "org.jline"
-    },
-    {
-      "artifactId": "jline-builtins",
-      "version": "3.12.1",
-      "groupId": "org.jline"
-    },
-    {
-      "artifactId": "log4j-1.2-api",
-      "version": "2.18.0",
-      "groupId": "org.apache.logging.log4j"
-    }
+    [
+      {
+        "artifactId": "phoenix-client-embedded-hbase-2.6",
+        "version": "5.2.2"
+      },
+      {
+        "artifactId": "sqlline",
+        "version": "1.9.0",
+        "groupId": "sqlline"
+      },
+      {
+        "artifactId": "jline-terminal",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "jline-reader",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "jline-builtins",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "log4j-1.2-api",
+        "version": "2.25.3",
+        "groupId": "org.apache.logging.log4j"
+      }
+    ],
+    [
+      {
+        "artifactId": "phoenix-client-embedded-hbase-2.6",
+        "version": "5.3.2"
+      },
+      {
+        "artifactId": "sqlline",
+        "version": "1.9.0",
+        "groupId": "sqlline"
+      },
+      {
+        "artifactId": "jline-terminal",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "jline-reader",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "jline-builtins",
+        "version": "3.12.1",
+        "groupId": "org.jline"
+      },
+      {
+        "artifactId": "log4j-1.2-api",
+        "version": "2.25.3",
+        "groupId": "org.apache.logging.log4j"
+      },
+      {
+        "artifactId": "commons-logging",
+        "version": "1.2",
+        "groupId": "commons-logging"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
Jira: [https://issues.apache.org/jira/browse/PHOENIX-7969](https://issues.apache.org/jira/browse/PHOENIX-7969)

The client versions exercised by BackwardCompatibilityIT (via compatible_client_versions.json) have drifted and no longer reflect the Phoenix clients actually supported against each HBase profile on master. Refresh the list so the test covers currently supported clients. A small adjustment to BackwardCompatibilityTestUtil is included to consume the updated config shape.

The 2.4 entry is left untouched since HBase 2.4 is no longer a supported profile on master.