### PR TITLE
PHOENIX-7970 :- QueryDatabaseMetaDataIT.testShowTables fails after SYSTEM.HA_GROUP is added to the SYSTEM schema

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/QueryDatabaseMetaDataIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/QueryDatabaseMetaDataIT.java
@@ -434,9 +434,10 @@ public class QueryDatabaseMetaDataIT extends ParallelStatsDisabledIT {
         tables.add(rs.getString("TABLE_NAME"));
         assertEquals("SYSTEM", rs.getString("TABLE_SCHEM"));
       }
-      assertEquals(12, tables.size());
+      assertEquals(13, tables.size());
       assertTrue(tables.contains("CATALOG"));
       assertTrue(tables.contains("FUNCTION"));
+      assertTrue(tables.contains("HA_GROUP"));
 
       tables.clear();
       // Add a filter on the table name.


### PR DESCRIPTION
### Description of the problem including root cause

The consistent-failover work on the `PHOENIX-7562-feature-new` line adds a new system table, `SYSTEM.HA_GROUP` (`PhoenixDatabaseMetaData.SYSTEM_HA_GROUP_TABLE`), to the SYSTEM schema. This raises the number of tables in the SYSTEM schema from 12 to 13.

`QueryDatabaseMetaDataIT.testShowTables` hard-codes the previous count when running `SHOW TABLES IN SYSTEM`, so on this feature line it fails with:

```
java.lang.AssertionError: expected:<12> but was:<13>
```

### Fix

Test-only change:
- Update the expected SYSTEM table count from `12` to `13`.
- Add `assertTrue(tables.contains("HA_GROUP"))` so the test documents that `SYSTEM.HA_GROUP` is expected to be present.

No production code is changed. The `SHOW TABLES IN SYSTEM LIKE 'FUNC%'` assertion (expecting exactly one match, `FUNCTION`) is untouched.

### Tests

`QueryDatabaseMetaDataIT#testShowTables` runs and passes locally on the `PHOENIX-7562-feature-new` base (`Tests run: 1, Failures: 0, Errors: 0`).

### AI disclosure

Per the ASF generative-tooling policy, this change was produced with the assistance of generative AI. The commit carries the trailer `Generated-by: Claude Code (Opus 4.8 (1M context))`. All changes were reviewed before submission.

### Notes / backward compatibility

No API, wire, or on-disk format changes; this is an integration-test assertion update scoped to the feature branch's new SYSTEM table. No backward-compatibility impact.
