### PR TITLE
PHOENIX-7986 : Replace IndexCDCConsumer's exponential idle backoff with a fixed poll interval

### DIFF
--- a/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexCDCConsumer.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/hbase/index/IndexCDCConsumer.java
@@ -115,6 +115,13 @@ public class IndexCDCConsumer implements Runnable {
   private static final long DEFAULT_POLL_INTERVAL_MS = 500;
 
   /**
+   * The interval in milliseconds between polls when the previous poll found no new events.
+   */
+  public static final String INDEX_CDC_CONSUMER_IDLE_POLL_INTERVAL_MS =
+    "phoenix.index.cdc.consumer.idle.poll.interval.ms";
+  private static final long DEFAULT_IDLE_POLL_INTERVAL_MS = 4000;
+
+  /**
    * The time buffer in milliseconds subtracted from current time when querying CDC mutations to
    * help avoid reading mutations that are too recent.
    */
@@ -157,6 +164,7 @@ public class IndexCDCConsumer implements Runnable {
   private final long startupDelayMs;
   private final int batchSize;
   private final long pollIntervalMs;
+  private final long idlePollIntervalMs;
   private final long timestampBufferMs;
   private final int maxDataVisibilityRetries;
   private final long parentProgressPauseMs;
@@ -237,6 +245,10 @@ public class IndexCDCConsumer implements Runnable {
     this.batchSize = baseBatchSize + jitter;
     this.pollIntervalMs =
       config.getLong(INDEX_CDC_CONSUMER_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS);
+    long baseIdlePollInterval =
+      config.getLong(INDEX_CDC_CONSUMER_IDLE_POLL_INTERVAL_MS, DEFAULT_IDLE_POLL_INTERVAL_MS);
+    this.idlePollIntervalMs =
+      baseIdlePollInterval + ThreadLocalRandom.current().nextLong(baseIdlePollInterval / 5 + 1);
     this.timestampBufferMs =
       config.getLong(INDEX_CDC_CONSUMER_TIMESTAMP_BUFFER_MS, DEFAULT_TIMESTAMP_BUFFER_MS);
     this.maxDataVisibilityRetries = config.getInt(INDEX_CDC_CONSUMER_MAX_DATA_VISIBILITY_RETRIES,
@@ -449,11 +461,11 @@ public class IndexCDCConsumer implements Runnable {
       lagEmissionEnabled = true;
       LOG.info(
         "IndexCDCConsumer started for table {} region {}"
-          + " [batchSize: {}, pollIntervalMs: {}, timestampBufferMs: {}, startupDelayMs: {},"
-          + " pause: {}, maxDataVisibilityRetries: {}, parentProgressPauseMs: {},"
-          + " serializeCDCMutations: {}]",
-        dataTableName, encodedRegionName, batchSize, pollIntervalMs, timestampBufferMs,
-        startupDelayMs, pause, maxDataVisibilityRetries, parentProgressPauseMs,
+          + " [batchSize: {}, pollIntervalMs: {}, idlePollIntervalMs: {}, timestampBufferMs: {},"
+          + " startupDelayMs: {}, pause: {}, maxDataVisibilityRetries: {},"
+          + " parentProgressPauseMs: {}, serializeCDCMutations: {}]",
+        dataTableName, encodedRegionName, batchSize, pollIntervalMs, idlePollIntervalMs,
+        timestampBufferMs, startupDelayMs, pause, maxDataVisibilityRetries, parentProgressPauseMs,
         serializeCDCMutations);
       if (!waitForCDCStreamEntry()) {
         LOG.error(
@@ -502,10 +514,10 @@ public class IndexCDCConsumer implements Runnable {
               lastProcessedTimestamp = processCDCBatchGenerated(encodedRegionName,
                 encodedRegionName, lastProcessedTimestamp, false);
             }
+            retryCount = 0;
             if (lastProcessedTimestamp == previousTimestamp) {
-              sleepWithLagSampling(ConnectionUtils.getPauseTime(pause, ++retryCount));
+              sleepWithLagSampling(idlePollIntervalMs);
             } else {
-              retryCount = 0;
               sleepWithLagSampling(pollIntervalMs);
             }
           } catch (Exception e) {

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexCDCConsumerLagIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/IndexCDCConsumerLagIT.java
@@ -58,7 +58,6 @@ public class IndexCDCConsumerLagIT extends ParallelStatsDisabledIT {
   private static final int TIMESTAMP_BUFFER_MS = 2_000;
   private static final int POLL_INTERVAL_MS = 500;
   private static final int LAG_SAMPLE_INTERVAL_MS = 500;
-  // Small retry pause so empty-poll backoff doesn't dominate idle behavior.
   private static final int RETRY_PAUSE_MS = 100;
   // Budget for the consumer to start up and emit its first lag sample. Generous because the
   // consumer waits up to INDEX_CDC_CONSUMER_STARTUP_DELAY_MS (default 10s) and then performs


### PR DESCRIPTION
### What changes were proposed in this pull request?

When an eventually consistent index consumer polls and finds no new CDC events, it now sleeps a fixed interval instead of walking HBase's `RETRY_BACKOFF` array.

- New config `phoenix.index.cdc.consumer.idle.poll.interval.ms`, default `4000`, with per-consumer jitter so consumers don't poll in lock-step after a RegionServer restart.
- `retryCount` is reset on any non-throwing iteration, so it now counts only consecutive exceptions. Error paths and the data-visibility retry loop keep their exponential backoff.

### Why are the changes needed?

Idle backoff caps at a 200x multiplier — 40s at the default 200ms retry pause, reached after ~96s of inactivity. A write to a quiet region therefore waits up to `timestampBufferMs + 40s` (~45s) before the consumer looks for it, versus ~5.6s measured on a region under steady write load.

That backoff is borrowed from RPC retry logic meant to relieve a failing server. An empty poll indicates nothing is wrong, so the escalation buys nothing and costs a 7x worse tail on exactly the low-traffic tables where a single write is most likely to be noticed.

It also makes `cdcIndexUpdateLag` unusable as an SLI: idle consumers emit a 5s → 45s sawtooth, so percentiles describe the backoff schedule rather than index freshness.

### Does this PR introduce _any_ user-facing change?

Yes. Worst-case index visibility on an idle region drops from `timestampBufferMs + 40s` to `timestampBufferMs + ~4.8s`. Steady-state latency under load is unchanged. Idle CDC query load rises from one poll per region per 40s to one per ~4s. The new config is optional and defaults to the behavior above.

### How was this patch tested?

`IndexCDCConsumerLagIT` passes unchanged.

No new test was added. `sleepWithLagSampling` emits a sample every `lagSampleIntervalMs` regardless of total sleep length, so the existing count-based assertion is invariant to sleep duration and cannot observe this change either way. A meaningful assertion needs the lag *value* rather than the count — `MetricHistogram` exposes only `add()` and `getCount()`, and cold-start samples floored at `now - consumerStartTime` would have to be excluded first.


### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor