### PR TITLE
PHOENIX-7991 Tag per-HA-group replication metric sources with the ha_group tag

### DIFF
--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/metrics/HAGroupStoreMetricsSource.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/metrics/HAGroupStoreMetricsSource.java
@@ -30,7 +30,7 @@ import org.apache.phoenix.thirdparty.com.google.common.annotations.VisibleForTes
  * latest Metrics2 collection interval. Metrics are not transactionally coordinated across client
  * replacement or RegionServers and never feed HA decisions.
  * <p>
- * {@code haGroup} is the only source-specific tag. Monitoring systems must supply cluster,
+ * {@code ha_group} is the only source-specific tag. Monitoring systems must supply cluster,
  * environment, host, and RegionServer identity as external scrape-target labels; role is mutable
  * and is represented by the state gauges rather than a tag.
  * <p>
@@ -60,9 +60,6 @@ public interface HAGroupStoreMetricsSource extends BaseSource {
   // Server-oriented JMX identity consistent with sibling HBase/Phoenix sources. Short-lived admin
   // CLI invocations can create an incidental bean under the same context.
   String METRICS_JMX_CONTEXT = "RegionServer,sub=" + METRICS_NAME;
-
-  String HA_GROUP_TAG_NAME = "haGroup";
-  String HA_GROUP_TAG_DESC = "HA group name";
 
   String LOCAL_CACHE_HEALTH_STATUS = "haGroupStoreLocalCacheHealthStatus";
   String LOCAL_CACHE_HEALTH_STATUS_DESC =

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/metrics/HAGroupStoreMetricsSourceImpl.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/jdbc/metrics/HAGroupStoreMetricsSourceImpl.java
@@ -17,6 +17,9 @@
  */
 package org.apache.phoenix.jdbc.metrics;
 
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_DESC;
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
+
 import java.util.concurrent.TimeUnit;
 import javax.management.ObjectName;
 import org.apache.hadoop.hbase.metrics.BaseSourceImpl;
@@ -58,10 +61,10 @@ public class HAGroupStoreMetricsSourceImpl extends BaseSourceImpl
       metricsJmxContext + ",haGroup=" + ObjectName.quote(haGroupName));
     getMetricsRegistry().tag(Interns.info(HA_GROUP_TAG_NAME, HA_GROUP_TAG_DESC), haGroupName);
 
