### PR TITLE
PHOENIX-7980 Improve handling of test timeouts and resource loss

### DIFF
--- a/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/query/BaseTest.java
@@ -169,6 +169,7 @@ import org.apache.phoenix.util.ServerUtil.ConnectionFactory;
 import org.apache.phoenix.util.TestUtil;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -198,6 +199,9 @@ public abstract class BaseTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseTest.class);
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  @ClassRule
+  public static Timeout CLASS_TIMEOUT =
+    Timeout.builder().withTimeout(20, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
   private static final int dropTableTimeout = 120; // 2 mins should be long enough.
   private static final ThreadFactory factory = new ThreadFactoryBuilder().setDaemon(true)
     .setNameFormat("DROP-TABLE-BASETEST" + "-thread-%s").build();
@@ -446,9 +450,28 @@ public abstract class BaseTest {
 
   protected static synchronized void setUpTestDriver(ReadOnlyProps serverProps,
     ReadOnlyProps clientProps) throws Exception {
+    assertSharedMiniClusterHealthy();
     if (driver == null) {
       String url = checkClusterInitialized(serverProps);
       driver = initAndRegisterTestDriver(url, clientProps);
+    }
+  }
+
+  private static void assertSharedMiniClusterHealthy() {
+    if (
+      !clusterInitialized || utility == null
+        || isDistributedClusterModeEnabled(utility.getConfiguration())
+    ) {
+      return;
+    }
+    MiniHBaseCluster cluster = utility.getHBaseCluster();
+    HMaster master = cluster == null ? null : cluster.getMaster();
+    if (
+      master == null || !master.isActiveMaster() || !master.isInitialized() || master.isAborted()
+        || master.isStopped()
+    ) {
+      throw new IllegalStateException("Shared in-JVM minicluster is unhealthy (master not up); "
+        + "failing fast so subsequent tests on this fork do not hang.");
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1647,6 +1647,7 @@
               </goals>
               <configuration>
                 <reuseForks>false</reuseForks>
+                <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                 <skip>${skipNeedsOwnMiniClusterTests}</skip>
                 <groups>org.apache.phoenix.end2end.NeedsOwnMiniClusterTest</groups>
               </configuration>
@@ -1877,6 +1878,8 @@
           <forkCount>${numForkedUT}</forkCount>
           <reuseForks>true</reuseForks>
           <redirectTestOutputToFile>${test.output.tofile}</redirectTestOutputToFile>
+          <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
+          <forkedProcessExitTimeoutInSeconds>180</forkedProcessExitTimeoutInSeconds>
           <shutdown>exit</shutdown>
           <trimStackTrace>false</trimStackTrace>
           <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>


### PR DESCRIPTION
Several Phoenix test classes run with `reuseForks=true`, sharing a single in-JVM minicluster across all classes that land on that same fork (via `BaseTest.setUpTestDriver`). This is important for reducing overall test runtime but can be problematic. When the fork's in-JVM minicluster dies this poisons every subsequent class assigned to that same reused fork and causes all manner of malfunction that currently are not handled all that well.

We should at least bound the failure blast radius with the following basic test improvements:

- Add `<forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>` to appropriate surefire/failsafe configuration. 
- Add a global ClassRule `Timeout(20, MINUTES)` to `BaseTest`. Triggers from inside the fork and produces a failure report XML for the wedged test class.
- Detect and fail fast on discovery of a dead in-JVM cluster in a shared fork. In `BaseTest.doSetup` after the utility starts, add a health check that verifies that the master is up. This alone may reduce failure case wastage of test runner resources to seconds from hours.