-    localCacheHealthStatus = getMetricsRegistry().newGauge(LOCAL_CACHE_HEALTH_STATUS,
-      LOCAL_CACHE_HEALTH_STATUS_DESC, 1L);
-    peerVisibilityStatus = getMetricsRegistry().newGauge(PEER_VISIBILITY_STATUS,
-      PEER_VISIBILITY_STATUS_DESC, 1L);
+    localCacheHealthStatus =
+      getMetricsRegistry().newGauge(LOCAL_CACHE_HEALTH_STATUS, LOCAL_CACHE_HEALTH_STATUS_DESC, 1L);
+    peerVisibilityStatus =
+      getMetricsRegistry().newGauge(PEER_VISIBILITY_STATUS, PEER_VISIBILITY_STATUS_DESC, 1L);
     degradedStandbyActive =
       getMetricsRegistry().newGauge(DEGRADED_STANDBY_ACTIVE, DEGRADED_STANDBY_ACTIVE_DESC, 0L);
     currentLocalState = getMetricsRegistry().newGauge(CURRENT_LOCAL_STATE, CURRENT_LOCAL_STATE_DESC,

--- a/phoenix-core-client/src/main/java/org/apache/phoenix/metrics/MetricConstants.java
+++ b/phoenix-core-client/src/main/java/org/apache/phoenix/metrics/MetricConstants.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.metrics;
+
+/**
+ * Shared Hadoop Metrics2 constant definitions used across Phoenix metric sources.
+ * <p>
+ * Holds the {@code ha_group} tag registered by the per-HA-group sources (HAGroupStore and the
+ * replication log sources) so their series can be sliced per HA group downstream. Lives in this
+ * module-neutral package so both {@code phoenix-core-client} and {@code phoenix-core-server}
+ * sources can reference it.
+ */
+public final class MetricConstants {
+
+  /** Metrics2 tag name carrying the HA group name. */
+  public static final String HA_GROUP_TAG_NAME = "ha_group";
+
+  /** Description for the {@link #HA_GROUP_TAG_NAME} tag. */
+  public static final String HA_GROUP_TAG_DESC = "HA group name";
+
+  private MetricConstants() {
+  }
+}

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogDiscoveryForwarderImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogDiscoveryForwarderImpl.java
@@ -17,6 +17,11 @@
  */
 package org.apache.phoenix.replication.metrics;
 
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_DESC;
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
+
+import org.apache.hadoop.metrics2.lib.Interns;
+
 /** Implementation of metrics source for ReplicationLogDiscoveryForwarder operations. */
 public class MetricsReplicationLogDiscoveryForwarderImpl
   extends MetricsReplicationLogDiscoveryImpl {
@@ -33,5 +38,6 @@ public class MetricsReplicationLogDiscoveryForwarderImpl
       MetricsReplicationLogDiscoveryForwarderImpl.METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName);
     super.groupMetricsContext =
       MetricsReplicationLogDiscoveryForwarderImpl.METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName;
+    getMetricsRegistry().tag(Interns.info(HA_GROUP_TAG_NAME, HA_GROUP_TAG_DESC), haGroupName);
   }
 }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogDiscoveryReplayImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogDiscoveryReplayImpl.java
@@ -17,6 +17,10 @@
  */
 package org.apache.phoenix.replication.metrics;
 
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_DESC;
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
+
+import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
 /** Implementation of metrics source for ReplicationLogDiscoveryReplay operations. */
@@ -35,6 +39,7 @@ public class MetricsReplicationLogDiscoveryReplayImpl extends MetricsReplication
       MetricsReplicationLogDiscoveryReplayImpl.METRICS_DESCRIPTION,
       MetricsReplicationLogDiscoveryImpl.METRICS_CONTEXT,
       MetricsReplicationLogDiscoveryReplayImpl.METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName);
+    getMetricsRegistry().tag(Interns.info(HA_GROUP_TAG_NAME, HA_GROUP_TAG_DESC), haGroupName);
     consistencyPoint = getMetricsRegistry().newGauge(CONSISTENCY_POINT, CONSISTENCY_POINT_DESC, 0L);
   }
 

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogGroupSourceImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogGroupSourceImpl.java
@@ -17,12 +17,16 @@
  */
 package org.apache.phoenix.replication.metrics;
 
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_DESC;
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
+
 import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.metrics.BaseSourceImpl;
 import org.apache.hadoop.hbase.metrics.Snapshot;
 import org.apache.hadoop.hbase.metrics.impl.HistogramImpl;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MutableFastCounter;
 import org.apache.hadoop.metrics2.lib.MutableHistogram;
 import org.apache.hadoop.metrics2.lib.MutableSizeHistogram;
@@ -52,6 +56,7 @@ public class MetricsReplicationLogGroupSourceImpl extends BaseSourceImpl
     String metricsContext, String metricsJmxContext, String haGroupName) {
     super(metricsName, metricsDescription, metricsContext,
       metricsJmxContext + ",haGroup=" + haGroupName);
+    getMetricsRegistry().tag(Interns.info(HA_GROUP_TAG_NAME, HA_GROUP_TAG_DESC), haGroupName);
     rotationCount = getMetricsRegistry().newCounter(ROTATION_COUNT, ROTATION_COUNT_DESC, 0L);
     rotationFailuresCount =
       getMetricsRegistry().newCounter(ROTATION_FAILURES, ROTATION_FAILURES_DESC, 0L);

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogProcessorImpl.java
@@ -17,8 +17,12 @@
  */
 package org.apache.phoenix.replication.metrics;
 
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_DESC;
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
+
 import org.apache.hadoop.hbase.metrics.BaseSourceImpl;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MutableFastCounter;
 import org.apache.hadoop.metrics2.lib.MutableHistogram;
 
@@ -38,6 +42,7 @@ public class MetricsReplicationLogProcessorImpl extends BaseSourceImpl
     this(METRICS_NAME, METRICS_DESCRIPTION, METRICS_CONTEXT,
       METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName);
     groupMetricsContext = METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName;
+    getMetricsRegistry().tag(Interns.info(HA_GROUP_TAG_NAME, HA_GROUP_TAG_DESC), haGroupName);
   }
 
   public MetricsReplicationLogProcessorImpl(String metricsName, String metricsDescription,

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogTrackerForwarderImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogTrackerForwarderImpl.java
@@ -17,6 +17,11 @@
  */
 package org.apache.phoenix.replication.metrics;
 
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_DESC;
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
+
+import org.apache.hadoop.metrics2.lib.Interns;
+
 public class MetricsReplicationLogTrackerForwarderImpl extends MetricsReplicationLogTrackerImpl {
 
   private static final String METRICS_NAME = "ReplicationLogTrackerForwarder";
@@ -31,6 +36,7 @@ public class MetricsReplicationLogTrackerForwarderImpl extends MetricsReplicatio
       MetricsReplicationLogTrackerForwarderImpl.METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName);
     super.groupMetricsContext =
       MetricsReplicationLogTrackerForwarderImpl.METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName;
+    getMetricsRegistry().tag(Interns.info(HA_GROUP_TAG_NAME, HA_GROUP_TAG_DESC), haGroupName);
   }
 
 }

--- a/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogTrackerReplayImpl.java
+++ b/phoenix-core-server/src/main/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogTrackerReplayImpl.java
@@ -17,6 +17,11 @@
  */
 package org.apache.phoenix.replication.metrics;
 
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_DESC;
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
+
+import org.apache.hadoop.metrics2.lib.Interns;
+
 public class MetricsReplicationLogTrackerReplayImpl extends MetricsReplicationLogTrackerImpl {
 
   private static final String METRICS_NAME = "ReplicationLogReplayFileTracker";
@@ -31,6 +36,7 @@ public class MetricsReplicationLogTrackerReplayImpl extends MetricsReplicationLo
       MetricsReplicationLogTrackerReplayImpl.METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName);
     super.groupMetricsContext =
       MetricsReplicationLogTrackerReplayImpl.METRICS_JMX_CONTEXT + ",haGroup=" + haGroupName;
+    getMetricsRegistry().tag(Interns.info(HA_GROUP_TAG_NAME, HA_GROUP_TAG_DESC), haGroupName);
   }
 
 }

--- a/phoenix-core/src/test/java/org/apache/phoenix/jdbc/metrics/HAGroupStoreMetricsSourceImplTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/jdbc/metrics/HAGroupStoreMetricsSourceImplTest.java
@@ -21,7 +21,6 @@ import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.CURRENT_
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.CURRENT_PEER_STATE;
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.DEGRADED_STANDBY_ACTIVE;
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.DEGRADED_STANDBY_PRESENTED_COUNT;
-import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.HA_GROUP_TAG_NAME;
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.INVALID_TRANSITION_REJECTED_COUNT;
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.LOCAL_CACHE_HEALTH_STATUS;
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.LOCAL_ZK_CONNECTION_LOST_COUNT;
@@ -31,6 +30,7 @@ import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.PEER_VIS
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.SUBSCRIBER_NOTIFY_TIME_MS;
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.SUBSCRIBER_NOTIFY_TIME_MS_EXPORTED_BASE;
 import static org.apache.phoenix.jdbc.metrics.HAGroupStoreMetricsSource.SYSTEM_TABLE_SYNC_FAILED_COUNT;
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;

--- a/phoenix-core/src/test/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogSourceHaGroupTagTest.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/replication/metrics/MetricsReplicationLogSourceHaGroupTagTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.replication.metrics;
+
+import static org.apache.phoenix.metrics.MetricConstants.HA_GROUP_TAG_NAME;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.hadoop.hbase.metrics.BaseSourceImpl;
+import org.junit.Test;
+
+/**
+ * Verifies that every per-HA-group replication metrics source registers the {@code haGroup}
+ * Metrics2 tag carrying the raw (unquoted, case-preserved) HA group name, matching the existing
+ * HAGroupStore metrics source. This is the tag the JMX-to-Argus collector promotes so replication
+ * metrics can be sliced per HA group.
+ */
+public class MetricsReplicationLogSourceHaGroupTagTest {
+
+  private static void assertHaGroupTagged(BaseSourceImpl source, String haGroupName) {
+    assertEquals(haGroupName, source.getMetricsRegistry().getTag(HA_GROUP_TAG_NAME).value());
+  }
+
+  @Test
+  public void testLogGroupSourceTagsHaGroup() {
+    String haGroupName = "testHaGroup-" + System.nanoTime();
+    MetricsReplicationLogGroupSourceImpl source =
+      new MetricsReplicationLogGroupSourceImpl(haGroupName);
+    try {
+      assertHaGroupTagged(source, haGroupName);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  public void testLogProcessorSourceTagsHaGroup() {
+    String haGroupName = "testHaGroup-" + System.nanoTime();
+    MetricsReplicationLogProcessorImpl source = new MetricsReplicationLogProcessorImpl(haGroupName);
+    try {
+      assertHaGroupTagged(source, haGroupName);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  public void testDiscoveryReplaySourceTagsHaGroup() {
+    String haGroupName = "testHaGroup-" + System.nanoTime();
+    MetricsReplicationLogDiscoveryReplayImpl source =
+      new MetricsReplicationLogDiscoveryReplayImpl(haGroupName);
+    try {
+      assertHaGroupTagged(source, haGroupName);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  public void testDiscoveryForwarderSourceTagsHaGroup() {
+    String haGroupName = "testHaGroup-" + System.nanoTime();
+    MetricsReplicationLogDiscoveryForwarderImpl source =
+      new MetricsReplicationLogDiscoveryForwarderImpl(haGroupName);
+    try {
+      assertHaGroupTagged(source, haGroupName);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  public void testTrackerReplaySourceTagsHaGroup() {
+    String haGroupName = "testHaGroup-" + System.nanoTime();
+    MetricsReplicationLogTrackerReplayImpl source =
+      new MetricsReplicationLogTrackerReplayImpl(haGroupName);
+    try {
+      assertHaGroupTagged(source, haGroupName);
+    } finally {
+      source.close();
+    }
+  }
+
+  @Test
+  public void testTrackerForwarderSourceTagsHaGroup() {
+    String haGroupName = "testHaGroup-" + System.nanoTime();
+    MetricsReplicationLogTrackerForwarderImpl source =
+      new MetricsReplicationLogTrackerForwarderImpl(haGroupName);
+    try {
+      assertHaGroupTagged(source, haGroupName);
+    } finally {
+      source.close();
+    }
+  }
+}


### PR DESCRIPTION
Register the `ha_group` Metrics2 tag on the six per-HA-group replication log metric sources so their series can be sliced per HA group downstream (Argus), matching the existing `HAGroupStore` source.

Also moves the shared `HA_GROUP_TAG_NAME`/`HA_GROUP_TAG_DESC` constants out of the `HAGroupStoreMetricsSource` interface into a new module-neutral `org.apache.phoenix.metrics.MetricConstants` so both client and server sources share one definition. Tested via `MetricsReplicationLogSourceHaGroupTagTest` (6 cases) + updated `HAGroupStoreMetricsSourceImplTest`.